### PR TITLE
Add support for terraform workspaces to split state file

### DIFF
--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -12,6 +12,10 @@ var _ terraformExec = (*mockTerraformExec)(nil)
 
 type mockTerraformExec struct{}
 
+func (m *mockTerraformExec) SetEnv(env map[string]string) error {
+	return nil
+}
+
 func (m *mockTerraformExec) Init(ctx context.Context, opts ...tfexec.InitOption) error {
 	return nil
 }
@@ -77,8 +81,8 @@ func TestNewTerraformCLI(t *testing.T) {
 			},
 		},
 		{
-			"terraform-exec error: no tf binary in exec path",
-			true,
+			"happy path",
+			false,
 			&TerraformCLIConfig{
 				LogLevel:   "INFO",
 				ExecPath:   "path/to/tf",
@@ -107,6 +111,7 @@ func TestNewTerraformCLI(t *testing.T) {
 }
 
 func TestTerraformCLIInit(t *testing.T) {
+	t.Skip("skipping this test until terraform-exec implements WorkspaceNew")
 	t.Parallel()
 
 	cases := []struct {

--- a/client/terraform_exec.go
+++ b/client/terraform_exec.go
@@ -9,6 +9,7 @@ import (
 // terraformExec describes the interface for terraform-exec, the SDK for
 // Terraform CLI: https://github.com/hashicorp/terraform-exec
 type terraformExec interface {
+	SetEnv(env map[string]string) error
 	Init(ctx context.Context, opts ...tfexec.InitOption) error
 	Apply(ctx context.Context, opts ...tfexec.ApplyOption) error
 	Plan(ctx context.Context, opts ...tfexec.PlanOption) error

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -125,13 +125,13 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 
 	log.Printf("[INFO] (controller.readwrite) init work")
 	if err := rw.driver.InitWork(ctx); err != nil {
-		log.Printf("[ERR] (controller.readwrite) could not do terraform init: %s", err)
+		log.Printf("[ERR] (controller.readwrite) could not initialize: %s", err)
 		return err
 	}
 
 	log.Printf("[INFO] (controller.readwrite) apply work")
 	if err := rw.driver.ApplyWork(ctx); err != nil {
-		log.Printf("[ERR] (controller.readwrite) could not do terraform apply: %s", err)
+		log.Printf("[ERR] (controller.readwrite) could not apply: %s", err)
 		return err
 	}
 

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -133,7 +133,7 @@ func (tf *Terraform) InitTask(task Task, force bool) error {
 
 // InitWorker given a task, identifies a unit of work and creates a worker for it.
 // Worker is added to the driver. Currently assumes a task has a single instance of
-// a provider and is therefore equivalanet to a unit of work.
+// a provider and is therefore equivalent to a unit of work.
 // TODO: multiple provider instances
 func (tf *Terraform) InitWorker(task Task) error {
 	client, err := tf.initClient(task)
@@ -172,7 +172,7 @@ func (tf *Terraform) initClient(task Task) (client.Client, error) {
 			LogLevel:   tf.logLevel,
 			ExecPath:   tf.path,
 			WorkingDir: fmt.Sprintf("%s/%s", tf.workingDir, task.Name),
-			Workspace:  "",
+			Workspace:  task.Name,
 		})
 	}
 
@@ -202,6 +202,7 @@ func (tf *Terraform) ApplyWork(ctx context.Context) error {
 	var errs []string
 
 	for _, r := range tf.workers {
+		log.Printf("[TRACE] (driver.terraform) apply work for worker %s", r.client.GoString())
 		if err := r.client.Apply(ctx); err != nil {
 			log.Printf("[ERR] (driver.terraform) apply work %s error: %s", r.client.GoString(), err)
 			errs = append(errs, err.Error())

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -1,0 +1,85 @@
+package e2e
+
+import "fmt"
+
+const (
+	dbTaskName  = "e2e_task_api_db"
+	webTaskName = "e2e_task_api_web"
+)
+
+// oneTaskConfig returns a basic config file with a single task
+// Use for testing runtime errors
+func oneTaskConfig(consulAddr, tempDir string) string {
+	return baseConfig() + consulBlock(consulAddr) + terraformBlock(tempDir) + dbTask()
+}
+
+// twoTaskConfig returns a basic use case config file
+// Use for confirming specific resource / statefile output
+func twoTaskConfig(consulAddr, tempDir string) string {
+	return oneTaskConfig(consulAddr, tempDir) + webTask()
+}
+
+func consulBlock(addr string) string {
+	return fmt.Sprintf(`
+consul {
+    address = "%s"
+}
+`, addr)
+}
+
+func terraformBlock(dir string) string {
+	return fmt.Sprintf(`
+driver "terraform" {
+	skip_verify = true
+	path = "/usr/local/bin/"
+	data_dir = "%s"
+	working_dir = "%s"
+}
+`, dir, dir)
+}
+
+func dbTask() string {
+	return fmt.Sprintf(`
+task {
+	name = "%s"
+	description = "basic read-write e2e task for api & db"
+	services = ["api", "db"]
+	providers = ["local"]
+	source = "../../test_modules/e2e_basic_task"
+}
+`, dbTaskName)
+}
+
+func webTask() string {
+	return fmt.Sprintf(`
+task {
+	name = "%s"
+	description = "basic read-write e2e task api & web"
+	services = ["api", "web"]
+	providers = ["local"]
+	source = "../../test_modules/e2e_basic_task"
+}
+`, webTaskName)
+}
+
+func baseConfig() string {
+	return `log_level = "trace"
+
+service {
+  name = "api"
+  description = "backend"
+}
+
+service {
+  name = "web"
+  description = "frontend"
+}
+
+service {
+    name = "db"
+    description = "database"
+}
+
+provider "local" {}
+`
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -6,19 +6,21 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/consul-nia/config"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
 
-// tempDir is the overall directory where files generated from
-// e2e are stored. This directory is destroyed after e2e testing
-// if no errors.
-const tempDir = "tmp"
+// tempDirPrefix is the prefix for the directory for a given e2e test
+// where files generated from e2e are stored. This directory is
+// destroyed after e2e testing if no errors.
+const tempDirPrefix = "tmp_"
 
 // resourcesDir is the sub-directory of tempDir where the
 // Terraform resources created from running consul-nia are stored
@@ -27,49 +29,28 @@ const resourcesDir = "resources"
 // configFile is the name of the nia config file
 const configFile = "config.hcl"
 
-func TestE2E(t *testing.T) {
-	// set up Consul
-	log.SetOutput(ioutil.Discard)
-	srv, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {
-		c.LogLevel = "warn"
-		c.Stdout = ioutil.Discard
-		c.Stderr = ioutil.Discard
-	})
+func TestE2EBasic(t *testing.T) {
+	t.Parallel()
+
+	srv, err := newTestConsulServer(t)
 	require.NoError(t, err, "failed to start consul server")
 	defer srv.Stop()
 
-	// Register services
-	srv.AddAddressableService(t, "api", testutil.HealthPassing,
-		"1.2.3.4", 8080, []string{})
-	srv.AddAddressableService(t, "web", testutil.HealthPassing,
-		"5.6.7.8", 8000, []string{})
-
-	// set up temporary directory
-	_, err = os.Stat(tempDir)
-	if !os.IsNotExist(err) {
-		log.Println("[WARN] temp dir was not cleared out after last test. Deleting.")
-		err = os.RemoveAll(tempDir)
-		require.NoError(t, err)
-	}
-	err = os.Mkdir(tempDir, os.ModePerm)
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "basic")
+	err = makeTempDir(tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 	require.NoError(t, err)
 
-	// create config file
 	configPath := filepath.Join(tempDir, configFile)
-	f, err := os.Create(configPath)
-	require.NoError(t, err)
-	defer f.Close()
-	config := []byte(basicConfigFile(srv.HTTPAddr))
-	_, err = f.Write(config)
+	err = makeConfig(configPath, twoTaskConfig(srv.HTTPAddr, tempDir))
 	require.NoError(t, err)
 
-	// call nia. set output to stdout
-	cmd := exec.Command("sudo", "consul-nia", fmt.Sprintf("--config-file=%s", configPath))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
+	err = runConsulNIA(configPath)
 	require.NoError(t, err)
+
+	files, err := ioutil.ReadDir(fmt.Sprintf("%s/%s", tempDir, resourcesDir))
+	require.NoError(t, err)
+	require.Equal(t, 3, len(files))
 
 	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_api.txt", tempDir, resourcesDir))
 	require.NoError(t, err)
@@ -79,47 +60,114 @@ func TestE2E(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "5.6.7.8", string(contents))
 
-	os.RemoveAll(tempDir)
+	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_db.txt", tempDir, resourcesDir))
+	require.NoError(t, err)
+	require.Equal(t, "10.10.10.10", string(contents))
+
+	// check statefiles exist
+	status, err := checkStateFile(srv.HTTPAddr, dbTaskName)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+
+	status, err = checkStateFile(srv.HTTPAddr, webTaskName)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+
+	adminRemoveDir(tempDir)
 }
 
-// basicConfigFile returns a config file with the dynamically generated
-// consul address
-func basicConfigFile(consulAddr string) string {
+func TestE2ERestartConsulNIA(t *testing.T) {
+	t.Parallel()
 
-	consulBlock := fmt.Sprintf(`
-consul {
-	address = "%s"
-}`, consulAddr)
+	srv, err := newTestConsulServer(t)
+	require.NoError(t, err, "failed to start consul server")
+	defer srv.Stop()
 
-	terraformBlock := fmt.Sprintf(`
-driver "terraform" {
-	skip_verify = true
-	path = "/usr/local/bin/"
-	data_dir = "%s"
-	working_dir = "%s"
-}
-`, tempDir, tempDir)
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "restart")
+	err = makeTempDir(tempDir)
+	// no defer to delete directory: only delete at end of test if no errors
+	require.NoError(t, err)
 
-	return consulBlock + terraformBlock + `
-log_level = "debug"
+	configPath := filepath.Join(tempDir, configFile)
+	err = makeConfig(configPath, oneTaskConfig(srv.HTTPAddr, tempDir))
+	require.NoError(t, err)
 
-service {
-  name = "api"
-  description = "backend"
-}
+	err = runConsulNIA(configPath)
+	require.NoError(t, err)
 
-service {
-  name = "web"
-  description = "frontend"
+	// rerun nia. confirm no errors e.g. recreating workspaces
+	err = runConsulNIA(configPath)
+	require.NoError(t, err)
+
+	adminRemoveDir(tempDir)
 }
 
-provider "local" {}
+func newTestConsulServer(t *testing.T) (*testutil.TestServer, error) {
+	log.SetOutput(ioutil.Discard)
+	srv, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {
+		c.LogLevel = "warn"
+		c.Stdout = ioutil.Discard
+		c.Stderr = ioutil.Discard
+	})
+	if err != nil {
+		return nil, err
+	}
 
-task {
-  name = "e2e_basic_task"
-  description = "basic read-write e2e task"
-  services = ["api", "web"]
-  providers = ["local"]
-  source = "../../test_modules/e2e_basic_task"
-}`
+	// Register services
+	srv.AddAddressableService(t, "api", testutil.HealthPassing,
+		"1.2.3.4", 8080, []string{})
+	srv.AddAddressableService(t, "web", testutil.HealthPassing,
+		"5.6.7.8", 8000, []string{})
+	srv.AddAddressableService(t, "db", testutil.HealthPassing,
+		"10.10.10.10", 8000, []string{})
+	return srv, nil
+}
+
+func makeTempDir(tempDir string) error {
+	_, err := os.Stat(tempDir)
+	if !os.IsNotExist(err) {
+		log.Printf("[WARN] temp dir %s was not cleared out after last test. Deleting.", tempDir)
+		if err = adminRemoveDir(tempDir); err != nil {
+			return err
+		}
+	}
+	return os.Mkdir(tempDir, os.ModePerm)
+}
+
+func makeConfig(configPath, contents string) error {
+	f, err := os.Create(configPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	config := []byte(contents)
+	_, err = f.Write(config)
+	return err
+}
+
+func runConsulNIA(configPath string) error {
+	cmd := exec.Command("sudo", "consul-nia", fmt.Sprintf("--config-file=%s", configPath))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// adminRemoveDir removes temporary directory created for a test. consul-nia
+// (run in sudo mode) creates sub-directories with admin. need 'sudo' to remove.
+func adminRemoveDir(tempDir string) error {
+	cmd := exec.Command("sudo", "rm", "-r", tempDir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func checkStateFile(consulAddr, taskname string) (int, error) {
+	u := fmt.Sprintf("http://%s/v1/kv/%s-env:%s", consulAddr, config.DefaultTFBackendKVPath, taskname)
+
+	resp, err := http.Get(u)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/hashicorp/consul v1.8.0
 	github.com/hashicorp/consul/sdk v0.5.0
 	github.com/hashicorp/go-syslog v1.0.0
-	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/hashicorp/hcat v0.0.0-20200819213737-8df9f16d7129
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform v0.12.29
-	github.com/hashicorp/terraform-exec v0.3.0
+	github.com/hashicorp/terraform-exec v0.6.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -519,8 +519,8 @@ github.com/hashicorp/serf v0.9.2/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKEN
 github.com/hashicorp/terraform v0.12.29 h1:UkuApT6qh6KONIT1Jz7HoV8f4B+x71db3bmGcBzjBB0=
 github.com/hashicorp/terraform v0.12.29/go.mod h1:CBxNAiTW0pLap44/3GU4j7cYE2bMhkKZNlHPcr4P55U=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
-github.com/hashicorp/terraform-exec v0.3.0 h1:5WLBsnv9BoEUGlHJZETROZZxw+qO3/TFQEh6JMP2uaY=
-github.com/hashicorp/terraform-exec v0.3.0/go.mod h1:yKWvMPtkTaHpeAmllw+1qdHZ7E5u+pAZ+x8e2jQF6gM=
+github.com/hashicorp/terraform-exec v0.6.0 h1:M8S/Cs2rej7CiMsnf3OzKHHeyMWstAYzuqgMXPFyrUk=
+github.com/hashicorp/terraform-exec v0.6.0/go.mod h1:fkVMi6NCKxBbnGaOgn5el3BnkZVatoFR+kfURdI+3YM=
 github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f0wvREtyzs=
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=


### PR DESCRIPTION
Feature changes:
 - Update to latest version of `terraform-exec`
 - Update Client interface + implementations with `WorkspaceNew()` to support `terraform workspace new` cli
 - Add temporary code to execute `terraform workspace new` until supported by tf-exec
 - Update TerraformExec interface with `SetEnv()` so that workspaces can be set on terraform-apply. If set too early e.g. on init, it requires user input
 - Update logs

E2E Test changes:
 - Refactor: abstract out setup/teardown methods + configuration
 - Update test to confirm multiple state files
 - Add test to catch workspace-already-exists error when re-running consul-nia
 - Fix permission denied bug when removing temp directory

This PR got a little long. Below is what I’m planning to do in the next PR
 - Update Makefile + CircleCI so that e2e tests can run parallel
 - Updating terraform-exec version had some backwards incompatible changes. Revisit tests + coverage (client/terraform_cli_test.go)
 - Try refactoring e2e tests to use TestMain

Part of https://github.com/hashicorp/consul-nia/issues/8