### PR TITLE
Configure Consul backend with TLS

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -267,6 +267,10 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.Consul.Transport.MaxIdleConns = Int(100)
 	expected.Driver.consul = expected.Consul
 	expected.Driver.Terraform.PersistLog = Bool(false)
+	backend := expected.Driver.Terraform.Backend["consul"].(map[string]interface{})
+	backend["scheme"] = "https"
+	backend["ca_file"] = "ca_cert"
+	backend["key_file"] = "key"
 	(*expected.Tasks)[0].VarFiles = []string{}
 	(*expected.Tasks)[0].Version = String("")
 	(*expected.Tasks)[0].Wait = expected.Wait


### PR DESCRIPTION
Allows users to define Consul TLS once within the Consul block without needing to duplicate configuration for the Terraform backend when using Consul.

Environment variables for the corresponding TLS options are still detected and translated to the Consul backend for Terraform. If TLS is enabled, the `scheme` is set to `https` by default. The example `consul` config block for NIA would output the corresponding `terraform` block within `main.tf` configuration file for tasks.

**config.hcl**
```hcl
consul {
  address = "example.consul.com"
  tls {
    ca_cert = "path/to/ca_file"
    cert = "path/to/client_cert"
    key = "path/to/client_key"
  }
}
```

**main.tf**
Docs for the Terraform Consul backend can be found here https://www.terraform.io/docs/backends/types/consul.html
```hcl
terraform {
  backend "consul" {
    address = "example.consul.com"
    scheme = "https"
    ca_file = "path/to/ca_file"
    cert_file = "path/to/client_cert"
    key_file = "path/to/client_key"
  }
}
```

Prior to these changes, any configuration to the driver backend would completely override defaults. For example, when specifying the KV path for the backend, all of the other default values are dropped.

**config.hcl**
```hcl
consul {
  address = "example.consul.com"
  tls {
    ca_cert = "path/to/ca_file"
    cert = "path/to/client_cert"
    key = "path/to/client_key"
  }
}

driver "terraform" {
  backend "consul" {
    path = "my/custom/kv-path"
  }
}
```

**main.tf**
```hcl
terraform {
  backend "consul" {
    path = "my/custom/kv-path"
  }
}
```

resolves #50