### PR TITLE
Add wait config for global and tasks

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,6 +101,10 @@ var (
 		Providers: &ProviderConfigs{{
 			"X": map[string]interface{}{},
 		}},
+		Wait: &WaitConfig{
+			Min: TimeDuration(20 * time.Second),
+			Max: TimeDuration(60 * time.Second),
+		},
 	}
 )
 
@@ -257,6 +261,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected := longConfig.Copy()
 	expected.ClientType = String("")
 	expected.Syslog.Facility = String("LOCAL0")
+	expected.Wait.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")
 	expected.Consul.TLS.Cert = String("")
 	expected.Consul.Transport.MaxIdleConns = Int(100)
@@ -264,6 +269,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.Driver.Terraform.PersistLog = Bool(false)
 	(*expected.Tasks)[0].VarFiles = []string{}
 	(*expected.Tasks)[0].Version = String("")
+	(*expected.Tasks)[0].Wait = expected.Wait
 	(*expected.Services)[0].ID = String("serviceA")
 	(*expected.Services)[0].Namespace = String("")
 	(*expected.Services)[0].Datacenter = String("")

--- a/config/convert.go
+++ b/config/convert.go
@@ -102,3 +102,12 @@ func TimeDurationCopy(t *time.Duration) *time.Duration {
 
 	return TimeDuration(*t)
 }
+
+// TimeDurationPresent returns a boolean indicating if the pointer is nil, or
+// if the pointer is pointing to the zero value.
+func TimeDurationPresent(t *time.Duration) bool {
+	if t == nil {
+		return false
+	}
+	return *t != 0
+}

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -6,6 +6,11 @@ syslog {
   name = "syslog"
 }
 
