### PR TITLE
Update services variable key to be unique across nodes and data centers

### DIFF
--- a/templates/tftmpl/template_funcs.go
+++ b/templates/tftmpl/template_funcs.go
@@ -11,6 +11,25 @@ var HCLTmplFuncMap = map[string]interface{}{
 	"hclString":     HCLString,
 	"hclStringList": HCLStringList,
 	"hclStringMap":  HCLStringMap,
+	"joinStrings":   JoinStrings,
+}
+
+// JoinStrings joins an optional number of strings with the separator while
+// omitting empty strings from the combined string. This is useful for
+// templating a number of strings that are not contained in a slice.
+func JoinStrings(sep string, values ...string) string {
+	if len(values) == 0 {
+		return ""
+	}
+
+	cleaned := make([]string, 0, len(values))
+	for _, v := range values {
+		if v != "" {
+			cleaned = append(cleaned, v)
+		}
+	}
+
+	return strings.Join(cleaned, sep)
 }
 
 // HCLString formats a string into HCL string with null as the default

--- a/templates/tftmpl/template_funcs_test.go
+++ b/templates/tftmpl/template_funcs_test.go
@@ -6,6 +6,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestJoinStrings(t *testing.T) {
+	testCases := []struct {
+		name     string
+		content  []string
+		expected string
+	}{
+		{
+			"empty",
+			[]string{},
+			"",
+		}, {
+			"string",
+			[]string{"foobar"},
+			"foobar",
+		}, {
+			"multiple strings",
+			[]string{"foo", "bar", "baz"},
+			"foo.bar.baz",
+		}, {
+			"empty string ignored",
+			[]string{"foo", "", "baz"},
+			"foo.baz",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := JoinStrings(".", tc.content...)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestHCLString(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/templates/tftmpl/testdata/only_api_service.tfvars
+++ b/templates/tftmpl/testdata/only_api_service.tfvars
@@ -11,7 +11,7 @@ testProvider = {
 }
 
 services = {
-  "api" : {
+  "api.worker-01.dc1" : {
     id              = "api"
     name            = "api"
     address         = "1.2.3.4"
@@ -20,7 +20,7 @@ services = {
     tags            = ["tag"]
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"
@@ -34,7 +34,7 @@ services = {
       consul-network-segment = ""
     }
   },
-  "api-2" : {
+  "api-2.worker-01.dc1" : {
     id              = "api-2"
     name            = "api"
     address         = "5.6.7.8"
@@ -43,8 +43,31 @@ services = {
     tags            = ["tag"]
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node_address    = "127.0.0.1"
+    node_datacenter = "dc1"
+    node_tagged_addresses = {
+      lan      = "127.0.0.1"
+      lan_ipv4 = "127.0.0.1"
+      wan      = "127.0.0.1"
+      wan_ipv4 = "127.0.0.1"
+    }
+    node_meta = {
+      consul-network-segment = ""
+    }
+  },
+  "api.worker-02.dc1" : {
+    id              = "api"
+    name            = "api"
+    address         = "1.2.3.4"
+    port            = 8080
+    meta            = {}
+    tags            = ["tag"]
+    namespace       = null
+    status          = "passing"
+    node            = "worker-02"
+    node_id         = "d407a592-e93c-4d8e-8a6d-aba853d1e067"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"
     node_tagged_addresses = {

--- a/templates/tftmpl/testdata/only_web_service.tfvars
+++ b/templates/tftmpl/testdata/only_web_service.tfvars
@@ -11,7 +11,7 @@ testProvider = {
 }
 
 services = {
-  "web" : {
+  "web.worker-01.dc1" : {
     id              = "web"
     name            = "web"
     address         = "1.1.1.1"
@@ -20,7 +20,7 @@ services = {
     tags            = []
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"

--- a/templates/tftmpl/testdata/terraform.tfvars
+++ b/templates/tftmpl/testdata/terraform.tfvars
@@ -11,7 +11,7 @@ testProvider = {
 }
 
 services = {
-  "api" : {
+  "api.worker-01.dc1" : {
     id              = "api"
     name            = "api"
     address         = "1.2.3.4"
@@ -20,7 +20,7 @@ services = {
     tags            = ["tag"]
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"
@@ -34,7 +34,7 @@ services = {
       consul-network-segment = ""
     }
   },
-  "api-2" : {
+  "api-2.worker-01.dc1" : {
     id              = "api-2"
     name            = "api"
     address         = "5.6.7.8"
@@ -43,7 +43,7 @@ services = {
     tags            = ["tag"]
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"
@@ -57,7 +57,7 @@ services = {
       consul-network-segment = ""
     }
   },
-  "web" : {
+  "web.worker-01.dc1" : {
     id              = "web"
     name            = "web"
     address         = "1.1.1.1"
@@ -66,7 +66,7 @@ services = {
     tags            = []
     namespace       = null
     status          = "passing"
-    node            = "node-39e5a7f5-2834-e16d-6925-78167c9f50d8"
+    node            = "worker-01"
     node_id         = "39e5a7f5-2834-e16d-6925-78167c9f50d8"
     node_address    = "127.0.0.1"
     node_datacenter = "dc1"

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -14,7 +14,7 @@ services = {
 {{- with $srv := service "tag.api@dc1"}}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
-  "{{.ID}}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
     id              = "{{.ID}}"
     name            = "{{.Name}}"
     address         = "{{.Address}}"
@@ -37,7 +37,7 @@ services = {
 {{- with $srv := service "web@dc1"}}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
-  "{{.ID}}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
     id              = "{{.ID}}"
     name            = "{{.Name}}"
     address         = "{{.Address}}"

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -91,7 +91,7 @@ const baseAddressStr = `
 {{- with $srv := service "%s"}}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
-  "{{.ID}}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
     id              = "{{.ID}}"
     name            = "{{.Name}}"
     address         = "{{.Address}}"


### PR DESCRIPTION
Proposal to change the key value for the services map used by compatible Terraform modules from service ID to `serviceID.node.namespace.datacenter`.

resolves #93