### PR TITLE
Additional unit tests for `ReadWrite` Controller Implementation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -90,12 +90,12 @@ func newDriverTasks(conf *config.Config) []driver.Task {
 
 // newTaskTemplates converts config task definitions into templates to be
 // monitored and rendered.
-func newTaskTemplates(conf *config.Config, fileReader func(string) ([]byte, error)) (map[string]hcatTemplate, error) {
+func newTaskTemplates(conf *config.Config, fileReader func(string) ([]byte, error)) (map[string]template, error) {
 	if conf.Driver.Terraform == nil {
 		return nil, errors.New("unsupported driver to run tasks")
 	}
 
-	templates := make(map[string]hcatTemplate, len(*conf.Tasks))
+	templates := make(map[string]template, len(*conf.Tasks))
 	for _, t := range *conf.Tasks {
 		tmplFile := tftmpl.TFVarsFilename(*t.Name)
 		tmplFullpath := path.Join(*conf.Driver.Terraform.WorkingDir, *t.Name, tmplFile)

--- a/controller/hcat.go
+++ b/controller/hcat.go
@@ -6,23 +6,31 @@ import (
 	"github.com/hashicorp/hcat"
 )
 
-// hcatTemplate describes the interface for hcat's Template
+var _ hcat.Templater = (template)(nil)
+var _ hcat.Renderer = (template)(nil)
+
+// template describes the interface for hashicat's Template structure
+// which implements the interfaces Templater and Renderer
 // https://github.com/hashicorp/hcat
-type hcatTemplate interface {
+type template interface {
 	Render(content []byte) (hcat.RenderResult, error)
 	Execute(hcat.Recaller) (*hcat.ExecuteResult, error)
 	ID() string
 }
 
-// hcatResolver describes the interface for hcat's Resolver
+// resolver describes the interface for hashicat's Resolver structure
+// which does implement any hashicat interface at time of writing
 // https://github.com/hashicorp/hcat
-type hcatResolver interface {
+type resolver interface {
 	Run(tmpl hcat.Templater, w hcat.Watcherer) (hcat.ResolveEvent, error)
 }
 
-// hcatWatcher describes the interface for hcat's Watcher
+var _ hcat.Watcherer = (watcher)(nil)
+
+// watcher describes the interface for hashicat's Watcher structure
+// which implements the interface Watcherer
 // https://github.com/hashicorp/hcat
-type hcatWatcher interface {
+type watcher interface {
 	Wait(timeout time.Duration) error
 	Add(d hcat.Dependency) bool
 	Changed(tmplID string) bool

--- a/controller/mock_hcat.go
+++ b/controller/mock_hcat.go
@@ -6,16 +6,16 @@ import (
 	"github.com/hashicorp/hcat"
 )
 
-var _ hcatTemplate = (*mockHcatTemplate)(nil)
+var _ template = (*mockTemplate)(nil)
 
-// mockHcatTemplate is a mock implementation of hcat's Template for testing purposes
-type mockHcatTemplate struct {
+// mockTemplate is a mock implementation of hcat's Template for testing purposes
+type mockTemplate struct {
 	RenderFunc func([]byte) (hcat.RenderResult, error)
 }
 
-// newMockHcatTemplate configures and initializes a new mock hcat Template
-func newMockHcatTemplate() *mockHcatTemplate {
-	return &mockHcatTemplate{
+// newMockTemplate configures and initializes a new mock hashicat Template
+func newMockTemplate() *mockTemplate {
+	return &mockTemplate{
 		RenderFunc: func([]byte) (hcat.RenderResult, error) {
 			return hcat.RenderResult{}, nil
 		},
@@ -23,32 +23,32 @@ func newMockHcatTemplate() *mockHcatTemplate {
 }
 
 // Render mocks render for testing
-func (m *mockHcatTemplate) Render(content []byte) (hcat.RenderResult, error) {
+func (m *mockTemplate) Render(content []byte) (hcat.RenderResult, error) {
 	return m.RenderFunc(content)
 }
 
 // Execute mocks execute for testing
 // Note: function not directly consumed by NIA, therefore not fully mocked out at this time
-func (m *mockHcatTemplate) Execute(hcat.Recaller) (*hcat.ExecuteResult, error) {
+func (m *mockTemplate) Execute(hcat.Recaller) (*hcat.ExecuteResult, error) {
 	return nil, nil
 }
 
 // ID mocks ID for testing
 // Note: function not directly consumed by NIA, therefore not fully mocked out at this time
-func (m *mockHcatTemplate) ID() string {
+func (m *mockTemplate) ID() string {
 	return "id"
 }
 
-var _ hcatResolver = (*mockHcatResolver)(nil)
+var _ resolver = (*mockResolver)(nil)
 
-// mockHcatResolver is a mock implementation of hcat's Resolver for testing purposes
-type mockHcatResolver struct {
+// mockResolver is a mock implementation of hcat's Resolver for testing purposes
+type mockResolver struct {
 	RunFunc func(hcat.Templater, hcat.Watcherer) (hcat.ResolveEvent, error)
 }
 
-// newMockHcatResolver configures and initializes a new mock hcat Resolver
-func newMockHcatResolver() *mockHcatResolver {
-	return &mockHcatResolver{
+// newMockResolver configures and initializes a new mock hashicat Resolver
+func newMockResolver() *mockResolver {
+	return &mockResolver{
 		RunFunc: func(hcat.Templater, hcat.Watcherer) (hcat.ResolveEvent, error) {
 			return hcat.ResolveEvent{
 				Complete: true,
@@ -58,20 +58,20 @@ func newMockHcatResolver() *mockHcatResolver {
 }
 
 // Run mocks run for testing
-func (m *mockHcatResolver) Run(tmpl hcat.Templater, w hcat.Watcherer) (hcat.ResolveEvent, error) {
+func (m *mockResolver) Run(tmpl hcat.Templater, w hcat.Watcherer) (hcat.ResolveEvent, error) {
 	return m.RunFunc(tmpl, w)
 }
 
-var _ hcatWatcher = (*mockHcatWatcher)(nil)
+var _ watcher = (*mockWatcher)(nil)
 
-// mockHcatWatcher is a mock implementation of Hcat's Watcher for testing purposes
-type mockHcatWatcher struct {
+// mockWatcher is a mock implementation of Hcat's Watcher for testing purposes
+type mockWatcher struct {
 	WaitFunc func(time.Duration) error
 }
 
-// newMockHcatWatcher configures and initializes a new mock hcat Watcher
-func newMockHcatWatcher() *mockHcatWatcher {
-	return &mockHcatWatcher{
+// newMockWatcher configures and initializes a new mock hashicat Watcher
+func newMockWatcher() *mockWatcher {
+	return &mockWatcher{
 		WaitFunc: func(time.Duration) error {
 			return nil
 		},
@@ -79,29 +79,29 @@ func newMockHcatWatcher() *mockHcatWatcher {
 }
 
 // Wait mocks wait for testing
-func (m *mockHcatWatcher) Wait(timeout time.Duration) error {
+func (m *mockWatcher) Wait(timeout time.Duration) error {
 	return m.WaitFunc(timeout)
 }
 
 // Add mocks add for testing
 // Note: function not directly consumed by NIA, therefore not fully mocked out at this time
-func (m *mockHcatWatcher) Add(d hcat.Dependency) bool {
+func (m *mockWatcher) Add(d hcat.Dependency) bool {
 	return true
 }
 
 // Changed mocks changed for testing
 // Note: function not directly consumed by NIA, therefore not fully mocked out at this time
-func (m *mockHcatWatcher) Changed(tmplID string) bool {
+func (m *mockWatcher) Changed(tmplID string) bool {
 	return true
 }
 
 // Recall mocks recall for testing
-func (m *mockHcatWatcher) Recall(id string) (interface{}, bool) {
+func (m *mockWatcher) Recall(id string) (interface{}, bool) {
 	return "", true
 }
 
 // Register mocks register for testing
 // Note: function not directly consumed by NIA, therefore not fully mocked out at this time
-func (m *mockHcatWatcher) Register(tmplID string, deps ...hcat.Dependency) {
+func (m *mockWatcher) Register(tmplID string, deps ...hcat.Dependency) {
 	return
 }

--- a/controller/mock_hcat_test.go
+++ b/controller/mock_hcat_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMockHcatTemplateRender(t *testing.T) {
+func TestMockTemplateRender(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -28,7 +28,7 @@ func TestMockHcatTemplateRender(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatTemplate()
+			m := newMockTemplate()
 
 			// setup Render() return values
 			if tc.returnErr != nil {
@@ -47,7 +47,7 @@ func TestMockHcatTemplateRender(t *testing.T) {
 	}
 }
 
-func TestMockHcatTemplateExecute(t *testing.T) {
+func TestMockTemplateExecute(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -60,7 +60,7 @@ func TestMockHcatTemplateExecute(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatTemplate()
+			m := newMockTemplate()
 
 			_, err := m.Execute(hcat.NewStore())
 			assert.NoError(t, err)
@@ -68,7 +68,7 @@ func TestMockHcatTemplateExecute(t *testing.T) {
 	}
 }
 
-func TestMockHcatTemplateID(t *testing.T) {
+func TestMockTemplateID(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -81,7 +81,7 @@ func TestMockHcatTemplateID(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatTemplate()
+			m := newMockTemplate()
 
 			id := m.ID()
 			assert.NotEmpty(t, id)
@@ -89,7 +89,7 @@ func TestMockHcatTemplateID(t *testing.T) {
 	}
 }
 
-func TestMockHcatResolverRun(t *testing.T) {
+func TestMockResolverRun(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -108,7 +108,7 @@ func TestMockHcatResolverRun(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatResolver()
+			m := newMockResolver()
 
 			// setup Run() return values
 			if tc.returnErr != nil {
@@ -127,7 +127,7 @@ func TestMockHcatResolverRun(t *testing.T) {
 	}
 }
 
-func TestMockHcatWatcherWait(t *testing.T) {
+func TestMockWatcherWait(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -146,7 +146,7 @@ func TestMockHcatWatcherWait(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatWatcher()
+			m := newMockWatcher()
 
 			// setup Wait() return values
 			if tc.returnErr != nil {
@@ -165,15 +165,15 @@ func TestMockHcatWatcherWait(t *testing.T) {
 	}
 }
 
-func TestMockHcatWatcherAdd(t *testing.T) {
-	// Skip writing test for mockHcatWatcher.Add(d hcat.Dependency)
+func TestMockWatcherAdd(t *testing.T) {
+	// Skip writing test for mockWatcher.Add(d hcat.Dependency)
 
-	// Dependency currently lives and is used in hcat internally. In order to
+	// Dependency currently lives and is used in hashicat internally. In order to
 	// write a unit test for Add(), we would have to mock Dependency and other
 	// internal elements it consumes.
 }
 
-func TestMockHcatWatcherChanged(t *testing.T) {
+func TestMockWatcherChanged(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -186,7 +186,7 @@ func TestMockHcatWatcherChanged(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatWatcher()
+			m := newMockWatcher()
 
 			ok := m.Changed("id")
 			assert.True(t, ok)
@@ -194,7 +194,7 @@ func TestMockHcatWatcherChanged(t *testing.T) {
 	}
 }
 
-func TestMockHcatWatcherRecall(t *testing.T) {
+func TestMockWatcherRecall(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -207,7 +207,7 @@ func TestMockHcatWatcherRecall(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatWatcher()
+			m := newMockWatcher()
 
 			_, ok := m.Recall("id")
 			assert.True(t, ok)
@@ -215,7 +215,7 @@ func TestMockHcatWatcherRecall(t *testing.T) {
 	}
 }
 
-func TestMockHcatWatcherRegister(t *testing.T) {
+func TestMockWatcherRegister(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -228,7 +228,7 @@ func TestMockHcatWatcherRegister(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newMockHcatWatcher()
+			m := newMockWatcher()
 
 			m.Register("id")
 			// no return value to assert.

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -18,9 +18,9 @@ type ReadWrite struct {
 	driver     driver.Driver
 	conf       *config.Config
 	fileReader func(string) ([]byte, error)
-	templates  map[string]hcatTemplate
-	watcher    hcatWatcher
-	resolver   hcatResolver
+	templates  map[string]template
+	watcher    watcher
+	resolver   resolver
 }
 
 // NewReadWrite configures and initializes a new ReadWrite controller
@@ -33,7 +33,7 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 	return &ReadWrite{
 		driver:     d,
 		conf:       conf,
-		templates:  make(map[string]hcatTemplate),
+		templates:  make(map[string]template),
 		watcher:    newWatcher(conf),
 		fileReader: ioutil.ReadFile,
 		resolver:   hcat.NewResolver(),

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -139,35 +139,35 @@ func TestReadWriteRun(t *testing.T) {
 		name         string
 		expectError  bool
 		mockDriver   *driver.MockDriver
-		mockResolver *mockHcatResolver
-		mockTemplate *mockHcatTemplate
-		mockWatcher  *mockHcatWatcher
+		mockResolver *mockResolver
+		mockTemplate *mockTemplate
+		mockWatcher  *mockWatcher
 		config       *config.Config
 	}{
 		{
 			"error on resolver.Run()",
 			true,
 			driver.NewMockDriver(),
-			&mockHcatResolver{
+			&mockResolver{
 				RunFunc: func(hcat.Templater, hcat.Watcherer) (hcat.ResolveEvent, error) {
 					return hcat.ResolveEvent{}, errors.New("error on resolver.Run()")
 				},
 			},
-			newMockHcatTemplate(),
-			newMockHcatWatcher(),
+			newMockTemplate(),
+			newMockWatcher(),
 			singleTaskConfig(),
 		},
 		{
 			"error on watcher.Wait()",
 			true,
 			driver.NewMockDriver(),
-			newMockHcatResolver(),
-			&mockHcatTemplate{
+			newMockResolver(),
+			&mockTemplate{
 				RenderFunc: func([]byte) (hcat.RenderResult, error) {
 					return hcat.RenderResult{}, errors.New("error on template.Render()")
 				},
 			},
-			&mockHcatWatcher{
+			&mockWatcher{
 				WaitFunc: func(time.Duration) error { return errors.New("error on watcher.Wait()") },
 			},
 			singleTaskConfig(),
@@ -178,9 +178,9 @@ func TestReadWriteRun(t *testing.T) {
 			&driver.MockDriver{
 				InitWorkFunc: func() error { return errors.New("error on driver.InitWork()") },
 			},
-			newMockHcatResolver(),
-			newMockHcatTemplate(),
-			newMockHcatWatcher(),
+			newMockResolver(),
+			newMockTemplate(),
+			newMockWatcher(),
 			singleTaskConfig(),
 		},
 		{
@@ -190,25 +190,25 @@ func TestReadWriteRun(t *testing.T) {
 				InitWorkFunc:  func() error { return nil },
 				ApplyWorkFunc: func() error { return errors.New("error on driver.ApplyWork()") },
 			},
-			newMockHcatResolver(),
-			newMockHcatTemplate(),
-			newMockHcatWatcher(),
+			newMockResolver(),
+			newMockTemplate(),
+			newMockWatcher(),
 			singleTaskConfig(),
 		},
 		{
 			"happy path",
 			false,
 			driver.NewMockDriver(),
-			newMockHcatResolver(),
-			newMockHcatTemplate(),
-			newMockHcatWatcher(),
+			newMockResolver(),
+			newMockTemplate(),
+			newMockWatcher(),
 			singleTaskConfig(),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			templates := make(map[string]hcatTemplate)
+			templates := make(map[string]template)
 			templates["test template"] = tc.mockTemplate
 
 			controller := ReadWrite{


### PR DESCRIPTION
This PR is the second pass at adding unit tests for https://github.com/hashicorp/consul-nia/pull/12. This addresses the 2 unit tests that are commented out in https://github.com/hashicorp/consul-nia/pull/16: `TestReadWriteInit` & `TestReadWriteRun`.

Changes
 - Refactor `ioutil.ReadFile` to fileReader function on `ReadWrite`. Update Init() unit test
 - Add interface for hcat template + mock. Update Run() unit tests
 - Add interface for hcat watcher + mock. Update Run() unit tests
 - Create hcat resolver interface and move resolver on to `ReadWrite` struct. Update Run() unit tests
 - Minor updates to code to return errors to ease testing

Partially resolves https://github.com/hashicorp/consul-nia/issues/4