+wait {
+  min = "20s"
+  max = "60s"
+}
+
 consul {
   address = "consul-example.com"
   auth {

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -5,6 +5,10 @@
     "enabled": true,
     "name": "syslog"
   },
+  "wait": {
+    "min": "20s",
+    "max": "60s"
+  },
   "consul": {
     "address": "consul-example.com",
     "auth": {

--- a/config/wait.go
+++ b/config/wait.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+var (
+	DefaultWaitMin = time.Duration(5 * time.Second)
+	DefaultWaitMax = time.Duration(4 * DefaultWaitMin)
+)
+
+// WaitConfig is the Min/Max duration used by the Watcher
+type WaitConfig struct {
+	// Enabled determines if this wait is enabled.
+	Enabled *bool `mapstructure:"enabled"`
+
+	// Min and Max are the minimum and maximum time, respectively, to wait for
+	// data changes before rendering a new template to disk.
+	Min *time.Duration `mapstructure:"min"`
+	Max *time.Duration `mapstructure:"max"`
+}
+
+// DefaultWaitConfig is the global default configuration for all tasks.
+func DefaultWaitConfig() *WaitConfig {
+	return &WaitConfig{
+		Enabled: Bool(true),
+		Min:     &DefaultWaitMin,
+		Max:     &DefaultWaitMax,
+	}
+}
+
+// DefaultTaskWaitConfig is the default configuration for a task.
+func DefaultTaskWaitConfig() *WaitConfig {
+	return &WaitConfig{
+		Enabled: Bool(false),
+		Min:     &DefaultWaitMin,
+		Max:     &DefaultWaitMax,
+	}
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *WaitConfig) Copy() *WaitConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o WaitConfig
+	o.Enabled = BoolCopy(c.Enabled)
+	o.Min = TimeDurationCopy(c.Min)
+	o.Max = TimeDurationCopy(c.Max)
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *WaitConfig) Merge(o *WaitConfig) *WaitConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.Enabled != nil {
+		r.Enabled = BoolCopy(o.Enabled)
+	}
+
+	if o.Min != nil {
+		r.Min = TimeDurationCopy(o.Min)
+	}
+
+	if o.Max != nil {
+		r.Max = TimeDurationCopy(o.Max)
+	}
+
+	return r
+}
+
+// Finalize ensures there no nil pointers.
+func (c *WaitConfig) Finalize() {
+	if c.Enabled == nil {
+		c.Enabled = Bool(TimeDurationPresent(c.Min))
+	}
+
+	if c.Min == nil {
+		c.Min = TimeDuration(DefaultWaitMin)
+	}
+
+	if c.Max == nil {
+		c.Max = TimeDuration(4 * *c.Min)
+	}
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *WaitConfig) Validate() error {
+	if c == nil {
+		// Wait config is not required, return early
+		return nil
+	}
+
+	if !BoolVal(c.Enabled) {
+		return nil
+	}
+
+	if c.Min.Seconds() < 0 || c.Max.Seconds() < 0 {
+		return fmt.Errorf("wait: cannot be negative")
+	}
+
+	if *c.Max < *c.Min {
+		return fmt.Errorf("wait: min must be less than max")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *WaitConfig) GoString() string {
+	if c == nil {
+		return "(*WaitConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&WaitConfig{"+
+		"Enabled:%v, "+
+		"Min:%s, "+
+		"Max:%s"+
+		"}",
+		BoolVal(c.Enabled),
+		TimeDurationVal(c.Min),
+		TimeDurationVal(c.Max),
+	)
+}

--- a/config/wait_test.go
+++ b/config/wait_test.go
@@ -1,0 +1,255 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitConfig_Copy(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *WaitConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&WaitConfig{},
+		},
+		{
+			"same_enabled",
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(10 * time.Second),
+				Max:     TimeDuration(20 * time.Second),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
+func TestWaitConfig_Merge(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *WaitConfig
+		b    *WaitConfig
+		r    *WaitConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&WaitConfig{},
+			&WaitConfig{},
+		},
+		{
+			"nil_b",
+			&WaitConfig{},
+			nil,
+			&WaitConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&WaitConfig{},
+			&WaitConfig{},
+			&WaitConfig{},
+		},
+		{
+			"enabled_overrides",
+			&WaitConfig{Enabled: Bool(true)},
+			&WaitConfig{Enabled: Bool(false)},
+			&WaitConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_empty_one",
+			&WaitConfig{Enabled: Bool(true)},
+			&WaitConfig{},
+			&WaitConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_empty_two",
+			&WaitConfig{},
+			&WaitConfig{Enabled: Bool(true)},
+			&WaitConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_same",
+			&WaitConfig{Enabled: Bool(true)},
+			&WaitConfig{Enabled: Bool(true)},
+			&WaitConfig{Enabled: Bool(true)},
+		},
+		{
+			"min_overrides",
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+			&WaitConfig{Min: TimeDuration(0 * time.Second)},
+			&WaitConfig{Min: TimeDuration(0 * time.Second)},
+		},
+		{
+			"min_empty_one",
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+			&WaitConfig{},
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+		},
+		{
+			"min_empty_two",
+			&WaitConfig{},
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+		},
+		{
+			"min_same",
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+			&WaitConfig{Min: TimeDuration(10 * time.Second)},
+		},
+		{
+			"max_overrides",
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+			&WaitConfig{Max: TimeDuration(0 * time.Second)},
+			&WaitConfig{Max: TimeDuration(0 * time.Second)},
+		},
+		{
+			"max_empty_one",
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+			&WaitConfig{},
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+		},
+		{
+			"max_empty_two",
+			&WaitConfig{},
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+		},
+		{
+			"max_same",
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+			&WaitConfig{Max: TimeDuration(20 * time.Second)},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestWaitConfig_Finalize(t *testing.T) {
+	cases := []struct {
+		name string
+		i    *WaitConfig
+		r    *WaitConfig
+	}{
+		{
+			"empty",
+			&WaitConfig{},
+			&WaitConfig{
+				Enabled: Bool(false),
+				Min:     TimeDuration(5 * time.Second),
+				Max:     TimeDuration(20 * time.Second),
+			},
+		},
+		{
+			"with_min",
+			&WaitConfig{
+				Min: TimeDuration(10 * time.Second),
+			},
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(10 * time.Second),
+				Max:     TimeDuration(40 * time.Second),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestWaitConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		i       *WaitConfig
+		isValid bool
+	}{
+		{
+			"nil",
+			nil,
+			true,
+		},
+		{
+			"empty",
+			&WaitConfig{},
+			true,
+		},
+		{
+			"valid",
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(time.Duration(10 * time.Second)),
+				Max:     TimeDuration(time.Duration(60 * time.Second)),
+			},
+			true,
+		},
+		{
+			"min negative",
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(time.Duration(-10 * time.Second)),
+				Max:     TimeDuration(time.Duration(5 * time.Second)),
+			},
+			false,
+		},
+		{
+			"max negative",
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(time.Duration(5 * time.Second)),
+				Max:     TimeDuration(time.Duration(-10 * time.Second)),
+			},
+			false,
+		},
+		{
+			"min > max",
+			&WaitConfig{
+				Enabled: Bool(true),
+				Min:     TimeDuration(time.Duration(5 * time.Second)),
+				Max:     TimeDuration(time.Duration(2 * time.Second)),
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			err := tc.i.Validate()
+			if tc.isValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,6 +45,9 @@ task {
   version = "1.0.0"
   providers = ["myprovider"]
   services = ["web", "api"]
+  wait {
+    min = "10s"
+  }
 }
 
 driver "terraform" {
@@ -78,6 +81,10 @@ syslog {}
   * `enabled` - `(bool: false)` Enable syslog logging. Specifying other option also enables syslog logging.
   * `facility` - `(string: <none>)` Name of the syslog facility to log to.
   * `name` - `(string: "consul-nia")` Name to use for the Consul NIA process when logging to syslog.
+* `wait` - Wait configures quiescence timers for all [tasks](#task). It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state before triggering task executions. The default is enabled to reduce the number of times downstream infrastructure is updated within a short period of time. This is useful to enable in systems that have a lot of flapping.
+  * `enabled` - `(bool: true)` Enable quiescence timer globally. Specifying `min` will also enable it.
+  * `min` - `(string: 5s)` The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - `(string: 20s)` The maximum period of time to wait after changes are detected before triggering related tasks.
 
 ### Consul
 
@@ -158,6 +165,10 @@ task {
 * `source` - `(string: <required>)` Source is the location the driver uses to fetch dependencies. The source format is dependent on the driver. For the [Terraform driver](#terraform-driver), the source is the module path (local or remote). Read more on [Terraform module source here](https://www.terraform.io/docs/modules/sources.html).
 * `variable_files` - `(list(string): [])` A list of paths to files containing variables for the task. For the [Terraform driver](#terraform-driver), these are files with `.tfvars` file extensions and are used as Terraform [input variables](https://www.terraform.io/docs/configuration/variables.html) to pass as arguments to the Terraform module. Variables are loaded in the same order as they appear in the order of the files. Duplicate variables are overwritten with the later value.
 * `version` - `(string: <none>)` The version of the provided source the task will use. For the [Terraform driver](#terraform-driver), this is the module version. The latest version will be used as the default if omitted.
+* `wait` - Wait configures a quiescence timer for the task. It defines the minimum and maximum amount of time to wait for the cluster to reach a consistent state before triggering task execution. The default is inherited from the top level [`wait` block](#consul-nia). If configured, these values will take precedence over the global quiescence timer. This is useful to enable for a task that is dependent on services that have a lot of flapping.
+  * `enabled` - `(bool: true)` Enable or disable a quiescence timer for the task. Specifying `min` will also enable it.
+  * `min` - `(string: 5s)` The minimum period of time to wait after changes are detected before triggering related tasks.
+  * `max` - `(string: 20s)` The maximum period of time to wait after changes are detected before triggering related tasks.
 
 ### Terraform Driver
 The `driver` block configures the subprocess for Consul NIA to propagate infrastructure change. The default Terraform driver does not need to be explicitly configured.


### PR DESCRIPTION
PR adds wait config options that are not hooked up with task execution yet. That will be done in a follow-up PR.
* Top level `wait` block to configure all tasks
* `task.wait` block to configure per task

`wait` option is similar in design to Consul Template `wait` used for templates with a few differences. The global default wait is enabled with `5s` min and `20s` max, the exact values can be tweaked in the future when we have more examples of runtime cases to improve the default values. The idea behind enabling the quiescence by default for NIA is that the downstream changes can be assumed to be infrastructure level changes. The cost of a few seconds delay outweighs possibly causing flooding / DoS to a network controller due to a poorly configured NIA.