### PR TITLE
feature to run through everything once and exit

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -24,6 +24,10 @@ type Controller interface {
 	Run(ctx context.Context) error
 }
 
+type Oncer interface {
+	Once(ctx context.Context) error
+}
+
 func newDriverFunc(conf *config.Config) (func(*config.Config) driver.Driver, error) {
 	if conf.Driver.Terraform != nil {
 		log.Printf("[INFO] (controller) setting up Terraform driver")

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,6 +18,9 @@ Usage of consul-nia:
   -inspect
       Run Consul NIA in Inspect mode to print the current and proposed state
       change, and then exits. No changes are applied in this mode.
+  -once
+      Render templates and run tasks once. Does not run the process as a daemon
+      and disables wait timers.
   -version
       Print the version of this daemon.
 ```


### PR DESCRIPTION
Add a Once mode to running the readwrite controller. It should run
through everything one time, rendering all templates and executing the
tasks then exit.

It doesn't do anything in parallel at this point to make it better for
debugging. This might require some additional handling at some point as
that means the first pass of running things will take longer than all
the others.

This is very useful for testing as well as adding a flexibility for
users who want to run it in a 'batch' mode.