### PR TITLE
Add support for local Terraform backend

### DIFF
--- a/config/terraform.go
+++ b/config/terraform.go
@@ -239,7 +239,9 @@ func (c *TerraformConfig) Validate() error {
 	}
 
 	for k := range c.Backend {
-		if k != "consul" {
+		switch k {
+		case "consul", "local":
+		default:
 			return fmt.Errorf("unsupported Terraform backend by Sync %q", k)
 		}
 	}
@@ -247,6 +249,7 @@ func (c *TerraformConfig) Validate() error {
 	return nil
 }
 
+// GoString defines the printable version of this struct.
 func (c *TerraformConfig) GoString() string {
 	if c == nil {
 		return "(*TerraformConfig)(nil)"

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -499,8 +499,12 @@ func TestTerraformValidate(t *testing.T) {
 			&TerraformConfig{},
 			false,
 		}, {
-			"valid",
+			"valid consul backend",
 			&TerraformConfig{Backend: map[string]interface{}{"consul": nil}},
+			true,
+		}, {
+			"valid local backend",
+			&TerraformConfig{Backend: map[string]interface{}{"local": nil}},
 			true,
 		}, {
 			"backend_invalid",

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -22,8 +22,8 @@ func twoTaskConfig(consulAddr, tempDir string) string {
 	return oneTaskConfig(consulAddr, tempDir) + webTask()
 }
 
-// panosConfig returns a basic use case config file
-// Use for confirming specific resource / statefile output
+// panosConfig returns a config file with panos provider with bad config
+// Use for testing handlers erroring out
 func panosConfig(consulAddr, tempDir string) string {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -43,6 +43,31 @@ driver "terraform" {
 }`, cwd, tempDir)
 
 	return panosBadCredConfig() + consulBlock(consulAddr) + tfBlock
+}
+
+// twoTaskCustomBackendConfig returns a basic config file with two tasks for
+// custom backend. Use for confirming resources / state file for custom backend.
+//
+// Example of customBackend:
+// `backend "local" {
+// 	path = "custom/terraform.tfstate"
+// }`
+func twoTaskCustomBackendConfig(consulAddr, tempDir, customBackend string) string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	terraformBlock := fmt.Sprintf(`
+driver "terraform" {
+	log = true
+	path = "%s"
+	working_dir = "%s"
+	%s
+}
+`, cwd, tempDir, customBackend)
+
+	return baseConfig() + consulBlock(consulAddr) +
+		terraformBlock + dbTask() + webTask()
 }
 
 func consulBlock(addr string) string {


### PR DESCRIPTION
We want to support local backend in addition to Consul backend. This will support users who need to persist their state file when they spin up/down their Consul agent.

Include e2e tests to document how configuring local backend’s `path` and `workspace_dir` plays out for two tasks. Note: configuring `path` is not meaningful for Sync since `path` is used for the default workspace. Sync creates a custom workspace for each task and therefore does not work in the default workspace. This configuration information will be documented separately. See https://github.com/hashicorp/terraform/blob/master/backend/local/backend.go#L445 for more details on `path`

Resolves: https://github.com/hashicorp/consul-terraform-sync/issues/92