### PR TITLE
Add logging to e2e test to track failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-integration:
 # test-e2e runs e2e tests
 test-e2e:
 	@echo "==> Testing ${NAME} (e2e)"
-	@go test ./e2e -count=1 -timeout=60s -tags=e2e ./... ${TESTARGS}
+	@go test ./e2e -count=1 -timeout=60s -tags=e2e -v ./... ${TESTARGS}
 .PHONY: test-e2e
 
 # test-setup-e2e sets up the nia binary and permissions to run consul-nia

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -37,6 +37,7 @@ func terraformBlock(dir string) string {
 	}
 	return fmt.Sprintf(`
 driver "terraform" {
+	log = true
 	path = "%s"
 	working_dir = "%s"
 }


### PR DESCRIPTION
Seeing e2e fail at some frequently, it's useful to have timestamps logged for successful runs as a good reference point.