### PR TITLE
change readwrite to use 1-to-1 driver/task setup

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -23,17 +23,15 @@ type Controller interface {
 	Run(ctx context.Context) error
 }
 
-func newDriver(conf *config.Config) (driver.Driver, error) {
-	var driver driver.Driver
+func newDriverFunc(conf *config.Config) (func(*config.Config) driver.Driver, error) {
 	if conf.Driver.Terraform != nil {
 		log.Printf("[INFO] (controller) setting up Terraform driver")
-		driver = newTerraformDriver(conf)
-		return driver, nil
+		return newTerraformDriver, nil
 	}
 	return nil, errors.New("Unsupported driver")
 }
 
-func newTerraformDriver(conf *config.Config) *driver.Terraform {
+func newTerraformDriver(conf *config.Config) driver.Driver {
 	tfConf := *conf.Driver.Terraform
 	return driver.NewTerraform(&driver.TerraformConfig{
 		LogLevel:          *tfConf.LogLevel,


### PR DESCRIPTION
This is a prototype of the readwrite controller to have 1 driver per task (expandable to per workflow in future). Having 1 task per driver means we can use the existing driver API for running tasks separately (as well as looking like it could be a good base for parallel execution).

[edit: removed prototype statement]