### PR TITLE
Improvements to testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  build:
+  unit_integration_tests:
     environment:
       GO111MODULE: "on"
       CONSUL_VERSION: 1.8.0
@@ -17,9 +17,37 @@ jobs:
           unzip consul.zip
           sudo cp consul /usr/local/bin/
       - run: |
-          make test-setup-e2e
-          make test-all
+          make test-integration
       - save_cache:
           key: ct-modcache-v1-{{ checksum "go.mod" }}
           paths:
           - /go/pkg/mod
+  e2e_tests:
+    environment:
+      GO111MODULE: "on"
+      CONSUL_VERSION: 1.8.0
+    docker:
+      - image: circleci/golang:latest
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - ct-modcache-v1-{{ checksum "go.mod" }}
+      - run: |
+          curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+          unzip consul.zip
+          sudo cp consul /usr/local/bin/
+      - run: |
+          make test-e2e
+      - save_cache:
+          key: ct-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+          - /go/pkg/mod
+
+workflows:
+  version: 2
+  build-test:
+    jobs:
+      - unit_integration_tests
+      - e2e_tests

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ test:
 	@go test -count=1 -timeout=30s -cover ./... ${TESTARGS}
 .PHONY: test
 
-# test-all runs the test suite and integration & e2e tests
-test-all:
-	@echo "==> Testing ${NAME} (integration & e2e)"
-	@go test -count=1 -timeout=60s -tags=integration,e2e -cover ./... ${TESTARGS}
+# test-integration runs the test suite and integration tests
+test-integration:
+	@echo "==> Testing ${NAME} (test suite & integration)"
+	@go test -count=1 -timeout=60s -tags=integration -cover ./... ${TESTARGS}
 .PHONY: test-all
 
 # test-setup-e2e sets up the nia binary and permissions to run consul-nia
@@ -50,4 +50,10 @@ test-all:
 test-setup-e2e: dev
 	sudo mv ${GOPATH}/bin/consul-nia /usr/local/bin/consul-nia
 .PHONY: test-setup-e2e
+
+# test-e2e runs e2e tests
+test-e2e: test-setup-e2e
+	@echo "==> Testing ${NAME} (e2e)"
+	@go test ./e2e -count=1 -timeout=60s -tags=e2e ./... ${TESTARGS}
+.PHONY: test-e2e
 

--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -115,7 +115,7 @@ func (t *TerraformCLI) workspaceNew(ctx context.Context) error {
 			log.Printf("[DEBUG] (client.terraformcli) workspace already exists: '%s'", t.workspace)
 			return nil
 		}
-		return fmt.Errorf("Error creating workspace %s: %s", t.workspace, errStr)
+		return fmt.Errorf("Error creating workspace %s: %s: %s", t.workspace, err.Error(), errStr)
 	}
 	return nil
 }

--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -90,9 +90,6 @@ func TestNewTerraformCLI(t *testing.T) {
 				Workspace:  "my-workspace",
 			},
 		},
-		// No happy path unit test possible because it requires the
-		// terraform binary to exist. This would need to be tested
-		// with an integration test
 	}
 
 	for _, tc := range cases {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -73,7 +73,7 @@ func NewTerraform(config *TerraformConfig) *Terraform {
 // installed to the configured path.
 func (tf *Terraform) Init() error {
 	if !terraformInstalled(tf.path) {
-		log.Printf("[INFO] (driver.terraform) installing terraform (%s) to path %s", tf.version, tf.path)
+		log.Printf("[INFO] (driver.terraform) installing terraform (%s) to path '%s'", tf.version, tf.path)
 		if err := tf.install(); err != nil {
 			log.Printf("[ERR] (driver.terraform) error installing terraform: %s", err)
 			return err

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,7 +30,9 @@ const resourcesDir = "resources"
 const configFile = "config.hcl"
 
 func TestE2EBasic(t *testing.T) {
-	t.Parallel()
+	// Note: no t.Parallel() for this particular test. Choosing this test to run 'first'
+	// since e2e test running simultaneously will download Terraform into shared
+	// directory causes some flakiness. All other e2e tests, should have t.Parallel()
 
 	srv, err := newTestConsulServer(t)
 	require.NoError(t, err, "failed to start consul server")


### PR DESCRIPTION
Context: in https://github.com/hashicorp/consul-nia/pull/25, expanded/added additional e2e tests and updated `terraform-exec` version. Wanted a separate PR to improve e2e tests and double-check coverage impacts of changes of initializing `terraform-exec`

Changes:
 - Parallelize running e2e tests in circle
 - Improve some logs/errors
 - Updates to test comments due to latest terraform-exec version
 - Fix e2e flakiness caused by tests simultaneously dl-ing tf into shared directory - see t.Parallel()

Part of https://github.com/hashicorp/consul-nia/issues/8