### PR TITLE
Update worker with init and apply

### DIFF
--- a/driver/task.go
+++ b/driver/task.go
@@ -1,12 +1,14 @@
 package driver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/hashicorp/consul-nia/client"
 )
 
+// Service contains service configuration information
 type Service struct {
 	Datacenter  string
 	Description string
@@ -15,6 +17,7 @@ type Service struct {
 	Tag         string
 }
 
+// Task contains task configuration information
 type Task struct {
 	Description  string
 	Name         string
@@ -26,11 +29,26 @@ type Task struct {
 	Version      string
 }
 
-// worker is executes a unit of work and has a one-to-one relationship with a client
-// that will be responsible for executing the work.
+// worker executes a unit of work and has a one-to-one relationship with a client
+// that will be responsible for executing the work. Currently worker is not safe for
+// concurrent use by multiple goroutines
 type worker struct {
 	client client.Client
 	work   *work
+}
+
+func (w *worker) init(ctx context.Context) error {
+	if err := w.client.Init(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *worker) apply(ctx context.Context) error {
+	if err := w.client.Apply(ctx); err != nil {
+		return err
+	}
+	return nil
 }
 
 // work represents a standalone unit of work that can be executed concurrently alongside others

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -1,0 +1,150 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	mocks "github.com/hashicorp/consul-nia/mocks/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWorkerInit(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		initErr error
+	}{
+		{
+			"happy path",
+			nil,
+		},
+		{
+			"error",
+			errors.New("error"),
+		},
+	}
+
+	for _, tc := range cases {
+		ctx := context.Background()
+		t.Run(tc.name, func(t *testing.T) {
+			c := new(mocks.Client)
+			c.On("Init", mock.Anything).Return(tc.initErr)
+			w := worker{client: c}
+
+			err := w.init(ctx)
+			if tc.initErr != nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestWorkerApply(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		applyErr error
+	}{
+		{
+			"happy path",
+			nil,
+		},
+		{
+			"error",
+			errors.New("error"),
+		},
+	}
+
+	for _, tc := range cases {
+		ctx := context.Background()
+		t.Run(tc.name, func(t *testing.T) {
+			c := new(mocks.Client)
+			c.On("Apply", mock.Anything).Return(tc.applyErr)
+			w := worker{client: c}
+
+			err := w.apply(ctx)
+			if tc.applyErr != nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestWorkString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		nilWork bool
+		task    Task
+		expect  string
+	}{
+		{
+			"nil",
+			true,
+			Task{Name: "first"},
+			"nil",
+		},
+		{
+			"name, no provider",
+			false,
+			Task{Name: "test_task"},
+			"TaskName: 'test_task', TaskProviders: ''",
+		},
+		{
+			"name with single provider",
+			false,
+			Task{
+				Name: "test_task",
+				Providers: []map[string]interface{}{
+					map[string]interface{}{"Provider1": true},
+				},
+			},
+			"TaskName: 'test_task', TaskProviders: 'Provider1'",
+		},
+		{
+			"name with multiple providers",
+			false,
+			Task{
+				Name: "test_task",
+				Providers: []map[string]interface{}{
+					map[string]interface{}{"Provider1": true},
+					map[string]interface{}{"Provider2": true},
+					map[string]interface{}{"Provider3": true},
+				},
+			},
+			"TaskName: 'test_task', TaskProviders: 'Provider1, Provider2, Provider3'",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w *work
+			if !tc.nilWork {
+				w = &work{task: tc.task}
+			}
+			actual := w.String()
+			assert.Equal(t, tc.expect, actual)
+
+			if tc.nilWork {
+				// no need to continue testing
+				return
+			}
+
+			// confirm desc field is set
+			assert.Equal(t, tc.expect, w.desc)
+
+			// rerun for coverage on retrieving from desc
+			rerun := w.String()
+			assert.Equal(t, tc.expect, rerun)
+		})
+	}
+}

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -198,7 +198,7 @@ func (tf *Terraform) InitWork(ctx context.Context) error {
 	for _, w := range tf.workers {
 		go func(ctx context.Context, w *worker) {
 			log.Printf("[TRACE] (driver.terraform) go init for work: %v", w.work)
-			resultCh <- w.client.Init(ctx)
+			resultCh <- w.init(ctx)
 		}(ctx, w)
 	}
 
@@ -230,7 +230,7 @@ func (tf *Terraform) ApplyWork(ctx context.Context) error {
 	for _, w := range tf.workers {
 		go func(ctx context.Context, w *worker) {
 			log.Printf("[TRACE] (driver.terraform) go apply for work: %v", w.work)
-			resultCh <- w.client.Apply(ctx)
+			resultCh <- w.apply(ctx)
 		}(ctx, w)
 	}
 


### PR DESCRIPTION
Changes:
 - Add worker-level `init()` and `apply()` methods to be consumed by driver

This change is part of a larger body of work to improve our Terraform error-handling. We want to be able to call init & apply per task. In a subsequent PR, we will consume these new fields in a more meaningful way to support more complex error-handling.

Part of: https://github.com/hashicorp/consul-nia/issues/28