### PR TITLE
Remove config option to skip TF verify

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,7 +63,6 @@ var (
 				Log:        Bool(true),
 				Path:       String("path"),
 				WorkingDir: String("working"),
-				SkipVerify: Bool(true),
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address": "consul-example.com",

--- a/config/driver_test.go
+++ b/config/driver_test.go
@@ -155,7 +155,6 @@ func TestDriverConfig_Finalize(t *testing.T) {
 					PersistLog:        Bool(false),
 					Path:              String(wd),
 					WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
-					SkipVerify:        Bool(false),
 					Backend:           map[string]interface{}{},
 					RequiredProviders: map[string]interface{}{},
 				},
@@ -165,8 +164,7 @@ func TestDriverConfig_Finalize(t *testing.T) {
 			"with_terraform",
 			&DriverConfig{
 				Terraform: &TerraformConfig{
-					Log:        Bool(true),
-					SkipVerify: Bool(true),
+					Log: Bool(true),
 				},
 			},
 			&DriverConfig{
@@ -175,7 +173,6 @@ func TestDriverConfig_Finalize(t *testing.T) {
 					PersistLog:        Bool(false),
 					Path:              String(wd),
 					WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
-					SkipVerify:        Bool(true),
 					Backend:           map[string]interface{}{},
 					RequiredProviders: map[string]interface{}{},
 				},

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -23,7 +23,6 @@ type TerraformConfig struct {
 	PersistLog        *bool                  `mapstructure:"persist_log"`
 	Path              *string                `mapstructure:"path"`
 	WorkingDir        *string                `mapstructure:"working_dir"`
-	SkipVerify        *bool                  `mapstructure:"skip_verify"`
 	Backend           map[string]interface{} `mapstructure:"backend"`
 	RequiredProviders map[string]interface{} `mapstructure:"required_providers"`
 }
@@ -42,7 +41,6 @@ func DefaultTerraformConfig() *TerraformConfig {
 		PersistLog:        Bool(false),
 		Path:              String(wd),
 		WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
-		SkipVerify:        Bool(false),
 		Backend:           make(map[string]interface{}),
 		RequiredProviders: make(map[string]interface{}),
 	}
@@ -90,10 +88,6 @@ func (c *TerraformConfig) Copy() *TerraformConfig {
 
 	if c.WorkingDir != nil {
 		o.WorkingDir = StringCopy(c.WorkingDir)
-	}
-
-	if c.SkipVerify != nil {
-		o.SkipVerify = BoolCopy(c.SkipVerify)
 	}
 
 	if c.Backend != nil {
@@ -147,10 +141,6 @@ func (c *TerraformConfig) Merge(o *TerraformConfig) *TerraformConfig {
 		r.WorkingDir = StringCopy(o.WorkingDir)
 	}
 
-	if o.SkipVerify != nil {
-		r.SkipVerify = BoolCopy(o.SkipVerify)
-	}
-
 	if o.Backend != nil {
 		for k, v := range o.Backend {
 			if r.Backend == nil {
@@ -201,10 +191,6 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 		c.WorkingDir = String(path.Join(wd, DefaultTFWorkingDir))
 	}
 
-	if c.SkipVerify == nil {
-		c.SkipVerify = Bool(false)
-	}
-
 	if c.Backend == nil {
 		c.Backend = make(map[string]interface{})
 	}
@@ -247,7 +233,6 @@ func (c *TerraformConfig) GoString() string {
 		"PersistLog:%v, "+
 		"Path:%s, "+
 		"WorkingDir:%s, "+
-		"SkipVerify:%v, "+
 		"Backend:%+v, "+
 		"RequiredProviders:%+v"+
 		"}",
@@ -255,7 +240,6 @@ func (c *TerraformConfig) GoString() string {
 		BoolVal(c.PersistLog),
 		StringVal(c.Path),
 		StringVal(c.WorkingDir),
-		BoolVal(c.SkipVerify),
 		c.Backend,
 		c.RequiredProviders,
 	)

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -29,7 +29,6 @@ func TestTerraformConfig_Copy(t *testing.T) {
 				Log:        Bool(true),
 				Path:       String("path"),
 				WorkingDir: String("working"),
-				SkipVerify: Bool(false),
 				Backend: map[string]interface{}{"consul": map[string]interface{}{
 					"path": "consul-nia/terraform",
 				}},
@@ -174,30 +173,6 @@ func TestTerraformConfig_Merge(t *testing.T) {
 			&TerraformConfig{WorkingDir: String("working")},
 			&TerraformConfig{WorkingDir: String("working")},
 			&TerraformConfig{WorkingDir: String("working")},
-		},
-		{
-			"skip_verify_overrides",
-			&TerraformConfig{SkipVerify: Bool(true)},
-			&TerraformConfig{SkipVerify: Bool(false)},
-			&TerraformConfig{SkipVerify: Bool(false)},
-		},
-		{
-			"skip_verify_empty_one",
-			&TerraformConfig{SkipVerify: Bool(true)},
-			&TerraformConfig{},
-			&TerraformConfig{SkipVerify: Bool(true)},
-		},
-		{
-			"skip_verify_empty_two",
-			&TerraformConfig{},
-			&TerraformConfig{SkipVerify: Bool(true)},
-			&TerraformConfig{SkipVerify: Bool(true)},
-		},
-		{
-			"skip_verify_same",
-			&TerraformConfig{SkipVerify: Bool(true)},
-			&TerraformConfig{SkipVerify: Bool(true)},
-			&TerraformConfig{SkipVerify: Bool(true)},
 		},
 		{
 			"backend_overrides",
@@ -420,7 +395,6 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				PersistLog:        Bool(false),
 				Path:              String(wd),
 				WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
-				SkipVerify:        Bool(false),
 				Backend:           map[string]interface{}{},
 				RequiredProviders: map[string]interface{}{},
 			},
@@ -434,7 +408,6 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				PersistLog: Bool(false),
 				Path:       String(wd),
 				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
-				SkipVerify: Bool(false),
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address": *consul.Address,
@@ -457,7 +430,6 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				PersistLog: Bool(false),
 				Path:       String(wd),
 				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
-				SkipVerify: Bool(false),
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address": "127.0.0.1:8080",

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -37,7 +37,6 @@ driver "terraform" {
   log = true
   path = "path"
   working_dir = "working"
-  skip_verify = true
   backend "consul" {
     address = "consul-example.com"
     path = "kv-path/terraform"

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -36,7 +36,6 @@
       "log": true,
       "path": "path",
       "working_dir": "working",
-      "skip_verify": true,
       "backend": {
         "consul": {
           "address": "consul-example.com",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -38,7 +38,6 @@ func newTerraformDriver(conf *config.Config) driver.Driver {
 		PersistLog:        *tfConf.PersistLog,
 		Path:              *tfConf.Path,
 		WorkingDir:        *tfConf.WorkingDir,
-		SkipVerify:        *tfConf.SkipVerify,
 		Backend:           tfConf.Backend,
 		RequiredProviders: tfConf.RequiredProviders,
 		ClientType:        *conf.ClientType,

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -290,7 +290,6 @@ func singleTaskConfig() *config.Config {
 				Log:        config.Bool(true),
 				Path:       config.String("path"),
 				WorkingDir: config.String("working"),
-				SkipVerify: config.Bool(true),
 			},
 		},
 		Tasks: &config.TaskConfigs{

--- a/docs/config.md
+++ b/docs/config.md
@@ -168,7 +168,6 @@ driver "terraform {
   persist_log = false
   path = ""
   working_dir = ""
-  skip_verify = false
   
   backend "consul" {
     scheme = "https"
@@ -188,7 +187,6 @@ driver "terraform {
 * `path` - `(string: optional)` The file path to install Terraform or discover an existing Terraform binary. If omitted, Consul NIA will install Terraform in the same directory as the daemon.
 * `persist_log` - `(bool: false)` Enable trace logging for each Terraform client to disk per task. This is equivalent to setting `TF_LOG_PATH=<work_dir>/terraform.log`. Trace log level results in verbose logging and may be useful for debugging and development purposes. We do not recommend enabling this for production. There is no log rotation and may quickly result in large files.
 * `required_providers` - `(obj)` Declare each Terraform providers used across all tasks. This is similar to the [Terraform `terraform.required_providers`](https://www.terraform.io/docs/configuration/provider-requirements.html#requiring-providers) field to specify the source and version for each provider. Consul NIA will process these requirements when preparing each task that uses the provider.
-* `skip_verify` - `(bool: false)` If enabled, Consul NIA will skip release signature validation when installing Terraform.
 * `working_dir` - `(string: "nia-tasks")` The base working directory to manage Terraform configurations all tasks. The full path of each working directory will have the task identifier appended to the end of the path, e.g. `./nia-tasks/task-name`.
 
 ### Provider

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -34,7 +34,6 @@ type Terraform struct {
 	persistLog        bool
 	path              string
 	workingDir        string
-	skipVerify        bool
 	workers           []*worker
 	backend           map[string]interface{}
 	requiredProviders map[string]interface{}
@@ -49,7 +48,6 @@ type TerraformConfig struct {
 	PersistLog        bool
 	Path              string
 	WorkingDir        string
-	SkipVerify        bool
 	Backend           map[string]interface{}
 	RequiredProviders map[string]interface{}
 
@@ -64,7 +62,6 @@ func NewTerraform(config *TerraformConfig) *Terraform {
 		persistLog:        config.PersistLog,
 		path:              config.Path,
 		workingDir:        config.WorkingDir,
-		skipVerify:        config.SkipVerify,
 		backend:           config.Backend,
 		requiredProviders: config.RequiredProviders,
 		clientType:        config.ClientType,

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -37,7 +37,6 @@ func terraformBlock(dir string) string {
 	}
 	return fmt.Sprintf(`
 driver "terraform" {
-	skip_verify = true
 	path = "%s"
 	working_dir = "%s"
 }


### PR DESCRIPTION
With the recent code cleanup to use tfexec for install, we'll defer to its verification logic. I can imagine this option could also be easily confused with `TF_SKIP_PROVIDER_VERIFY` which skips verifying provider signature (which is no longer used in 0.13 and greater.