### PR TITLE
set default retry count

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -183,6 +183,7 @@ func (tf *Terraform) InitTask(task Task, force bool) error {
 		persistLog: tf.persistLog,
 		path:       tf.path,
 		workingDir: tf.workingDir,
+		retry:      defaultRetry,
 	})
 	if err != nil {
 		log.Printf("[ERR] (driver.terraform) init worker error: %s", err)


### PR DESCRIPTION
I think the worker retry https://github.com/hashicorp/consul-terraform-sync/pull/72 was somehow missed in the refactor efforts https://github.com/hashicorp/consul-terraform-sync/pull/81. `defaultRetry` is 2 and was used in #72 and no longer referenced anywhere after #81