### PR TITLE
Update hcat to wait on Consul agent on start up

### DIFF
--- a/controller/consul.go
+++ b/controller/consul.go
@@ -6,16 +6,7 @@ import (
 )
 
 // newWatcher initializes a new hcat Watcher with a Consul client
-func newWatcher(conf *config.Config) *hcat.Watcher {
-	return hcat.NewWatcher(hcat.WatcherInput{
-		Clients: newConsulClient(conf),
-		Cache:   hcat.NewStore(),
-	})
-}
-
-// newConsulClient creates a new Consul client used for monitoring the Service
-// Catalog
-func newConsulClient(conf *config.Config) hcat.Looker {
+func newWatcher(conf *config.Config) (*hcat.Watcher, error) {
 	consulConf := conf.Consul
 	transport := hcat.TransportInput{
 		SSLEnabled: *consulConf.TLS.Enabled,
@@ -44,6 +35,13 @@ func newConsulClient(conf *config.Config) hcat.Looker {
 		Transport:    transport,
 	}
 
-	cs := hcat.NewClientSet()
-	return cs.AddConsul(consul)
+	clients := hcat.NewClientSet()
+	if err := clients.AddConsul(consul); err != nil {
+		return nil, err
+	}
+
+	return hcat.NewWatcher(hcat.WatcherInput{
+		Clients: clients,
+		Cache:   hcat.NewStore(),
+	}), nil
 }

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -43,11 +43,15 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 	if err != nil {
 		return nil, err
 	}
+	watcher, err := newWatcher(conf)
+	if err != nil {
+		return nil, err
+	}
 	return &ReadWrite{
 		conf:       conf,
 		newDriver:  nd,
 		fileReader: ioutil.ReadFile,
-		watcher:    newWatcher(conf),
+		watcher:    watcher,
 		resolver:   hcat.NewResolver(),
 		postApply:  h,
 	}, nil

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20200925205440-f610abc021d3
+	github.com/hashicorp/hcat v0.0.0-20201001022531-5a93181f0fe6
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcat v0.0.0-20200925205440-f610abc021d3 h1:CqCejHiH6Zx6sEJTiF/GnxEMhudi1ALY1Ncke0V3sOg=
 github.com/hashicorp/hcat v0.0.0-20200925205440-f610abc021d3/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
+github.com/hashicorp/hcat v0.0.0-20201001022531-5a93181f0fe6 h1:T307AZ4PR7KYNW1KeJI5vKVf3sQ6hsBxVcXZEaDQdHU=
+github.com/hashicorp/hcat v0.0.0-20201001022531-5a93181f0fe6/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=


### PR DESCRIPTION
Pulls in @eikenb 's changes to [hcat/#12](https://github.com/hashicorp/hcat/pull/12). This is useful on a few fronts:
* When the Consul server is not reachable on startup, Sync will error earlier instead of allowing controller/driver/tasks are set up to finally error and exit on first fetch to a template dependency on `watcher.Wait`
```
2020/10/05 19:06:28.538096 [INFO] 1de7959 (1de7959)
2020/10/05 19:06:28.538149 [INFO] (cli) setting up controller
2020/10/05 19:06:28.538152 [INFO] (controller) setting up Terraform driver
2020/10/05 19:06:28.539394 [ERR] (cli) error setting up controller: Get "http://localhost:8500/v1/status/leader": dial tcp 127.0.0.1:8500: connect: connection refused
```
* Waits for Consul leader to be elected to ensure consistency across agents before fetching info from Consul Catalog (#98)

Resolves #98