### PR TITLE
Inspect mode

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -247,7 +247,7 @@ func (cli *CLI) Run(args []string) int {
 			}
 
 		case <-exitCh:
-			if isOnce {
+			if isOnce || isInspect {
 				log.Printf("[INFO] (cli) graceful shutdown")
 				return ExitCodeOK
 			}

--- a/cli.go
+++ b/cli.go
@@ -79,9 +79,9 @@ func (cli *CLI) Run(args []string) int {
 		"Configuration file requires an .hcl or .json extension in order to "+
 		"specify their format. This option can be specified multiple times to "+
 		"load different configuration files.")
-	// f.BoolVar(&isInspect, "inspect", false, "Run Sync in Inspect mode to "+
-	// 	"print the current and proposed state change, and then exits. No changes "+
-	// 	"are applied in this mode.")
+	f.BoolVar(&isInspect, "inspect", false, "Run Sync in Inspect mode to "+
+		"print the proposed state changes for all tasks, and then exits. No changes "+
+		"are applied in this mode.")
 	f.BoolVar(&isOnce, "once", false, "Render templates and run tasks once. "+
 		"Does not run the process as a daemon and disables buffer periods.")
 	f.BoolVar(&isVersion, "version", false, "Print the version of this daemon.")
@@ -153,9 +153,7 @@ func (cli *CLI) Run(args []string) int {
 	if isInspect {
 		log.Printf("[DEBUG] (cli) inspect mode enabled, processing then exiting")
 		log.Printf("[INFO] (cli) setting up controller: readonly")
-		fmt.Fprintln(cli.outStream, "TODO")
-		return ExitCodeOK
-		ctrl = controller.NewReadOnly(conf)
+		ctrl, err = controller.NewReadOnly(conf)
 	} else {
 		log.Printf("[INFO] (cli) setting up controller: readwrite")
 		ctrl, err = controller.NewReadWrite(conf)

--- a/cli.go
+++ b/cli.go
@@ -64,7 +64,7 @@ func NewCLI(out, err io.Writer) *CLI {
 // status from the command.
 func (cli *CLI) Run(args []string) int {
 	// Handle parsing the CLI flags.
-	var configFiles config.FlagAppendSliceValue
+	var configFiles, inspectTasks config.FlagAppendSliceValue
 	var isVersion, isInspect, isOnce bool
 	var clientType string
 	var help, h bool
@@ -82,6 +82,9 @@ func (cli *CLI) Run(args []string) int {
 	f.BoolVar(&isInspect, "inspect", false, "Run Sync in Inspect mode to "+
 		"print the proposed state changes for all tasks, and then exits. No changes "+
 		"are applied in this mode.")
+	f.Var(&inspectTasks, "inspect-task", "Run Sync in Inspect mode to "+
+		"print the proposed state changes for the task, and then exits. No "+
+		"changes are applied in this mode.")
 	f.BoolVar(&isOnce, "once", false, "Render templates and run tasks once. "+
 		"Does not run the process as a daemon and disables buffer periods.")
 	f.BoolVar(&isVersion, "version", false, "Print the version of this daemon.")
@@ -146,6 +149,15 @@ func (cli *CLI) Run(args []string) int {
 	// Print information on startup for debugging
 	log.Printf("[INFO] %s", version.GetHumanVersion())
 	log.Printf("[DEBUG] %s", conf.GoString())
+
+	if len(inspectTasks) != 0 {
+		isInspect = true
+		conf.Tasks, err = config.FilterTasks(conf.Tasks, inspectTasks)
+		if err != nil {
+			log.Printf("[ERR] (cli) error inspecting tasks: %s", err)
+			return ExitCodeConfigError
+		}
+	}
 
 	// Set up controller
 	conf.ClientType = config.String(clientType)

--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -118,9 +117,7 @@ func (t *TerraformCLI) Apply(ctx context.Context) error {
 	for i, vf := range t.varFiles {
 		opts[i] = tfexec.VarFile(vf)
 	}
-
-	tfvarFile := strings.TrimRight(tftmpl.TFVarsTmplFilename, ".tmpl")
-	opts[numFiles] = tfexec.VarFile(tfvarFile)
+	opts[numFiles] = tfexec.VarFile(tftmpl.TFVarsFilename)
 
 	return t.tf.Apply(ctx, opts...)
 }
@@ -133,9 +130,7 @@ func (t *TerraformCLI) Plan(ctx context.Context) error {
 	for i, vf := range t.varFiles {
 		opts[i] = tfexec.VarFile(vf)
 	}
-
-	tfvarFile := strings.TrimRight(tftmpl.TFVarsTmplFilename, ".tmpl")
-	opts[numFiles] = tfexec.VarFile(tfvarFile)
+	opts[numFiles] = tfexec.VarFile(tftmpl.TFVarsFilename)
 
 	_, err := t.tf.Plan(ctx, opts...)
 	return err

--- a/config/task.go
+++ b/config/task.go
@@ -345,3 +345,21 @@ func (c *TaskConfigs) GoString() string {
 
 	return "{" + strings.Join(s, ", ") + "}"
 }
+
+// FilterTasks filters the task configurations by task name.
+func FilterTasks(tasks *TaskConfigs, names []string) (*TaskConfigs, error) {
+	allTasks := make(map[string]*TaskConfig)
+	for _, t := range *tasks {
+		allTasks[*t.Name] = t
+	}
+
+	var filtered TaskConfigs
+	for _, name := range names {
+		tconf, ok := allTasks[name]
+		if !ok {
+			return nil, fmt.Errorf("task not found: %s", name)
+		}
+		filtered = append(filtered, tconf)
+	}
+	return &filtered, nil
+}

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -2,6 +2,9 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"sort"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 )
@@ -10,25 +13,105 @@ var _ Controller = (*ReadOnly)(nil)
 
 // ReadOnly is the controller to run in read-only mode
 type ReadOnly struct {
-	conf *config.Config
+	*baseController
 }
 
 // NewReadOnly configures and initializes a new ReadOnly controller
-func NewReadOnly(conf *config.Config) *ReadOnly {
-	return &ReadOnly{
-		conf: conf,
+func NewReadOnly(conf *config.Config) (Controller, error) {
+	// Run the driver with logging to output the Terraform plan to stdout
+	if tfConfig := conf.Driver.Terraform; tfConfig != nil {
+		tfConfig.Log = config.Bool(true)
 	}
+
+	baseCtrl, err := newBaseController(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReadOnly{baseController: baseCtrl}, nil
 }
 
 // Init initializes the controller before it can be run
-func (ro *ReadOnly) Init(ctx context.Context) error {
-	// TODO
+func (ctrl *ReadOnly) Init(ctx context.Context) error {
+	if err := ctrl.init(ctx); err != nil {
+		return err
+	}
+
+	sort.Slice(ctrl.units, func(i, j int) bool {
+		return ctrl.units[i].taskName < ctrl.units[j].taskName
+	})
+
 	return nil
 }
 
 // Run runs the controller in read-only mode by checking Consul catalog once for
 // latest and using the driver to plan network infrastructure changes
-func (ro *ReadOnly) Run(ctx context.Context) error {
-	// TODO
-	return nil
+func (ctrl *ReadOnly) Run(ctx context.Context) error {
+	log.Println("[INFO] (ctrl) inspecting all tasks")
+
+	completed := make(map[string]bool, len(ctrl.units))
+	for {
+		done := true
+		for _, u := range ctrl.units {
+			if !completed[u.taskName] {
+				complete, err := ctrl.checkInspect(ctx, u)
+				if err != nil {
+					return err
+				}
+				completed[u.taskName] = complete
+				if !complete && done {
+					done = false
+				}
+			}
+		}
+		if done {
+			log.Println("[INFO] (ctrl) completed task inspections")
+			return nil
+		}
+
+		select {
+		case err := <-ctrl.watcher.WaitCh(ctx):
+			if err != nil {
+				log.Printf("[ERR] (ctrl) error watching template dependencies: %s", err)
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (ctrl *ReadOnly) checkInspect(ctx context.Context, u unit) (bool, error) {
+	tmpl := u.template
+	taskName := u.taskName
+
+	log.Printf("[TRACE] (ctrl) checking dependencies changes for task %s", taskName)
+	result, err := ctrl.resolver.Run(tmpl, ctrl.watcher)
+	if err != nil {
+		return false, fmt.Errorf("error fetching template dependencies for task %s: %s",
+			taskName, err)
+	}
+
+	// result.Complete is only `true` if the template has new data that has been
+	// completely fetched. Rendering a template for the first time may take several
+	// cycles to load all the dependencies asynchronously.
+	if result.Complete {
+		log.Printf("[DEBUG] (ctrl) change detected for task %s", taskName)
+		rendered, err := tmpl.Render(result.Contents)
+		if err != nil {
+			return false, fmt.Errorf("error rendering template for task %s: %s",
+				taskName, err)
+		}
+		log.Printf("[TRACE] (ctrl) template for task %q rendered: %+v", taskName, rendered)
+
+		d := u.driver
+		log.Printf("[INFO] (ctrl) inspecting task %s", taskName)
+		if err := d.InspectTask(ctx); err != nil {
+			return false, fmt.Errorf("could not apply changes for task %s: %s", taskName, err)
+		}
+
+		log.Printf("[INFO] (ctrl) inspected task %s", taskName)
+	}
+
+	return result.Complete, nil
 }

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -37,6 +37,7 @@ func (ctrl *ReadOnly) Init(ctx context.Context) error {
 		return err
 	}
 
+	// Sort units for consistent ordering when inspecting tasks
 	sort.Slice(ctrl.units, func(i, j int) bool {
 		return ctrl.units[i].taskName < ctrl.units[j].taskName
 	})

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -1,0 +1,126 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/controller"
+	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
+	"github.com/hashicorp/hcat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestReadOnlyRun(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		expectError       bool
+		inspectTaskErr    error
+		resolverRunErr    error
+		templateRenderErr error
+		watcherWaitErr    error
+		config            *config.Config
+	}{
+		{
+			"error on resolver.Run()",
+			true,
+			nil,
+			errors.New("error on resolver.Run()"),
+			nil,
+			nil,
+			singleTaskConfig(),
+		},
+		{
+			"error on driver.InspectTask()",
+			true,
+			errors.New("error on driver.InspectTask()"),
+			nil,
+			nil,
+			nil,
+			singleTaskConfig(),
+		},
+		{
+			"happy path",
+			false,
+			nil,
+			nil,
+			nil,
+			nil,
+			singleTaskConfig(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			tmpl := new(mocks.Template)
+			tmpl.On("Render", mock.Anything).Return(hcat.RenderResult{}, tc.templateRenderErr).Once()
+
+			r := new(mocks.Resolver)
+			r.On("Run", mock.Anything, mock.Anything).
+				Return(hcat.ResolveEvent{Complete: true}, tc.resolverRunErr)
+
+			w := new(mocks.Watcher)
+			w.On("Wait", mock.Anything).Return(tc.watcherWaitErr)
+
+			d := new(mocksD.Driver)
+			d.On("InspectTask", mock.Anything).Return(tc.inspectTaskErr)
+
+			ctrl := ReadOnly{baseController: &baseController{
+				watcher:  w,
+				resolver: r,
+				units:    []unit{{template: tmpl, driver: d}},
+			}}
+			ctx := context.Background()
+
+			err := ctrl.Run(ctx)
+			if tc.expectError {
+				if assert.Error(t, err) {
+					assert.Contains(t, err.Error(), tc.name)
+				}
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestReadOnlyRun_context_cancel(t *testing.T) {
+	r := new(mocks.Resolver)
+	r.On("Run", mock.Anything, mock.Anything).
+		Return(hcat.ResolveEvent{Complete: false}, nil)
+
+	w := new(mocks.Watcher)
+	w.On("WaitCh", mock.Anything, mock.Anything).Return(nil).
+		On("Stop").Return()
+
+	ctrl := ReadOnly{baseController: &baseController{
+		watcher:  w,
+		resolver: r,
+		units:    []unit{{template: new(mocks.Template)}},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error)
+	go func() {
+		err := ctrl.Run(ctx)
+		if err != nil {
+			errCh <- err
+		}
+	}()
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Error("wanted 'context canceled', got:", err)
+		}
+	case <-time.After(time.Second * 5):
+		t.Fatal("Run did not exit properly from cancelling context")
+	}
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -13,6 +13,10 @@ type Driver interface {
 	// InitTask initializes the task that the driver executes
 	InitTask(task Task, force bool) error
 
+	// InspectTask inspects for any differences pertaining to the task between
+	// the state of Consul and network infrastructure
+	InspectTask(ctx context.Context) error
+
 	// ApplyTask applies change for the task managed by the driver
 	ApplyTask(ctx context.Context) error
 

--- a/driver/task.go
+++ b/driver/task.go
@@ -123,13 +123,13 @@ func (w *worker) init(ctx context.Context) error {
 	return nil
 }
 
-func (w *worker) apply(ctx context.Context) error {
+func (w *worker) withRetry(ctx context.Context, f func(context.Context) error, desc string) error {
 	r := retry{
-		desc:   fmt.Sprintf("Apply %s", w.task.Name),
+		desc:   desc,
 		retry:  w.retry,
 		random: w.random,
 		fxn: func() error {
-			return w.client.Apply(ctx)
+			return f(ctx)
 		},
 	}
 

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -161,7 +161,7 @@ func TestWorkerApply(t *testing.T) {
 				random: rand.New(rand.NewSource(1)),
 			}
 
-			err := w.apply(ctx)
+			err := w.withRetry(ctx, w.client.Apply, "apply")
 			if tc.applyErr != nil {
 				assert.Error(t, err)
 				return

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -134,7 +134,7 @@ func TestWorkerInit(t *testing.T) {
 	}
 }
 
-func TestWorkerApply(t *testing.T) {
+func TestWithRetry_client(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -215,7 +215,7 @@ func (tf *Terraform) InspectTask(ctx context.Context) error {
 		log.Printf("[TRACE] (driver.terraform) initializing workspace '%s'", taskName)
 		if err := w.init(ctx); err != nil {
 			log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
-				"skipping apply for '%s'", taskName)
+				"skipping plan for '%s'", taskName)
 			return errors.Wrap(err, fmt.Sprintf("error tf-init for '%s'", taskName))
 		}
 	}

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -202,6 +202,33 @@ func (tf *Terraform) InitTask(task Task, force bool) error {
 	return nil
 }
 
+// InspectTask inspects for any differences pertaining to the task between
+// the state of Consul and network infrastructure using the Terraform plan command
+func (tf *Terraform) InspectTask(ctx context.Context) error {
+	w := tf.worker
+	taskName := w.task.Name
+
+	if w.inited {
+		log.Printf("[TRACE] (driver.terraform) workspace for task already "+
+			"initialized, skipping for '%s'", taskName)
+	} else {
+		log.Printf("[TRACE] (driver.terraform) initializing workspace '%s'", taskName)
+		if err := w.init(ctx); err != nil {
+			log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
+				"skipping apply for '%s'", taskName)
+			return errors.Wrap(err, fmt.Sprintf("error tf-init for '%s'", taskName))
+		}
+	}
+
+	log.Printf("[TRACE] (driver.terraform) plan '%s'", taskName)
+	desc := fmt.Sprintf("Plan %s", taskName)
+	if err := w.withRetry(ctx, w.client.Plan, desc); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error tf-plan for '%s'", taskName))
+	}
+
+	return nil
+}
+
 // ApplyTask applies the task changes.
 func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	w := tf.worker
@@ -220,7 +247,8 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	}
 
 	log.Printf("[TRACE] (driver.terraform) apply '%s'", taskName)
-	if err := w.apply(ctx); err != nil {
+	desc := fmt.Sprintf("Apply %s", taskName)
+	if err := w.withRetry(ctx, w.client.Apply, desc); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error tf-apply for '%s'", taskName))
 	}
 

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -56,6 +56,20 @@ func (_m *Driver) InitTask(task driver.Task, force bool) error {
 	return r0
 }
 
+// InspectTask provides a mock function with given fields: ctx
+func (_m *Driver) InspectTask(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Version provides a mock function with given fields:
 func (_m *Driver) Version() string {
 	ret := _m.Called()

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -31,8 +31,11 @@ const (
 	// to the input variables from a user that is specific to the task's module.
 	ModuleVarsFilename = "variables.module.tf"
 
-	// TFVarsTmplFilename is the file name for input variables for configured
+	// TFVarsFilename is the file name for input variables for configured
 	// Terraform providers and Consul service information.
+	TFVarsFilename = "terraform.tfvars"
+
+	// TFVarsTmplFilename is the template file for TFVarsFilename
 	TFVarsTmplFilename = "terraform.tfvars.tmpl"
 )
 


### PR DESCRIPTION
Implements support for inspect mode. This PR adds 2 CLI flag options to run inspect mode
1. `-inspect` which runs all tasks
1. `-inspect-task` to run selected task by name

## Changes
* Moved core content of initializing the controller to a new `baseController` to use struct-embedding for composition.
  * Moved test along with slight refactor to condense testing methods with similar test setup
* Add `InspectTask` which corresponds to Terraform plan on the driver level.
* Refactor worker retry to accept a function instead of implementing 1:1 worker functions to client
* Small fix to isolate Terraform CLI client from template concepts (".tmpl" file suffix)

## UX
```
$ consul-terraform-sync -h
Usage of consul-terraform-sync:
  ...
  -inspect false
        Run Sync in Inspect mode to print the proposed state changes for all tasks, and then exits. No changes are applied in this mode.
  -inspect-task 
        Run Sync in Inspect mode to print the proposed state changes for the task, and then exits. No changes are applied in this mode.
  ...
```

Example flag usage to inspect 2 tasks named "foo" and "bar"
```
$ consul-terraform-sync \
  -config-file example.hcl \
  -inspect-task foo \
  -inspect-task bar
```


<details>
<summary>Log example of Terraform plan output with inspect mode</summary>

```
2020/10/21 21:53:21.212785 [INFO] (ctrl) inspecting task foo
...
2020/10/21 21:53:21.795712 [INFO] running Terraform command: <PATH>/consul-terraform-sync/terraform plan -no-color -input=false -detailed-exitcode -lock-timeout=0s -var-file=terraform.tfvars -lock=true -parallelism=10 -refresh=true
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.foo.local_file.all_addresses will be created
  + resource "local_file" "all_addresses" {
      + content              = "127.0.0.1:80"
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "addresses.txt"
      + id                   = (known after apply)
    }

  # module.foo.local_file.services["web"] will be created
  + resource "local_file" "services" {
      + content              = "127.0.0.1"
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "web.txt"
      + id                   = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.
2020/10/21 21:53:22.304930 [INFO] (ctrl) inspected task foo
2020/10/21 21:53:22.304944 [INFO] (ctrl) completed task inspections
2020/10/21 21:53:22.304961 [INFO] (cli) graceful shutdown
```

</details>

Resolves #7 