### PR TITLE
Refactor Driver interface

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -81,12 +81,6 @@ func (rw *ReadWrite) Init(ctx context.Context) error {
 			return err
 		}
 
-		log.Printf("[DEBUG] (controller.readwrite) initializing worker for task %q", task.Name)
-		err = d.InitWorker(task)
-		if err != nil {
-			log.Printf("[ERR] (controller.readwrite) error initializing worker for task %q: %s", task.Name, err)
-			return err
-		}
 		template, err := newTaskTemplate(task.Name, rw.conf, rw.fileReader)
 		if err != nil {
 			log.Printf("[ERR] (controller.readwrite) error initializing template: %s", err)
@@ -196,7 +190,7 @@ func (rw *ReadWrite) checkApply(u unit, ctx context.Context) error {
 
 		d := u.driver
 		log.Printf("[INFO] (controller.readwrite) apply work %s", taskName)
-		if err := d.ApplyWork(ctx); err != nil {
+		if err := d.ApplyTask(ctx); err != nil {
 			return fmt.Errorf("could not apply: %s", err)
 		}
 	}

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -71,19 +71,17 @@ func TestReadWriteInit(t *testing.T) {
 	conf := singleTaskConfig()
 
 	cases := []struct {
-		name          string
-		expectError   bool
-		initErr       error
-		initTaskErr   error
-		initWorkerErr error
-		fileReader    func(string) ([]byte, error)
-		config        *config.Config
+		name        string
+		expectError bool
+		initErr     error
+		initTaskErr error
+		fileReader  func(string) ([]byte, error)
+		config      *config.Config
 	}{
 		{
 			"error on driver.Init()",
 			true,
 			errors.New("error on driver.Init()"),
-			nil,
 			nil,
 			func(string) ([]byte, error) { return []byte{}, nil },
 			conf,
@@ -93,16 +91,6 @@ func TestReadWriteInit(t *testing.T) {
 			true,
 			nil,
 			errors.New("error on driver.InitTask()"),
-			nil,
-			func(string) ([]byte, error) { return []byte{}, nil },
-			conf,
-		},
-		{
-			"error on driver.InitWorker()",
-			true,
-			nil,
-			nil,
-			errors.New("error on driver.InitWorker()"),
 			func(string) ([]byte, error) { return []byte{}, nil },
 			conf,
 		},
@@ -111,14 +99,12 @@ func TestReadWriteInit(t *testing.T) {
 			true,
 			nil,
 			nil,
-			nil,
 			func(string) ([]byte, error) { return []byte{}, errors.New("error on newTaskTemplates()") },
 			conf,
 		},
 		{
 			"happy path",
 			false,
-			nil,
 			nil,
 			nil,
 			func(string) ([]byte, error) { return []byte{}, nil },
@@ -132,7 +118,6 @@ func TestReadWriteInit(t *testing.T) {
 			d := new(mocksD.Driver)
 			d.On("Init", mock.Anything).Return(tc.initErr).Once()
 			d.On("InitTask", mock.Anything, mock.Anything).Return(tc.initTaskErr).Once()
-			d.On("InitWorker", mock.Anything).Return(tc.initWorkerErr).Once()
 
 			controller := ReadWrite{
 				newDriver:  func(*config.Config) driver.Driver { return d },
@@ -158,7 +143,7 @@ func TestReadWriteRun(t *testing.T) {
 	cases := []struct {
 		name              string
 		expectError       bool
-		applyWorkErr      error
+		applyTaskErr      error
 		resolverRunErr    error
 		templateRenderErr error
 		watcherWaitErr    error
@@ -174,9 +159,9 @@ func TestReadWriteRun(t *testing.T) {
 			singleTaskConfig(),
 		},
 		{
-			"error on driver.ApplyWork()",
+			"error on driver.ApplyTask()",
 			true,
-			errors.New("error on driver.ApplyWork()"),
+			errors.New("error on driver.ApplyTask()"),
 			nil,
 			nil,
 			nil,
@@ -207,7 +192,7 @@ func TestReadWriteRun(t *testing.T) {
 			w.On("Wait", mock.Anything).Return(tc.watcherWaitErr)
 
 			d := new(mocksD.Driver)
-			d.On("ApplyWork", mock.Anything).Return(tc.applyWorkErr)
+			d.On("ApplyTask", mock.Anything).Return(tc.applyTaskErr)
 
 			h, err := getPostApplyHandlers(tc.config)
 			assert.NoError(t, err)
@@ -246,8 +231,8 @@ func TestReadWriteUnits(t *testing.T) {
 	t.Run("simple-success", func(t *testing.T) {
 		d := new(mocksD.Driver)
 		d.On("InitWork", mock.Anything).Return(nil)
-		d.On("ApplyWork", mock.Anything).Return(nil)
-		d.On("ApplyWork", mock.Anything).Return(fmt.Errorf("test"))
+		d.On("ApplyTask", mock.Anything).Return(nil)
+		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
 
 		u := unit{taskName: "foo", template: tmpl, driver: d}
 		controller := ReadWrite{
@@ -267,7 +252,7 @@ func TestReadWriteUnits(t *testing.T) {
 	t.Run("apply-error", func(t *testing.T) {
 		d := new(mocksD.Driver)
 		d.On("InitWork", mock.Anything).Return(nil)
-		d.On("ApplyWork", mock.Anything).Return(fmt.Errorf("test"))
+		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
 
 		u := unit{taskName: "foo", template: tmpl, driver: d}
 		controller := ReadWrite{

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -10,14 +10,11 @@ type Driver interface {
 	// Init initializes the driver and environment
 	Init(ctx context.Context) error
 
-	// InitTask initializes a task that the driver will execute
+	// InitTask initializes the task that the driver executes
 	InitTask(task Task, force bool) error
 
-	// InitWorker initializes a worker for a task
-	InitWorker(task Task) error
-
-	// ApplyWork applies changes for all the work managed by driver
-	ApplyWork(ctx context.Context) error
+	// ApplyTask applies change for the task managed by the driver
+	ApplyTask(ctx context.Context) error
 
 	// Version returns the version of the driver.
 	Version() string

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -14,8 +14,8 @@ type Driver struct {
 	mock.Mock
 }
 
-// ApplyWork provides a mock function with given fields: ctx
-func (_m *Driver) ApplyWork(ctx context.Context) error {
+// ApplyTask provides a mock function with given fields: ctx
+func (_m *Driver) ApplyTask(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
 	var r0 error
@@ -49,20 +49,6 @@ func (_m *Driver) InitTask(task driver.Task, force bool) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(driver.Task, bool) error); ok {
 		r0 = rf(task, force)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// InitWorker provides a mock function with given fields: task
-func (_m *Driver) InitWorker(task driver.Task) error {
-	ret := _m.Called(task)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(driver.Task) error); ok {
-		r0 = rf(task)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Changes:
 - Rename `ApplyWork` => `ApplyTask`: the term 'work' is no longer meaningful since the work struct and paired `InitWork` were deleted earlier. Align to 'task' terminology
 - Combine `InitTask` and `InitWorker` into only `InitTask`: creates parallel init/apply tasks and keeps worker abstraction inside driver

Context: https://github.com/hashicorp/consul-nia/pull/64#issuecomment-692951526