### PR TITLE
Fix e2e panos test to use changed provider source

### DIFF
--- a/e2e/config.go
+++ b/e2e/config.go
@@ -25,7 +25,24 @@ func twoTaskConfig(consulAddr, tempDir string) string {
 // panosConfig returns a basic use case config file
 // Use for confirming specific resource / statefile output
 func panosConfig(consulAddr, tempDir string) string {
-	return panosBadCredConfig() + consulBlock(consulAddr) + terraformBlock(tempDir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	tfBlock := fmt.Sprintf(`
+driver "terraform" {
+	log = true
+	path = "%s"
+	working_dir = "%s"
+	required_providers {
+		panos = {
+			source = "paloaltonetworks/panos"
+		}
+	}
+}`, cwd, tempDir)
+
+	return panosBadCredConfig() + consulBlock(consulAddr) + tfBlock
 }
 
 func consulBlock(addr string) string {


### PR DESCRIPTION
e2e test have been failing recently https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/325/workflows/1d2d5eda-b3a5-41f1-8597-e8781d56dcae/jobs/573

I see logs about missing provider source