### PR TITLE
change e2e to not require sudo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+terraform

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,8 @@ test-setup-e2e: dev
 # test-e2e-cirecleci does circleci setup and then runs the e2e tests
 test-e2e-cirecleci: test-setup-e2e test-e2e
 .PHONY: test-e2e-cirecleci
+
+# delete any cruft
+clean:
+	rm -f ./e2e/terraform
+.PHONY: clean

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -1,6 +1,9 @@
 package e2e
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 const (
 	dbTaskName  = "e2e_task_api_db"
@@ -28,14 +31,18 @@ consul {
 }
 
 func terraformBlock(dir string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
 	return fmt.Sprintf(`
 driver "terraform" {
 	skip_verify = true
-	path = "/usr/local/bin/"
+	path = "%s"
 	data_dir = "%s"
 	working_dir = "%s"
 }
-`, dir, dir)
+`, cwd, dir, dir)
 }
 
 func dbTask() string {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -75,7 +75,7 @@ func TestE2EBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, status)
 
-	adminRemoveDir(tempDir)
+	removeDir(tempDir)
 }
 
 func TestE2ERestartConsulNIA(t *testing.T) {
@@ -101,7 +101,7 @@ func TestE2ERestartConsulNIA(t *testing.T) {
 	err = runConsulNIA(configPath)
 	require.NoError(t, err)
 
-	adminRemoveDir(tempDir)
+	removeDir(tempDir)
 }
 
 func newTestConsulServer(t *testing.T) (*testutil.TestServer, error) {
@@ -129,7 +129,7 @@ func makeTempDir(tempDir string) error {
 	_, err := os.Stat(tempDir)
 	if !os.IsNotExist(err) {
 		log.Printf("[WARN] temp dir %s was not cleared out after last test. Deleting.", tempDir)
-		if err = adminRemoveDir(tempDir); err != nil {
+		if err = removeDir(tempDir); err != nil {
 			return err
 		}
 	}
@@ -148,19 +148,15 @@ func makeConfig(configPath, contents string) error {
 }
 
 func runConsulNIA(configPath string) error {
-	cmd := exec.Command("sudo", "consul-nia", fmt.Sprintf("--config-file=%s", configPath))
+	cmd := exec.Command("consul-nia", fmt.Sprintf("--config-file=%s", configPath))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
-// adminRemoveDir removes temporary directory created for a test. consul-nia
-// (run in sudo mode) creates sub-directories with admin. need 'sudo' to remove.
-func adminRemoveDir(tempDir string) error {
-	cmd := exec.Command("sudo", "rm", "-r", tempDir)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+// removeDir removes temporary directory created for a test
+func removeDir(tempDir string) error {
+	return os.RemoveAll(tempDir)
 }
 
 func checkStateFile(consulAddr, taskname string) (int, error) {


### PR DESCRIPTION
Instead of downloading terraform to /usr/loca/bin, just download it to
the local working directory. Terraform is called using its absolute path
by the client code so it doesn't need to be on the system's searched
PATH.

Also (.git)ignore the downloaded binary and have `make clean` remove it.