### PR TITLE
Remove inspect mode from config file option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,9 +21,8 @@ const (
 
 // Config is used to configure Sync
 type Config struct {
-	LogLevel    *string `mapstructure:"log_level"`
-	InspectMode *bool   `mapstructure:"inspect_mode"`
-	ClientType  *string `mapstructure:"client_type"`
+	LogLevel   *string `mapstructure:"log_level"`
+	ClientType *string `mapstructure:"client_type"`
 
 	Syslog       *SyslogConfig       `mapstructure:"syslog"`
 	Consul       *ConsulConfig       `mapstructure:"consul"`
@@ -63,7 +62,6 @@ func DefaultConfig() *Config {
 	consul := DefaultConsulConfig()
 	return &Config{
 		LogLevel:     String(DefaultLogLevel),
-		InspectMode:  Bool(false),
 		Syslog:       DefaultSyslogConfig(),
 		Consul:       consul,
 		Driver:       DefaultDriverConfig(),
@@ -83,7 +81,6 @@ func (c *Config) Copy() *Config {
 
 	return &Config{
 		LogLevel:     StringCopy(c.LogLevel),
-		InspectMode:  BoolCopy(c.InspectMode),
 		Syslog:       c.Syslog.Copy(),
 		Consul:       c.Consul.Copy(),
 		Driver:       c.Driver.Copy(),
@@ -114,10 +111,6 @@ func (c *Config) Merge(o *Config) *Config {
 
 	if o.LogLevel != nil {
 		r.LogLevel = StringCopy(o.LogLevel)
-	}
-
-	if o.InspectMode != nil {
-		r.InspectMode = BoolCopy(o.InspectMode)
 	}
 
 	if o.Syslog != nil {
@@ -240,7 +233,6 @@ func (c *Config) GoString() string {
 
 	return fmt.Sprintf("&Config{"+
 		"LogLevel:%s, "+
-		"InspectMode:%#v, "+
 		"Syslog:%s, "+
 		"Consul:%s, "+
 		"Driver:%s, "+
@@ -250,7 +242,6 @@ func (c *Config) GoString() string {
 		"BufferPeriod:%s"+
 		"}",
 		StringVal(c.LogLevel),
-		BoolVal(c.InspectMode),
 		c.Syslog.GoString(),
 		c.Consul.GoString(),
 		c.Driver.GoString(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,23 +11,19 @@ import (
 
 var (
 	jsonConfig = []byte(`{
-	"log_level": "ERR",
-	"inspect_mode": true
+	"log_level": "ERR"
 }`)
 
 	hclConfig = []byte(`
 	log_level = "ERR"
-	inspect_mode = true
 `)
 
 	testConfig = Config{
-		LogLevel:    String("ERR"),
-		InspectMode: Bool(true),
+		LogLevel: String("ERR"),
 	}
 
 	longConfig = Config{
-		LogLevel:    String("ERR"),
-		InspectMode: Bool(true),
+		LogLevel: String("ERR"),
 		Syslog: &SyslogConfig{
 			Enabled: Bool(true),
 			Name:    String("syslog"),
@@ -177,15 +173,18 @@ func TestFromPath(t *testing.T) {
 			"load file",
 			"testdata/simple.hcl",
 			&Config{
-				LogLevel:    String("ERR"),
-				InspectMode: Bool(true),
+				LogLevel: String("ERR"),
 			},
 		}, {
 			"load dir merge",
 			"testdata/simple",
 			&Config{
-				LogLevel:    String("ERR"),
-				InspectMode: Bool(true),
+				LogLevel: String("ERR"),
+				BufferPeriod: &BufferPeriodConfig{
+					Enabled: Bool(true),
+					Min:     TimeDuration(time.Duration(10 * time.Second)),
+					Max:     TimeDuration(time.Duration(30 * time.Second)),
+				},
 			},
 		}, {
 			"load dir merges tasks and services",
@@ -218,8 +217,7 @@ func TestFromPath(t *testing.T) {
 			"load dir override sorted by filename",
 			"testdata/override",
 			&Config{
-				LogLevel:    String("DEBUG"),
-				InspectMode: Bool(false),
+				LogLevel: String("DEBUG"),
 			},
 		}, {
 			"file DNE",

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -1,5 +1,4 @@
 log_level = "ERR"
-inspect_mode = true
 
 syslog {
   enabled = true

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -1,6 +1,5 @@
 {
   "log_level": "ERR",
-  "inspect_mode": true,
   "syslog": {
     "enabled": true,
     "name": "syslog"

--- a/config/testdata/override/a.hcl
+++ b/config/testdata/override/a.hcl
@@ -1,2 +1,1 @@
 log_level = "ERR"
-inspect_mode = true

--- a/config/testdata/override/b.hcl
+++ b/config/testdata/override/b.hcl
@@ -1,2 +1,1 @@
 log_level = "DEBUG"
-inspect_mode = false

--- a/config/testdata/simple.hcl
+++ b/config/testdata/simple.hcl
@@ -1,2 +1,1 @@
 log_level = "ERR"
-inspect_mode = true

--- a/config/testdata/simple/b.hcl
+++ b/config/testdata/simple/b.hcl
@@ -1,1 +1,5 @@
-inspect_mode = true
+buffer_period {
+  enabled = true
+  min = "10s"
+  max = "30s"
+}


### PR DESCRIPTION
This aligns the daemon modes to be controlled only by CLI flags, similar to the support for Once.

Having inspect mode as a config option requires multiple steps for a debugging option to change modes that would be better without -- write config file, save, run the program, then later open config, delete option, save, run again

Note, at this point `inspect` flag is not available and is not implemented yet, just shifts existing code around