### PR TITLE
Improve readability of logs

### DIFF
--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -51,14 +51,14 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 	// purposes. It may be difficult to work with log aggregators that expect
 	// uniform log format.
 	if config.Log {
-		log.Printf("[DEBUG] (client.terraformcli) Terraform logging is set, " +
+		log.Printf("[INFO] (client.terraformcli) Terraform logging is set, " +
 			"Terraform logs will output with Sync logs")
 		logger := log.New(log.Writer(), "", log.Flags())
 		tf.SetLogger(logger)
 		tf.SetStdout(log.Writer())
 		tf.SetStderr(log.Writer())
 	} else {
-		log.Printf("[DEBUG] (client.terraformcli) Terraform output is muted")
+		log.Printf("[INFO] (client.terraformcli) Terraform output is muted")
 	}
 
 	// This is equivalent to setting TF_LOG_PATH=$WORKDIR/terraform.log.
@@ -69,7 +69,7 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 	if config.PersistLog {
 		logPath := filepath.Join(config.WorkingDir, "terraform.log")
 		tf.SetLogPath(logPath)
-		log.Printf("[DEBUG] (client.terraformcli) Terraform log persiting on disk: %s", logPath)
+		log.Printf("[INFO] (client.terraformcli) persiting Terraform logs on disk: %s", logPath)
 	}
 
 	client := &TerraformCLI{
@@ -90,13 +90,16 @@ func (t *TerraformCLI) Init(ctx context.Context) error {
 		return err
 	}
 
-	if err := t.tf.WorkspaceNew(ctx, t.workspace); err != nil {
+	err := t.tf.WorkspaceNew(ctx, t.workspace)
+	if err != nil {
 		var wsErr *tfexec.ErrWorkspaceExists
 		if !errors.As(err, &wsErr) {
 			log.Printf("[ERR] (client.terraformcli) unable to create workspace: %q", t.workspace)
 			return err
 		}
 		log.Printf("[DEBUG] (client.terraformcli) workspace already exists: '%s'", t.workspace)
+	} else {
+		log.Printf("[TRACE] (client.terraformcli) workspace created: %q", t.workspace)
 	}
 
 	if err := t.tf.WorkspaceSelect(ctx, t.workspace); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -277,7 +277,7 @@ func decodeConfig(content []byte, format string) (*Config, error) {
 		return nil, fmt.Errorf("invalid format: %s", format)
 	}
 	if err != nil {
-		log.Printf("[DEBUG] (config) failed to decode %s", format)
+		log.Printf("[ERR] (config) failed to decode %s", format)
 		return nil, err
 	}
 
@@ -313,13 +313,13 @@ func fromFile(path string) (*Config, error) {
 
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		log.Printf("[DEBUG] (config) failed reading config file from disk: %s\n", path)
+		log.Printf("[ERR] (config) failed reading config file from disk: %s\n", path)
 		return nil, err
 	}
 
 	config, err := decodeConfig(content, format)
 	if err != nil {
-		log.Printf("[DEBUG] (config) failed decoding content from file: %s\n", path)
+		log.Printf("[ERR] (config) failed decoding content from file: %s\n", path)
 		return nil, err
 	}
 
@@ -331,7 +331,7 @@ func fromFile(path string) (*Config, error) {
 func fromPath(path string) (*Config, error) {
 	// Ensure the given filepath exists
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Printf("[DEBUG] (config) missing file/folder: %s\n", path)
+		log.Printf("[ERR] (config) missing file/folder: %s\n", path)
 		return nil, err
 	}
 
@@ -356,7 +356,7 @@ func fromPath(path string) (*Config, error) {
 	// Ensure the given filepath has at least one config file
 	files, err := ioutil.ReadDir(path)
 	if err != nil {
-		log.Printf("[DEBUG] (config) failed listing directory: %s\n", path)
+		log.Printf("[ERR] (config) failed listing directory: %s\n", path)
 		return nil, err
 	}
 

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -31,8 +31,8 @@ type TerraformConfig struct {
 func DefaultTerraformConfig() *TerraformConfig {
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Println("[ERR] unable to retrieve current working directory to setup " +
-			"default configuration for the Terraform driver")
+		log.Println("[ERR] (config) unable to retrieve current working directory " +
+			"to setup default configuration for the Terraform driver")
 		log.Panic(err)
 	}
 
@@ -189,8 +189,8 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Println("[ERR] unable to retrieve current working directory to setup " +
-			"default configuration for the Terraform driver")
+		log.Println("[ERR] (config) unable to retrieve current working directory " +
+			"to setup default configuration for the Terraform driver")
 		log.Panic(err)
 	}
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -33,10 +33,10 @@ type Oncer interface {
 
 func newDriverFunc(conf *config.Config) (func(*config.Config) driver.Driver, error) {
 	if conf.Driver.Terraform != nil {
-		log.Printf("[INFO] (controller) setting up Terraform driver")
+		log.Printf("[INFO] (ctrl) setting up Terraform driver")
 		return newTerraformDriver, nil
 	}
-	return nil, errors.New("Unsupported driver")
+	return nil, errors.New("unsupported driver")
 }
 
 func newTerraformDriver(conf *config.Config) driver.Driver {
@@ -196,7 +196,7 @@ func getPostApplyHandlers(conf *config.Config) (handler.Handler, error) {
 	if conf.Driver.Terraform != nil {
 		return getTerraformHandlers(conf)
 	}
-	return nil, errors.New("Unsupported driver")
+	return nil, errors.New("unsupported driver")
 }
 
 // getTerraformHandlers returns the first handler in a chain of handlers
@@ -206,24 +206,24 @@ func getPostApplyHandlers(conf *config.Config) (handler.Handler, error) {
 // no providers have a handler.
 func getTerraformHandlers(conf *config.Config) (handler.Handler, error) {
 	counter := 0
-	var next handler.Handler = nil
+	var next handler.Handler
 	for _, p := range *conf.Providers {
 		for k, v := range *p {
 			h, err := handler.TerraformProviderHandler(k, v)
 			if err != nil {
 				log.Printf(
-					"[ERR] (controller) could not initialize handler for provider '%s': %s", k, err)
+					"[ERR] (ctrl) could not initialize handler for provider '%s': %s", k, err)
 				return nil, err
 			}
 			if h != nil {
 				counter++
 				log.Printf(
-					"[DEBUG] (controller) retrieved handler for provider '%s'", k)
+					"[INFO] (ctrl) retrieved handler for provider '%s'", k)
 				h.SetNext(next)
 				next = h
 			}
 		}
 	}
-	log.Printf("[INFO] (controller) retrieved %d Terraform handlers", counter)
+	log.Printf("[INFO] (ctrl) retrieved %d Terraform handlers", counter)
 	return next, nil
 }

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -56,31 +56,30 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 // Init initializes the controller before it can be run. Ensures that
 // driver is initializes, works are created for each task.
 func (rw *ReadWrite) Init(ctx context.Context) error {
-	log.Printf("[INFO] (controller.readwrite) initializing driver")
+	log.Printf("[INFO] (ctrl) initializing driver")
 
-	// initialize tasks. this is hardcoded in main function for demo purposes
 	// TODO: separate by provider instances using workspaces.
 	// Future: improve by combining tasks into workflows.
-	log.Printf("[INFO] (controller.readwrite) initializing all tasks and workers")
+	log.Printf("[INFO] (ctrl) initializing all tasks")
 	tasks := newDriverTasks(rw.conf)
 	units := make([]unit, 0, len(tasks))
 
 	for _, task := range tasks {
 		d := rw.newDriver(rw.conf)
 		if err := d.Init(ctx); err != nil {
-			log.Printf("[ERR] (controller.readwrite) error initializing driver: %s", err)
+			log.Printf("[ERR] (ctrl) error initializing driver: %s", err)
 			return err
 		}
-		log.Printf("[DEBUG] (controller.readwrite) initializing task %q", task.Name)
+		log.Printf("[DEBUG] (ctrl) initializing task %q", task.Name)
 		err := d.InitTask(task, true)
 		if err != nil {
-			log.Printf("[ERR] (controller.readwrite) error initializing task %q: %s", task.Name, err)
+			log.Printf("[ERR] (ctrl) error initializing task %q: %s", task.Name, err)
 			return err
 		}
 
 		template, err := newTaskTemplate(task.Name, rw.conf, rw.fileReader)
 		if err != nil {
-			log.Printf("[ERR] (controller.readwrite) error initializing template "+
+			log.Printf("[ERR] (ctrl) error initializing template "+
 				"for task %q: %s", task.Name, err)
 			return err
 		}
@@ -94,7 +93,7 @@ func (rw *ReadWrite) Init(ctx context.Context) error {
 
 	rw.units = units
 
-	log.Printf("[INFO] (controller.readwrite) driver initialized")
+	log.Printf("[INFO] (ctrl) driver initialized")
 	return nil
 }
 
@@ -115,18 +114,18 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 		select {
 		case err := <-rw.watcher.WaitCh(ctx):
 			if err != nil {
-				log.Printf("[ERR] (controller.readwrite) wait error from watcher: %s", err)
+				log.Printf("[ERR] (ctrl) error watching template dependencies: %s", err)
 			}
 
 		case <-ctx.Done():
-			log.Printf("[INFO] (controller.readwrite) stopping controller")
+			log.Printf("[INFO] (ctrl) stopping controller")
 			rw.watcher.Stop()
 			return ctx.Err()
 		}
 
 		for err := range rw.runUnits(ctx) {
 			// aggregate error collector for runUnits, just logs everything for now
-			log.Printf("[ERR] (controller.readwrite) %s", err)
+			log.Printf("[ERR] (ctrl) %s", err)
 		}
 	}
 }
@@ -134,15 +133,13 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 // A single run through of all the units/tasks/templates
 // Returned error channel closes when done with all units
 func (rw *ReadWrite) runUnits(ctx context.Context) chan error {
-	log.Printf("[TRACE] (controller.readwrite) preparing work")
-
 	// keep error chan and waitgroup here to keep runTask simple (on task)
 	errCh := make(chan error, 1)
 	wg := sync.WaitGroup{}
 	for _, u := range rw.units {
 		wg.Add(1)
 		go func(u unit) {
-			_, err := rw.checkApply(u, ctx)
+			_, err := rw.checkApply(ctx, u)
 			if err != nil {
 				errCh <- err
 			}
@@ -161,16 +158,16 @@ func (rw *ReadWrite) runUnits(ctx context.Context) chan error {
 // Once runs the controller in read-write mode making sure each template has
 // been fully rendered and the task run, then it returns.
 func (rw *ReadWrite) Once(ctx context.Context) error {
-	log.Printf("[TRACE] (controller.readwrite) preparing work")
+	log.Println("[INFO] (ctrl) executing all tasks once through")
 
 	completed := make(map[string]bool, len(rw.units))
 	for {
 		done := true
 		for _, u := range rw.units {
 			if !completed[u.taskName] {
-				complete, err := rw.checkApply(u, ctx)
+				complete, err := rw.checkApply(ctx, u)
 				if err != nil {
-					return fmt.Errorf("[ERR] (controller.readwrite): %s", err)
+					return err
 				}
 				completed[u.taskName] = complete
 				if !complete && done {
@@ -179,12 +176,14 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 			}
 		}
 		if done {
+			log.Println("[INFO] (ctrl) all tasks completed once")
 			return nil
 		}
 
 		select {
 		case err := <-rw.watcher.WaitCh(ctx):
 			if err != nil {
+				log.Printf("[ERR] (ctrl) error watching template dependencies: %s", err)
 				return err
 			}
 		case <-ctx.Done():
@@ -194,41 +193,44 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 }
 
 // Single run, render, apply of a unit (task)
-func (rw *ReadWrite) checkApply(u unit, ctx context.Context) (bool, error) {
+func (rw *ReadWrite) checkApply(ctx context.Context, u unit) (bool, error) {
 	tmpl := u.template
 	taskName := u.taskName
 
-	log.Print("[TRACE] (controller.readwrite) running task:", taskName)
-	// This only returns result.Complete if the template has new data
-	// that has been completely fetched.
+	log.Printf("[TRACE] (ctrl) checking dependencies changes for task %s", taskName)
 	result, err := rw.resolver.Run(tmpl, rw.watcher)
 	if err != nil {
-		return false, fmt.Errorf("error running template for task %s: %s",
+		return false, fmt.Errorf("error fetching template dependencies for task %s: %s",
 			taskName, err)
 	}
-	// If true the template should be rendered and driver work run.
+
+	// result.Complete is only `true` if the template has new data that has been
+	// completely fetched. Rendering a template for the first time may take several
+	// cycles to load all the dependencies asynchronously.
 	if result.Complete {
-		log.Printf("[DEBUG] (controller.readwrite) change detected for task %s", taskName)
+		log.Printf("[DEBUG] (ctrl) change detected for task %s", taskName)
 		rendered, err := tmpl.Render(result.Contents)
 		if err != nil {
 			return false, fmt.Errorf("error rendering template for task %s: %s",
 				taskName, err)
 		}
-		log.Printf("[DEBUG] template for task %q rendered: %+v", taskName, rendered)
+		log.Printf("[TRACE] (ctrl) template for task %q rendered: %+v", taskName, rendered)
 
 		d := u.driver
-		log.Printf("[INFO] (controller.readwrite) executing task %s", taskName)
+		log.Printf("[INFO] (ctrl) executing task %s", taskName)
 		if err := d.ApplyTask(ctx); err != nil {
-			return false, fmt.Errorf("could not apply: %s", err)
+			return false, fmt.Errorf("could not apply changes for task %s: %s", taskName, err)
 		}
 
 		if rw.postApply != nil {
-			log.Printf("[TRACE] (controller.readwrite) post-apply out-of-band actions")
+			log.Printf("[TRACE] (ctrl) post-apply out-of-band actions")
 			// TODO: improvement to only trigger handlers for tasks that were updated
 			if err := rw.postApply.Do(nil); err != nil {
 				return false, err
 			}
 		}
+
+		log.Printf("[INFO] (ctrl) task completed %s", taskName)
 	}
 
 	return result.Complete, nil

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -205,7 +205,7 @@ func TestReadWriteRun(t *testing.T) {
 			u := unit{template: tmpl, driver: d}
 			ctx := context.Background()
 
-			_, err = controller.checkApply(u, ctx)
+			_, err = controller.checkApply(ctx, u)
 			if tc.expectError {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tc.name)

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -198,18 +198,20 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	taskName := w.task.Name
 
 	if w.inited {
-		log.Printf("[TRACE] (driver.terraform) already inited, skip for '%s'", taskName)
+		log.Printf("[TRACE] (driver.terraform) workspace for task already "+
+			"initialized, skipping for '%s'", taskName)
 	} else {
-		log.Printf("[TRACE] (driver.terraform) init '%s'", taskName)
+		log.Printf("[TRACE] (driver.terraform) initializing workspace '%s'", taskName)
 		if err := w.init(ctx); err != nil {
-			log.Printf("[ERR] (driver.terraform) init (skip apply) for '%s'", taskName)
-			return errors.Wrap(err, fmt.Sprintf("Error tf-init for '%s'", taskName))
+			log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
+				"skipping apply for '%s'", taskName)
+			return errors.Wrap(err, fmt.Sprintf("error tf-init for '%s'", taskName))
 		}
 	}
 
 	log.Printf("[TRACE] (driver.terraform) apply '%s'", taskName)
 	if err := w.apply(ctx); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Error tf-apply for '%s'", taskName))
+		return errors.Wrap(err, fmt.Sprintf("error tf-apply for '%s'", taskName))
 	}
 	return nil
 }

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -73,7 +73,8 @@ func isTFCompatible(ctx context.Context, workingDir, tfPath string) (*goVersion.
 func (tf *Terraform) install(ctx context.Context) error {
 	resp, err := checkpoint.Check(&checkpoint.CheckParams{Product: "terraform"})
 	if err != nil {
-		log.Printf("[ERR] (driver.terraform) Checkpoint error: %s", err)
+		log.Printf("[ERR] (driver.terraform) error fetching Terraform versions "+
+			"from Checkpoint: %s", err)
 		return err
 	}
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -49,7 +49,7 @@ func Setup(config *Config) error {
 
 	// Check if syslog is enabled
 	if config.Syslog {
-		log.Printf("[DEBUG] (logging) enabling syslog on %s", config.SyslogFacility)
+		log.Printf("[INFO] (logging) enabling syslog on %s", config.SyslogFacility)
 
 		l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, config.SyslogFacility, config.SyslogName)
 		if err != nil {


### PR DESCRIPTION
Did a once through all the log lines to improve consistency and readability.
* Change several log levels
* Added missing log prefixes `(<pkg-name>)`
* Reworded log lines to include high level context instead of code-specific verbiage.
* Reduced `controller.readwrite` to `ctrl`, and log `readwrite` only once since the controller doesn't change throughout runtime.

Other minor changes:
* Lint: lower-case error text
* Lint: swap order of `ctx` param to be first in `checkApply` func