### PR TITLE
Call init then apply sequentially for a single worker/task in Driver

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -195,12 +195,7 @@ func (rw *ReadWrite) checkApply(u unit, ctx context.Context) error {
 		log.Printf("[DEBUG] %q rendered: %+v", taskName, rendered)
 
 		d := u.driver
-		log.Printf("[INFO] (controller.readwrite) init work")
-		if err := d.InitWork(ctx); err != nil {
-			return fmt.Errorf("could not initialize: %s", err)
-		}
-
-		log.Printf("[INFO] (controller.readwrite) apply work")
+		log.Printf("[INFO] (controller.readwrite) apply work %s", taskName)
 		if err := d.ApplyWork(ctx); err != nil {
 			return fmt.Errorf("could not apply: %s", err)
 		}

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -158,7 +158,6 @@ func TestReadWriteRun(t *testing.T) {
 	cases := []struct {
 		name              string
 		expectError       bool
-		initWorkErr       error
 		applyWorkErr      error
 		resolverRunErr    error
 		templateRenderErr error
@@ -169,18 +168,7 @@ func TestReadWriteRun(t *testing.T) {
 			"error on resolver.Run()",
 			true,
 			nil,
-			nil,
 			errors.New("error on resolver.Run()"),
-			nil,
-			nil,
-			singleTaskConfig(),
-		},
-		{
-			"error on driver.InitWork()",
-			true,
-			errors.New("error on driver.InitWork()"),
-			nil,
-			nil,
 			nil,
 			nil,
 			singleTaskConfig(),
@@ -188,7 +176,6 @@ func TestReadWriteRun(t *testing.T) {
 		{
 			"error on driver.ApplyWork()",
 			true,
-			nil,
 			errors.New("error on driver.ApplyWork()"),
 			nil,
 			nil,
@@ -198,7 +185,6 @@ func TestReadWriteRun(t *testing.T) {
 		{
 			"happy path",
 			false,
-			nil,
 			nil,
 			nil,
 			nil,
@@ -221,7 +207,6 @@ func TestReadWriteRun(t *testing.T) {
 			w.On("Wait", mock.Anything).Return(tc.watcherWaitErr)
 
 			d := new(mocksD.Driver)
-			d.On("InitWork", mock.Anything).Return(tc.initWorkErr)
 			d.On("ApplyWork", mock.Anything).Return(tc.applyWorkErr)
 
 			h, err := getPostApplyHandlers(tc.config)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -16,9 +16,6 @@ type Driver interface {
 	// InitWorker initializes a worker for a task
 	InitWorker(task Task) error
 
-	// InitWork initalizes all work that is managed by driver
-	InitWork(ctx context.Context) error
-
 	// ApplyWork applies changes for all the work managed by driver
 	ApplyWork(ctx context.Context) error
 

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -16,33 +16,25 @@ func TestInitWorker(t *testing.T) {
 		name        string
 		clientType  string
 		expectError bool
-		tasks       []Task
+		task        Task
 	}{
 		{
 			"happy path with development client",
 			developmentClient,
 			false,
-			[]Task{
-				Task{Name: "first"},
-			},
+			Task{Name: "development-client task"},
 		},
 		{
 			"happy path with mock client",
 			testClient,
 			false,
-			[]Task{
-				Task{Name: "first"},
-				Task{Name: "second"},
-				Task{Name: "third"},
-			},
+			Task{Name: "mock-client task"},
 		},
 		{
 			"error when creating Terraform CLI client",
 			"",
 			true,
-			[]Task{
-				Task{Name: "task"},
-			},
+			Task{Name: "task"},
 		},
 	}
 
@@ -54,100 +46,13 @@ func TestInitWorker(t *testing.T) {
 				clientType: tc.clientType,
 			}
 
-			for _, task := range tc.tasks {
-				err := tf.InitWorker(task)
-				if tc.expectError {
-					assert.Error(t, err)
-					return
-				}
-				assert.NoError(t, err)
-			}
-			assert.Equal(t, len(tc.tasks), len(tf.workers))
-		})
-	}
-}
-
-func TestInitWork(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name        string
-		expectError bool
-		errs        []error
-	}{
-		{
-			"single worker, no error",
-			false,
-			[]error{
-				nil,
-			},
-		},
-		{
-			"multiple workers, no errors",
-			false,
-			[]error{
-				nil,
-				nil,
-				nil,
-				nil,
-			},
-		},
-		{
-			"single worker, with error",
-			true,
-			[]error{
-				errors.New("first task error"),
-			},
-		},
-		{
-			"multiple workers, mixed error",
-			true,
-			[]error{
-				errors.New("first task error"),
-				nil,
-				errors.New("third task error"),
-				errors.New("fourth task error"),
-				nil,
-				nil,
-				errors.New("seventh task error"),
-				errors.New("eighth task error"),
-				errors.New("nineth task error"),
-				nil,
-				nil,
-			},
-		},
-	}
-	ctx := context.Background()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// create workers for the driver
-			workers := make([]*worker, len(tc.errs))
-			for ix, err := range tc.errs {
-				c := new(mocks.Client)
-				c.On("Init", ctx).Return(err)
-				workers[ix] = &worker{
-					client: c,
-					task:   Task{},
-				}
-			}
-
-			tf := &Terraform{
-				workers: workers,
-			}
-			err := tf.InitWork(ctx)
-			if !tc.expectError {
-				assert.NoError(t, err)
+			err := tf.InitWorker(tc.task)
+			if tc.expectError {
+				assert.Error(t, err)
 				return
 			}
-
-			assert.Error(t, err)
-			// confirm all the error strings are within error
-			for _, e := range tc.errs {
-				if e == nil {
-					continue
-				}
-				assert.Contains(t, err.Error(), e.Error())
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.task, tf.worker.task)
 		})
 	}
 }
@@ -158,80 +63,47 @@ func TestApplyWork(t *testing.T) {
 	cases := []struct {
 		name        string
 		expectError bool
-		errs        []error
+		initReturn  error
+		applyReturn error
 	}{
 		{
-			"single worker, no error",
+			"happy path",
 			false,
-			[]error{
-				nil,
-			},
+			nil,
+			nil,
 		},
 		{
-			"multiple workers, no errors",
-			false,
-			[]error{
-				nil,
-				nil,
-				nil,
-				nil,
-			},
-		},
-		{
-			"single worker, with error",
+			"error on init",
 			true,
-			[]error{
-				errors.New("first task error"),
-			},
+			errors.New("init error"),
+			nil,
 		},
 		{
-			"multiple workers, mixed error",
+			"error on apply",
 			true,
-			[]error{
-				errors.New("first task error"),
-				nil,
-				errors.New("third task error"),
-				errors.New("fourth task error"),
-				nil,
-				nil,
-				errors.New("seventh task error"),
-				errors.New("eighth task error"),
-				errors.New("nineth task error"),
-				nil,
-				nil,
-			},
+			nil,
+			errors.New("apply error"),
 		},
 	}
 	ctx := context.Background()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// create workers for the driver
-			workers := make([]*worker, len(tc.errs))
-			for ix, err := range tc.errs {
-				c := new(mocks.Client)
-				c.On("Apply", ctx).Return(err)
-				workers[ix] = &worker{
-					client: c,
-					task:   Task{},
-				}
-			}
+			c := new(mocks.Client)
+			c.On("Init", ctx).Return(tc.initReturn).Once()
+			c.On("Apply", ctx).Return(tc.applyReturn).Once()
 
 			tf := &Terraform{
-				workers: workers,
+				worker: &worker{
+					client: c,
+					task:   Task{},
+				},
 			}
+
 			err := tf.ApplyWork(ctx)
 			if !tc.expectError {
 				assert.NoError(t, err)
-				return
-			}
-
-			assert.Error(t, err)
-			// confirm all the error strings are within error
-			for _, e := range tc.errs {
-				if e == nil {
-					continue
-				}
-				assert.Contains(t, err.Error(), e.Error())
+			} else {
+				assert.Error(t, err)
 			}
 		})
 	}

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -56,20 +56,6 @@ func (_m *Driver) InitTask(task driver.Task, force bool) error {
 	return r0
 }
 
-// InitWork provides a mock function with given fields: ctx
-func (_m *Driver) InitWork(ctx context.Context) error {
-	ret := _m.Called(ctx)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // InitWorker provides a mock function with given fields: task
 func (_m *Driver) InitWorker(task driver.Task) error {
 	ret := _m.Called(task)


### PR DESCRIPTION
Changes:
 - Update driver `workers` field to `worker`. Reinforce 1:1 relationship with worker
 - Remove `InitWork()` from driver interface
 - Update driver implementation of `ApplyWork()` to call client’s terraform init and apply

Part of a larger body of work to improve Terraform error-handling: https://github.com/hashicorp/consul-nia/issues/28. This PR works towards having a task's terraform commands fail and succeed independently from another
