### PR TITLE
Redact provider configurations

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -2,6 +2,8 @@ package config
 
 import "fmt"
 
+const redactMessage = "(redacted)"
+
 // AuthConfig is the HTTP basic authentication data.
 type AuthConfig struct {
 	Enabled  *bool   `mapstructure:"enabled"`
@@ -95,13 +97,13 @@ func (c *AuthConfig) GoString() string {
 		"}",
 		BoolVal(c.Enabled),
 		StringVal(c.Username),
-		senstiveGoString(c.Password),
+		sensitiveGoString(c.Password),
 	)
 }
 
-func senstiveGoString(s *string) string {
+func sensitiveGoString(s *string) string {
 	if StringPresent(s) {
-		return "(redacted)"
+		return redactMessage
 	}
 
 	return ""

--- a/config/consul.go
+++ b/config/consul.go
@@ -193,7 +193,7 @@ func (c *ConsulConfig) GoString() string {
 		StringVal(c.KVNamespace),
 		StringVal(c.KVPath),
 		c.TLS.GoString(),
-		senstiveGoString(c.Token),
+		sensitiveGoString(c.Token),
 		c.Transport.GoString(),
 	)
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -5,8 +5,11 @@ import (
 	"strings"
 )
 
+// ProviderConfigs is an array of configuration for each provider.
 type ProviderConfigs []*ProviderConfig
 
+// ProviderConfig is a map representing the configuration for a single provider
+// where the key is the name of provider and value is the configuration.
 type ProviderConfig map[string]interface{}
 
 // DefaultProviderConfigs returns a configuration that is populated with the
@@ -97,20 +100,25 @@ func (c *ProviderConfigs) Validate() error {
 	return nil
 }
 
-// GoString defines the printable version of this struct.
+// GoString defines the printable version of this struct. Provider configuration
+// is completely redacted since providers will have varying arguments containing
+// secrets
 func (c *ProviderConfigs) GoString() string {
 	if c == nil {
 		return "(*ProviderConfigs)(nil)"
 	}
 
 	s := make([]string, len(*c))
-	for i, t := range *c {
-		s[i] = fmt.Sprint(t)
+	for i, provider := range *c {
+		for name := range *provider {
+			s[i] = fmt.Sprintf("&map[%s:%s]", name, redactMessage)
+		}
 	}
 
 	return "{" + strings.Join(s, ", ") + "}"
 }
 
+// Validate validates the values and nested values of the configuration struct.
 func (c *ProviderConfig) Validate() error {
 	if c == nil {
 		return fmt.Errorf("invalid provider configuration")

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -286,3 +286,72 @@ func TestProviderConfigs_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderConfigs_GoString(t *testing.T) {
+	t.Parallel()
+
+	// only testing provider cases with one argument since map order is random
+	cases := []struct {
+		name     string
+		i        *ProviderConfigs
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			`(*ProviderConfigs)(nil)`,
+		},
+		{
+			"empty",
+			&ProviderConfigs{},
+			`{}`,
+		},
+		{
+			"single config",
+			&ProviderConfigs{{
+				"null": map[string]interface{}{
+					"count": "10",
+				},
+			}},
+			fmt.Sprintf(`{&map[null:%s]}`, redactMessage),
+		},
+		{
+			"multiple configs, same provider",
+			&ProviderConfigs{{
+				"null": map[string]interface{}{
+					"attr": "n",
+				},
+			}, {
+				"null": map[string]interface{}{
+					"alias": "negative",
+				},
+			}},
+			fmt.Sprintf(`{&map[null:%s], &map[null:%s]}`,
+				redactMessage, redactMessage),
+		},
+		{
+			"multiple configs, different provider",
+			&ProviderConfigs{{
+				"firewall": map[string]interface{}{
+					"hostname": "127.0.0.10",
+					"username": "username",
+					"password": "password123",
+				},
+			}, {
+				"loadbalancer": map[string]interface{}{
+					"address": "10.10.10.10",
+					"api_key": "abcd123",
+				},
+			}},
+			fmt.Sprintf(`{&map[firewall:%s], &map[loadbalancer:%s]}`,
+				redactMessage, redactMessage),
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			actual := tc.i.GoString()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Updated provider configuration GoString() to redact all configuration values. Different providers will have varying arguments that contain sensitive values. Since we cannot predict these arguments (e.g. ‘password’ and and ‘api_key’) or audit all providers, we decided to redact all information.

Example with redaction: `{&map[firewall:(redacted)], &map[loadbalancer:(redacted)]}`

Resolves: https://github.com/hashicorp/consul-nia/issues/84