### PR TITLE
Terraform error-handling: handle init errors

### DIFF
--- a/driver/task.go
+++ b/driver/task.go
@@ -33,17 +33,22 @@ type Task struct {
 type worker struct {
 	client client.Client
 	task   Task
+
+	inited bool
 }
 
 func (w *worker) init(ctx context.Context) error {
 	if err := w.client.Init(ctx); err != nil {
+		// TODO: retry strategy
 		return err
 	}
+	w.inited = true
 	return nil
 }
 
 func (w *worker) apply(ctx context.Context) error {
 	if err := w.client.Apply(ctx); err != nil {
+		// TODO: retry strategy
 		return err
 	}
 	return nil

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -37,9 +37,11 @@ func TestWorkerInit(t *testing.T) {
 			err := w.init(ctx)
 			if tc.initErr != nil {
 				assert.Error(t, err)
+				assert.False(t, w.inited)
 				return
 			}
 			assert.NoError(t, err)
+			assert.True(t, w.inited)
 		})
 	}
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -205,16 +205,18 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	w := tf.worker
 	taskName := w.task.Name
 
-	log.Printf("[TRACE] (driver.terraform) init '%s'", taskName)
-	if err := w.init(ctx); err != nil {
-		log.Printf("[ERROR] (driver.terraform) init (skip apply) for '%s': %s",
-			taskName, err)
-		return errors.Wrap(err, fmt.Sprintf("Error tf-init for '%s'", taskName))
+	if w.inited {
+		log.Printf("[TRACE] (driver.terraform) already inited, skip for '%s'", taskName)
+	} else {
+		log.Printf("[TRACE] (driver.terraform) init '%s'", taskName)
+		if err := w.init(ctx); err != nil {
+			log.Printf("[ERROR] (driver.terraform) init (skip apply) for '%s'", taskName)
+			return errors.Wrap(err, fmt.Sprintf("Error tf-init for '%s'", taskName))
+		}
 	}
 
 	log.Printf("[TRACE] (driver.terraform) apply '%s'", taskName)
 	if err := w.apply(ctx); err != nil {
-		log.Printf("[ERROR] (driver.terraform) apply '%s': %s", taskName, err)
 		return errors.Wrap(err, fmt.Sprintf("Error tf-apply for '%s'", taskName))
 	}
 	return nil

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -63,24 +63,35 @@ func TestApplyTask(t *testing.T) {
 	cases := []struct {
 		name        string
 		expectError bool
+		inited      bool
 		initReturn  error
 		applyReturn error
 	}{
 		{
 			"happy path",
 			false,
+			false,
+			nil,
+			nil,
+		},
+		{
+			"already inited",
+			false,
+			true,
 			nil,
 			nil,
 		},
 		{
 			"error on init",
 			true,
+			false,
 			errors.New("init error"),
 			nil,
 		},
 		{
 			"error on apply",
 			true,
+			false,
 			nil,
 			errors.New("apply error"),
 		},
@@ -96,6 +107,7 @@ func TestApplyTask(t *testing.T) {
 				worker: &worker{
 					client: c,
 					task:   Task{},
+					inited: tc.inited,
 				},
 			}
 


### PR DESCRIPTION
- If an init command fails, we do not want to call subsequent apply command
- If an init command fails, on subsequent triggers to run, we must try the init command again
- If an init command succeeds, we do not need to call it again

Part of: https://github.com/hashicorp/consul-nia/issues/28

Remaining work: will open a separate PR for retry

Note: I originally added a `skip` field on `worker` to support skipping commands when we hit a non-retryable error (discussed offline as an error like misconfiguration, wrong creds, etc). In trying to reproduce non-retryable errors, I found that they could be very specific and potentially many e.g. not-found local module vs. not-found remote module return different error message. I was thinking the errors that would qualify for `skip` would happen every execution (vs. transient) and that they would be better surfaced and dealt with in the `once` mode, rather than trying to capture a bunch of unique Terraform errors. I’d like to hold off adding this feature at least for Tech Preview.