### PR TITLE
Elevate service configuration block optional language

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -132,7 +132,7 @@ consul {
   * `tls_handshake_timeout` - `(string: "10s")` amount of time to wait to complete the TLS handshake.
 
 ### Service
-A `service` block defines the explicit configuration for Sync to monitor a service. This block may be specified multiple times to configure multiple services. For a service to be included in task automation, the service name or ID must be included in the `task.services` field of a [`task` block](#task). A service can be implicitly declared with default values by omitting the `service` block for that service and referenced by its name in the `task.services` field.
+A `service` block is an optional block to explicitly define configuration of services that Sync monitors. A `service` block is only necessary for services that have non-default values e.g. custom datacenter. Services that do not have a `service` block configured will assume default values. To configure multiple services, specify multiple `service` blocks. For services to be included in task automation, the service must be included in the `task.services` field of a [`task` block](#task). If a `service` block is configured, the service can be referred in `task.services` by service name or ID. If a `service` block is not configured, it can only be referred to by service name.
 
 ```hcl
 service {


### PR DESCRIPTION
Update the service configuration block description so that it is more explicit that it is optional and move the language to be earlier in the description. Some additional rewording to highlight difference in configuring `task.services` when service block is included vs. omitted.

Preview of updated readme:
<img width="794" alt="Screen Shot 2020-10-01 at 2 36 16 PM" src="https://user-images.githubusercontent.com/6819378/94849497-821ff200-03f3-11eb-93e1-75dc1813367e.png">



Resolves https://github.com/hashicorp/consul-terraform-sync/issues/95