### PR TITLE
Fix tasks to reference correct required_providers block

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-nia/config"
+	"github.com/hashicorp/consul-nia/driver"
 	"github.com/hashicorp/consul-nia/handler"
 	"github.com/stretchr/testify/assert"
 )
@@ -122,6 +123,133 @@ func TestGetPostApplyHandlers(t *testing.T) {
 				return
 			}
 			assert.NotNil(t, h)
+		})
+	}
+}
+
+func TestNewDriverTasks(t *testing.T) {
+	// newDriverTasks function reorganizes various user-defined configuration
+	// blocks into a task object with all the information for the driver to
+	// execute on.
+	testCases := []struct {
+		name  string
+		conf  *config.Config
+		tasks []driver.Task
+	}{
+		{
+			"no config",
+			nil,
+			[]driver.Task{},
+		}, {
+			"no tasks",
+			&config.Config{Tasks: &config.TaskConfigs{}},
+			[]driver.Task{},
+		}, {
+			// Fetches correct provider and required_providers blocks from config
+			"providers",
+			&config.Config{
+				Tasks: &config.TaskConfigs{
+					{
+						Name:      config.String("name"),
+						Providers: []string{"providerA", "providerB"},
+						Source:    config.String("source"),
+					},
+				},
+				Driver: &config.DriverConfig{
+					Terraform: &config.TerraformConfig{
+						RequiredProviders: map[string]interface{}{
+							"providerA": map[string]string{
+								"source": "source/providerA",
+							},
+						},
+					},
+				},
+				Providers: &config.ProviderConfigs{
+					{"providerB": map[string]interface{}{
+						"var": "val",
+					}},
+				},
+			},
+			[]driver.Task{{
+				Name: "name",
+				Providers: []map[string]interface{}{
+					{"providerA": map[string]interface{}{}},
+					{"providerB": map[string]interface{}{
+						"var": "val",
+					}},
+				},
+				ProviderInfo: map[string]interface{}{
+					"providerA": map[string]string{
+						"source": "source/providerA",
+					},
+				},
+				Services: []driver.Service{},
+				Source:   "source",
+				VarFiles: []string{},
+			}},
+		}, {
+			// Fetches correct provider and required_providers blocks from config
+			// with context of alias
+			"provider instance",
+			&config.Config{
+				Tasks: &config.TaskConfigs{
+					{
+						Name:      config.String("name"),
+						Providers: []string{"providerA.alias1", "providerB"},
+						Source:    config.String("source"),
+					},
+				},
+				Driver: &config.DriverConfig{
+					Terraform: &config.TerraformConfig{
+						RequiredProviders: map[string]interface{}{
+							"providerA": map[string]string{
+								"source": "source/providerA",
+							},
+						},
+					},
+				},
+				Providers: &config.ProviderConfigs{
+					{"providerA": map[string]interface{}{
+						"alias": "alias1",
+						"foo":   "bar",
+					}},
+					{"providerA": map[string]interface{}{
+						"alias": "alias2",
+						"baz":   "baz",
+					}},
+					{"providerB": map[string]interface{}{
+						"var": "val",
+					}},
+				},
+			},
+			[]driver.Task{{
+				Name: "name",
+				Providers: []map[string]interface{}{
+					{"providerA": map[string]interface{}{
+						"alias": "alias1",
+						"foo":   "bar",
+					}},
+					{"providerB": map[string]interface{}{
+						"var": "val",
+					}},
+				},
+				ProviderInfo: map[string]interface{}{
+					"providerA": map[string]string{
+						"source": "source/providerA",
+					},
+				},
+				Services: []driver.Service{},
+				Source:   "source",
+				VarFiles: []string{},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.conf.Finalize()
+			tasks := newDriverTasks(tc.conf)
+			assert.Equal(t, tc.tasks, tasks)
 		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/terraform v0.12.29
 	github.com/hashicorp/terraform-exec v0.9.0
 	github.com/mitchellh/mapstructure v1.3.3
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.5.1
 	github.com/zclconf/go-cty v1.5.1
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect


### PR DESCRIPTION
The list of providers for a task could be aliased. This changes
to consistently fetch on the provider name without the alias.