### PR TITLE
Update Terraform version discovery

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -132,6 +132,7 @@ func (cli *CLI) Run(args []string) int {
 	if isVersion {
 		log.Printf("[DEBUG] (cli) version flag was given, exiting now")
 		fmt.Fprintf(cli.errStream, "%s %s\n", version.Name, version.GetHumanVersion())
+		fmt.Fprintf(cli.errStream, "Compatible with Terraform %s\n", version.CompatibleTerraformVersionConstraint)
 		return ExitCodeOK
 	}
 
@@ -151,14 +152,14 @@ func (cli *CLI) Run(args []string) int {
 		prov = controller.NewReadOnly(conf)
 	}
 
+	ctx := context.Background()
 	log.Printf("[INFO] (cli) initializing controller")
-	if err = prov.Init(); err != nil {
+	if err = prov.Init(ctx); err != nil {
 		log.Printf("[ERR] (cli) error initializing controller: %s", err)
 		return ExitCodeError
 	}
 
 	log.Printf("[INFO] (cli) running controller")
-	ctx := context.Background()
 	if err := runLoop(prov, ctx); err != nil {
 		log.Printf("[ERR] (cli) error running controller: %s", err)
 		return ExitCodeError

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -17,7 +17,7 @@ import (
 // and triggering the driver to update network infrastructure.
 type Controller interface {
 	// Init initializes elements needed by controller
-	Init() error
+	Init(ctx context.Context) error
 
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
 	Run(ctx context.Context) <-chan error

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -21,7 +21,7 @@ func NewReadOnly(conf *config.Config) *ReadOnly {
 }
 
 // Init initializes the controller before it can be run
-func (ro *ReadOnly) Init() error {
+func (ro *ReadOnly) Init(ctx context.Context) error {
 	// TODO
 	return nil
 }

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -47,7 +47,7 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 
 // Init initializes the controller before it can be run. Ensures that
 // driver is initializes, works are created for each task.
-func (rw *ReadWrite) Init() error {
+func (rw *ReadWrite) Init(ctx context.Context) error {
 	log.Printf("[INFO] (controller.readwrite) initializing driver")
 
 	log.Printf("[INFO] (controller.readwrite) driver initialized")
@@ -61,7 +61,7 @@ func (rw *ReadWrite) Init() error {
 
 	for _, task := range tasks {
 		d := rw.newDriver(rw.conf)
-		if err := d.Init(); err != nil {
+		if err := d.Init(ctx); err != nil {
 			log.Printf("[ERR] (controller.readwrite) error initializing driver: %s", err)
 			return err
 		}

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -110,10 +110,11 @@ func TestReadWriteInit(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
-			d.On("Init").Return(tc.initErr).Once()
+			d.On("Init", mock.Anything).Return(tc.initErr).Once()
 			d.On("InitTask", mock.Anything, mock.Anything).Return(tc.initTaskErr).Once()
 			d.On("InitWorker", mock.Anything).Return(tc.initWorkerErr).Once()
 
@@ -123,7 +124,7 @@ func TestReadWriteInit(t *testing.T) {
 				fileReader: tc.fileReader,
 			}
 
-			err := controller.Init()
+			err := controller.Init(ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,7 +8,7 @@ import "context"
 // downstream to update network infrastructure.
 type Driver interface {
 	// Init initializes the driver and environment
-	Init() error
+	Init(ctx context.Context) error
 
 	// InitTask initializes a task that the driver will execute
 	InitTask(task Task, force bool) error

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -1,31 +1,23 @@
 package driver
 
 import (
-	"archive/zip"
-	"bytes"
-	"crypto/sha256"
-	"fmt"
-	"io"
-	"io/ioutil"
+	"context"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strings"
 
-	"github.com/pkg/errors"
-	"golang.org/x/crypto/openpgp"
+	"github.com/hashicorp/consul-nia/version"
+	"github.com/hashicorp/go-checkpoint"
+	goVersion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/hashicorp/terraform-exec/tfinstall"
 )
 
-const hashicorpPublicKeyURL = "https://keybase.io/hashicorp/pgp_keys.asc"
+const fallbackTFVersion = "0.13.2"
 
-// terraformInstalled checks to see if terraform already exists at path.
-// Note: at this point assuming if terraform already exists, that it is the
-// correct version, os, arch. User may have previously installed a version
-// that we don't support. May want to add handling in the future.
-func terraformInstalled(tfPath string) bool {
+// isTFInstalled checks to see if terraform already exists at path.
+func isTFInstalled(tfPath string) bool {
 	tfPath = filepath.Join(tfPath, "terraform")
 
 	// Check if terraform exists in target path
@@ -47,199 +39,72 @@ func terraformInstalled(tfPath string) bool {
 	return false
 }
 
-// installTerraform installs terraform: download file, verifies download, and
-// unzips binary into path, and cleans up downloaded artifacts
-func (tf *Terraform) install() error {
-	// system info needed to install compatible binary
-	opsys := runtime.GOOS
-	arch := runtime.GOARCH
+// isTFCompatible checks if the installed Terraform is compatible with the
+// current architecture and is valid within Consul NIA version constraints.
+func isTFCompatible(ctx context.Context, workingDir, tfPath string) (*goVersion.Version, bool, error) {
+	// Verify version for existing terraform
+	tf, err := tfexec.NewTerraform(workingDir, filepath.Join(tfPath, "terraform"))
+	if err != nil {
+		log.Printf("[ERR] (driver.terraform) unable to setup Terraform client "+
+			"from path %s: %s", tfPath, err)
+		return nil, false, err
+	}
+
+	tfVersion, _, err := tf.Version(ctx, true)
+	if err != nil {
+		log.Printf("[ERR] (driver.terraform) unable to verify Terraform version "+
+			"from path %s: %s", tfPath, err)
+		return nil, false, err
+	}
+
+	if !version.TerraformConstraint.Check(tfVersion) {
+		log.Printf("[ERR] (driver.terraform) Terraform found in path %s is "+
+			"version %q and does not satisfy the constraint %q.",
+			tfPath, tfVersion.String(), version.CompatibleTerraformVersionConstraint)
+		return tfVersion, false, nil
+	}
+
+	return tfVersion, true, nil
+}
+
+// install attempts to install the latest version of Terraform into the path.
+// If the latest version is outside of the known supported range for Consul NIA,
+// the fall back version 0.13.2 is downloaded.
+func (tf *Terraform) install(ctx context.Context) error {
+	resp, err := checkpoint.Check(&checkpoint.CheckParams{Product: "terraform"})
+	if err != nil {
+		log.Printf("[ERR] (driver.terraform) Checkpoint error: %s", err)
+		return err
+	}
+
+	var v string
+	if resp.CurrentVersion == "" {
+		log.Printf("[WARN] (driver.terrform) could not determine latest version "+
+			"of terraform using checkpoint, fallback to version %s", fallbackTFVersion)
+		v = fallbackTFVersion
+	} else {
+		// Check if the latest version is within support range for Consul NIA.
+		latest := goVersion.Must(goVersion.NewVersion(resp.CurrentVersion))
+		if version.TerraformConstraint.Check(latest) {
+			v = resp.CurrentVersion
+		} else {
+			// At this point we cannot guarantee compatibility for the latest
+			// Terraform version, so we will move forward with a safe fallback
+			// version.
+			v = fallbackTFVersion
+		}
+	}
 
 	// Create path if doesn't already exist
 	os.MkdirAll(tf.path, os.ModePerm)
 
-	filename := fmt.Sprintf("terraform_%s_%s_%s.zip", tf.version, opsys, arch)
-	fullFilePath := filepath.Join(tf.path, filename)
-	url := fmt.Sprintf("%s/terraform/%s/%s", releasesURL, tf.version, filename)
-
-	log.Printf("[DEBUG] (driver.terraform) downloading %s from %s\n", filename, url)
-	if err := download(url, fullFilePath); err != nil {
-		return errors.Wrap(err, "Unable to download zip")
-	}
-	log.Printf("[DEBUG] (driver.terraform) successfully downloaded terraform")
-
-	if !tf.skipVerify {
-		log.Printf("[DEBUG] (driver.terraform) verifying checksum and signature")
-		if err := verifyTerraformDownload(tf.path, filename, tf.version); err != nil {
-			return err
-		}
-		log.Printf("[DEBUG] (driver.terraform) checksum and signature verified")
-	} else {
-		log.Printf("[DEBUG] (driver.terraform) skipping download verification")
-	}
-
-	log.Printf("[DEBUG] (driver.terraform) unziping %s to %s\n", filename, tf.path)
-	if err := unzip(fullFilePath, tf.path); err != nil {
-		return errors.Wrap(err, "Unable to unzip binary")
-	}
-
-	// Cleanup zip file after successful installation
-	log.Printf("[DEBUG] (driver.terraform) removing %s", filename)
-	os.Remove(fullFilePath)
-
-	return nil
-}
-
-// download downloads a file from the provided URL and writes it locally to a
-// file. Include the full path of the file to specificy the download location.
-func download(url, filename string) error {
-	resp, err := http.Get(url)
+	path, err := tfinstall.ExactVersion(v, tf.path).ExecPath(ctx)
 	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	out, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	if _, err = io.Copy(out, resp.Body); err != nil {
-		return err
-	}
-	return nil
-}
-
-func verifyTerraformDownload(path, filename, version string) error {
-	// Download SHASUM file and signature
-	shasumFilename := fmt.Sprintf("terraform_%s_SHA256SUMS", version)
-	shasumURL := fmt.Sprintf("%s/terraform/%s/%s", releasesURL, version, shasumFilename)
-	shasumContent, err := getFile(http.DefaultClient, shasumURL)
-	if err != nil {
-		return errors.Wrap(err, "unable to fetch SHASUM to verify download")
-	}
-
-	signatureURL := fmt.Sprintf("%s.sig", shasumURL)
-	signatureContent, err := getFile(http.DefaultClient, signatureURL)
-	if err != nil {
-		return errors.Wrap(err, "unable to fetch signature to verify download")
-	}
-
-	hashicorpPublicKey, err := getFile(http.DefaultClient, hashicorpPublicKeyURL)
-	if err != nil {
-		return errors.Wrap(err, "unable to fetch HashiCorp public GPG key to verify download")
-	}
-
-	// Verify the signature using the HashiCorp public key
-	err = verifySignature(hashicorpPublicKey, shasumContent, signatureContent)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to verify HashiCorp signature "+
-			"for terraform downloaded from %s", signatureURL))
-	}
-
-	// Verify that the SHA256 calculated for the file matches the SHASUM file
-	err = verifyChecksum(path, filename, shasumContent)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to verify checksum for terraform "+
-			"downloaded from %s", shasumURL))
-	}
-
-	return nil
-}
-
-// unzip unzips the terraform binary. Assumes only one file inside the zip file.
-// Simplied version of https://stackoverflow.com/a/24792688 for the sake of the poc
-func unzip(src, dest string) error {
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	for _, f := range r.File {
-		rc, err := f.Open()
-		if err != nil {
-			return err
-		}
-		defer rc.Close()
-
-		path := filepath.Join(dest, f.Name)
-		fc, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-		defer fc.Close()
-
-		_, err = io.Copy(fc, rc)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// getFile returns the content of a downloaded file.
-func getFile(client *http.Client, url string) ([]byte, error) {
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", resp.Status)
-	}
-
-	return ioutil.ReadAll(resp.Body)
-}
-
-// verifySignature verifies a PGP signature for a file with the provided key
-func verifySignature(key, file, signature []byte) error {
-	keyring, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(key))
-	if err != nil {
+		log.Printf("[ERR] (driver.terraform) error installing terraform")
 		return err
 	}
 
-	_, err = openpgp.CheckDetachedSignature(keyring,
-		bytes.NewReader(file), bytes.NewReader(signature))
-	return err
-}
-
-// verifyChecksum calculates and verifies the SHA256 of the file with the
-// checksum file containing lines of checksums and filenames.
-func verifyChecksum(path, filename string, shasumContent []byte) error {
-	var expectedChecksum string
-	for _, line := range strings.Split(string(shasumContent), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) != 2 {
-			continue
-		}
-		checksum, f := fields[0], fields[1]
-		if f == filename {
-			expectedChecksum = checksum
-		}
-	}
-	if expectedChecksum == "" {
-		return fmt.Errorf("checksum for %s not found to verify download", filename)
-	}
-
-	f, err := os.Open(filepath.Join(path, filename))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	hash := sha256.New()
-	if _, err := io.Copy(hash, f); err != nil {
-		return err
-	}
-
-	actualChecksum := fmt.Sprintf("%x", hash.Sum(nil))
-	if actualChecksum != expectedChecksum {
-		return fmt.Errorf("%s has incorrect SHA-256 checksum %x (expected %x)",
-			filename, actualChecksum, expectedChecksum)
-	}
-
+	tf.version = v
+	log.Printf("[DEBUG] (driver.terraform) successfully installed terraform %s: %s", v, path)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,19 @@ go 1.14
 require (
 	github.com/hashicorp/consul v1.8.0
 	github.com/hashicorp/consul/sdk v0.5.0
+	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-syslog v1.0.0
+	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcat v0.0.0-20200819213737-8df9f16d7129
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform v0.12.29
-	github.com/hashicorp/terraform-exec v0.8.1-0.20200904210734-4052798662d1
+	github.com/hashicorp/terraform-exec v0.9.0
 	github.com/mitchellh/mapstructure v1.3.3
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	github.com/zclconf/go-cty v1.5.1
-	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
+	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,8 @@ github.com/hashicorp/terraform v0.12.29/go.mod h1:CBxNAiTW0pLap44/3GU4j7cYE2bMhk
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-exec v0.8.1-0.20200904210734-4052798662d1 h1:ACNuXeyuUeARuZXEquGtO1FSP6fyseGM7C4oFsH0elo=
 github.com/hashicorp/terraform-exec v0.8.1-0.20200904210734-4052798662d1/go.mod h1:tOT8j1J8rP05bZBGWXfMyU3HkLi1LWyqL3Bzsc3CJjo=
+github.com/hashicorp/terraform-exec v0.9.0 h1:NmCtcsnmPBU6P3cDeKD26bD72evsMhmuDLvuNRgrTHc=
+github.com/hashicorp/terraform-exec v0.9.0/go.mod h1:tOT8j1J8rP05bZBGWXfMyU3HkLi1LWyqL3Bzsc3CJjo=
 github.com/hashicorp/terraform-json v0.5.0 h1:7TV3/F3y7QVSuN4r9BEXqnWqrAyeOtON8f0wvREtyzs=
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -28,13 +28,13 @@ func (_m *Driver) ApplyWork(ctx context.Context) error {
 	return r0
 }
 
-// Init provides a mock function with given fields:
-func (_m *Driver) Init() error {
-	ret := _m.Called()
+// Init provides a mock function with given fields: ctx
+func (_m *Driver) Init(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -1,0 +1,20 @@
+package version
+
+import (
+	"log"
+
+	"github.com/hashicorp/go-version"
+)
+
+const CompatibleTerraformVersionConstraint = "~>0.13.0"
+
+var TerraformConstraint version.Constraints
+
+func init() {
+	var err error
+	TerraformConstraint, err = version.NewConstraint(CompatibleTerraformVersionConstraint)
+	if err != nil {
+		log.Panicf("error setting up Terraform version constraint %q: %s",
+			CompatibleTerraformVersionConstraint, err)
+	}
+}


### PR DESCRIPTION
Updates Terraform version handling:
* Changes hard coded TF version to latest version (0.13) using checkpoint
* Removes code that now lives hashicorp/terraform-exec library
* Terraform driver init (install) is now cancellable with context
* Version is validated for existing Terraform binaries
  * Unsupported version will exit and return an error for users to handle.
    ```
    2020/09/09 22:44:29.752217 [ERR] (driver.terraform) Terraform found in path /Users/kngo/dev/hashicorp/consul-nia is version "0.13.0-rc1" and does not satisfy the constraint "~>0.13.0".
    2020/09/09 22:44:29.752256 [ERR] (controller.readwrite) error initializing driver: unsupported Terraform version: remove Terraform from the configured path or specify a new path to safely install a compatible version.
    2020/09/09 22:44:29.752363 [ERR] (cli) error initializing controller: unsupported Terraform version: remove Terraform from the configured path or specify a new path to safely install a compatible version.
    ```
* Latest version  is installed within constraint ~>0.13.0
  * Defaults to `0.13.2` if the latest version is 0.14 and beyond. This is protection in place until we establish a strong protocol.
* Adds information to `-version` flag for compatible Terraform
```
$ consul-nia -verison
consul-nia c1f1228 (c1f1228)
Compatible with Terraform ~>0.13.0
```

Resolves #21