### PR TITLE
use ok exit code after good run of Once

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -224,6 +224,10 @@ func (cli *CLI) Run(args []string) int {
 			}
 
 		case <-exitCh:
+			if isOnce {
+				log.Printf("[INFO] graceful shutdown")
+				return ExitCodeOK
+			}
 			log.Printf("[WARN] unexpected shutdown")
 			return ExitCodeError
 


### PR DESCRIPTION
Micro change... just fix the log/exit code when running with `-once`.