### PR TITLE
Refactor worker and driver

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -150,6 +150,14 @@ func (cli *CLI) Run(args []string) int {
 	log.Printf("[INFO] %s", version.GetHumanVersion())
 	log.Printf("[DEBUG] %s", conf.GoString())
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := controller.InstallDriver(ctx, conf); err != nil {
+		log.Printf("[ERR] (cli) error installing driver: %s", err)
+		return ExitCodeDriverError
+	}
+
 	if len(inspectTasks) != 0 {
 		isInspect = true
 		conf.Tasks, err = config.FilterTasks(conf.Tasks, inspectTasks)
@@ -174,9 +182,6 @@ func (cli *CLI) Run(args []string) int {
 		log.Printf("[ERR] (cli) error setting up controller: %s", err)
 		return ExitCodeConfigError
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	errCh := make(chan error, 1)
 	exitCh := make(chan struct{}, 1)

--- a/cli.go
+++ b/cli.go
@@ -219,7 +219,7 @@ func (cli *CLI) Run(args []string) int {
 			}
 		}
 
-		log.Printf("[INFO] (cli) running controller")
+		log.Printf("[INFO] (cli) running controller in daemon mode")
 		if err := ctrl.Run(ctx); err != nil {
 			if err == context.Canceled {
 				exitCh <- struct{}{}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -105,6 +105,7 @@ func (ctrl *baseController) init(ctx context.Context) error {
 	return nil
 }
 
+// InstallDriver installs necessary drivers based on user configuration.
 func InstallDriver(ctx context.Context, conf *config.Config) error {
 	if conf.Driver.Terraform != nil {
 		tfConf := *conf.Driver.Terraform
@@ -113,6 +114,7 @@ func InstallDriver(ctx context.Context, conf *config.Config) error {
 	return errors.New("unsupported driver")
 }
 
+// newDriverFunc is a constructor abstraction for all of supported drivers
 func newDriverFunc(conf *config.Config) (
 	func(conf *config.Config, task driver.Task) (driver.Driver, error), error) {
 	if conf.Driver.Terraform != nil {
@@ -121,6 +123,8 @@ func newDriverFunc(conf *config.Config) (
 	return nil, errors.New("unsupported driver")
 }
 
+// newTerraformDriver maps user configuration to initialize a Terraform driver
+// for a task
 func newTerraformDriver(conf *config.Config, task driver.Task) (driver.Driver, error) {
 	tfConf := *conf.Driver.Terraform
 	return driver.NewTerraform(&driver.TerraformConfig{

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -74,13 +74,20 @@ func (ctrl *baseController) init(ctx context.Context) error {
 	units := make([]unit, 0, len(tasks))
 
 	for _, task := range tasks {
+		select {
+		case <-ctx.Done():
+			// Stop initializing remaining tasks if context has stopped.
+			return ctx.Err()
+		default:
+		}
+
 		log.Printf("[DEBUG] (ctrl) initializing task %q", task.Name)
 		d, err := ctrl.newDriver(ctrl.conf, task)
 		if err != nil {
 			return err
 		}
 
-		err = d.InitTask(ctx, true)
+		err = d.InitTask(true)
 		if err != nil {
 			log.Printf("[ERR] (ctrl) error initializing task %q: %s", task.Name, err)
 			return err

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -94,14 +94,6 @@ func TestBaseControllerInit(t *testing.T) {
 		config      *config.Config
 	}{
 		{
-			"error on driver.Init()",
-			true,
-			errors.New("error on driver.Init()"),
-			nil,
-			func(string) ([]byte, error) { return []byte{}, nil },
-			conf,
-		},
-		{
 			"error on driver.InitTask()",
 			true,
 			nil,
@@ -133,11 +125,12 @@ func TestBaseControllerInit(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
-			d.On("Init", mock.Anything).Return(tc.initErr).Once()
 			d.On("InitTask", mock.Anything, mock.Anything).Return(tc.initTaskErr).Once()
 
 			baseCtrl := baseController{
-				newDriver:  func(*config.Config) driver.Driver { return d },
+				newDriver: func(*config.Config, driver.Task) (driver.Driver, error) {
+					return d, nil
+				},
 				conf:       tc.config,
 				fileReader: tc.fileReader,
 			}

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -117,7 +117,7 @@ func TestOnce(t *testing.T) {
 		w.On("WaitCh", mock.Anything).Return(errChRc).Once()
 
 		d := new(mocksD.Driver)
-		d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
+		d.On("InitTask", mock.Anything).Return(nil).Once()
 		d.On("ApplyTask", mock.Anything).Return(nil).Once()
 
 		rw := &ReadWrite{baseController: &baseController{

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -117,20 +117,23 @@ func TestOnce(t *testing.T) {
 		w.On("WaitCh", mock.Anything).Return(errChRc).Once()
 
 		d := new(mocksD.Driver)
-		d.On("Init", mock.Anything).Return(nil).Once()
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
 		d.On("ApplyTask", mock.Anything).Return(nil).Once()
 
 		rw := &ReadWrite{baseController: &baseController{
-			watcher:    w,
-			resolver:   r,
-			newDriver:  func(*config.Config) driver.Driver { return d },
+			watcher:  w,
+			resolver: r,
+			newDriver: func(*config.Config, driver.Task) (driver.Driver, error) {
+				return d, nil
+			},
 			conf:       conf,
 			fileReader: func(string) ([]byte, error) { return []byte{}, nil },
 		}}
 
 		ctx := context.Background()
-		rw.Init(ctx)
+		err := rw.Init(ctx)
+		assert.NoError(t, err)
+
 		// insert mock template into units
 		for i, u := range rw.units {
 			u.template = tmpl

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -7,11 +7,8 @@ import "context"
 // Driver describes the interface for using an Sync driver to carry out changes
 // downstream to update network infrastructure.
 type Driver interface {
-	// Init initializes the driver and environment
-	Init(ctx context.Context) error
-
 	// InitTask initializes the task that the driver executes
-	InitTask(task Task, force bool) error
+	InitTask(ctx context.Context, force bool) error
 
 	// InspectTask inspects for any differences pertaining to the task between
 	// the state of Consul and network infrastructure

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,7 +8,7 @@ import "context"
 // downstream to update network infrastructure.
 type Driver interface {
 	// InitTask initializes the task that the driver executes
-	InitTask(ctx context.Context, force bool) error
+	InitTask(force bool) error
 
 	// InspectTask inspects for any differences pertaining to the task between
 	// the state of Consul and network infrastructure

--- a/driver/task.go
+++ b/driver/task.go
@@ -28,7 +28,7 @@ type Task struct {
 	Version      string
 }
 
-// workerConfig configures a worker
+// clientConfig configures a driver client for a task
 type clientConfig struct {
 	task       Task
 	clientType string

--- a/driver/task.go
+++ b/driver/task.go
@@ -1,16 +1,10 @@
 package driver
 
 import (
-	"context"
-	"fmt"
 	"log"
-	"math/rand"
-	"path/filepath"
-	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/client"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
-	"github.com/pkg/errors"
 )
 
 // Service contains service configuration information
@@ -34,167 +28,45 @@ type Task struct {
 	Version      string
 }
 
-// worker executes a unit of work and has a one-to-one relationship with a client
-// that will be responsible for executing the work. Currently worker is not safe for
-// concurrent use by multiple goroutines
-type worker struct {
-	client client.Client
-	task   Task
-	random *rand.Rand
-
-	retry  int
-	inited bool
-}
-
 // workerConfig configures a worker
-type workerConfig struct {
+type clientConfig struct {
 	task       Task
 	clientType string
 	log        bool
 	persistLog bool
 	path       string
 	workingDir string
-	retry      int
 }
 
-// newWorker initializes a worker for a task
-func newWorker(c *workerConfig) (*worker, error) {
-	client, err := initClient(c)
-	if err != nil {
-		log.Printf("[ERR] (task) init client type '%s' error: %s", c.clientType, err)
-		return nil, err
-	}
-
-	return &worker{
-		client: client,
-		task:   c.task,
-		random: rand.New(rand.NewSource(time.Now().UnixNano())),
-		retry:  c.retry,
-	}, nil
-}
-
-// initClient initializes a specific type of client given a task
-func initClient(conf *workerConfig) (client.Client, error) {
+// newClient initializes a specific type of client given a task
+func newClient(conf *clientConfig) (client.Client, error) {
 	var err error
 	var c client.Client
 	taskName := conf.task.Name
 
 	switch conf.clientType {
 	case developmentClient:
-		log.Printf("[TRACE] (task) creating development client for task '%s'", taskName)
+		log.Printf("[TRACE] (driver) creating development client for task '%s'", taskName)
 		c, err = client.NewPrinter(&client.PrinterConfig{
 			LogLevel:   "debug",
 			ExecPath:   conf.path,
-			WorkingDir: filepath.Join(conf.workingDir, taskName),
+			WorkingDir: conf.workingDir,
 			Workspace:  taskName,
 		})
 	case testClient:
-		log.Printf("[TRACE] (task) creating mock client for task '%s'", taskName)
+		log.Printf("[TRACE] (driver) creating mock client for task '%s'", taskName)
 		c = new(mocks.Client)
 	default:
-		log.Printf("[TRACE] (task) creating terraform cli client for task '%s'", taskName)
+		log.Printf("[TRACE] (driver) creating terraform cli client for task '%s'", taskName)
 		c, err = client.NewTerraformCLI(&client.TerraformCLIConfig{
 			Log:        conf.log,
 			PersistLog: conf.persistLog,
 			ExecPath:   conf.path,
-			WorkingDir: filepath.Join(conf.workingDir, taskName),
+			WorkingDir: conf.workingDir,
 			Workspace:  taskName,
 			VarFiles:   conf.task.VarFiles,
 		})
 	}
 
 	return c, err
-}
-
-func (w *worker) init(ctx context.Context) error {
-	r := retry{
-		desc:   fmt.Sprintf("Init %s", w.task.Name),
-		retry:  w.retry,
-		random: w.random,
-		fxn: func() error {
-			return w.client.Init(ctx)
-		},
-	}
-	if err := r.do(ctx); err != nil {
-		return err
-	}
-
-	w.inited = true
-	return nil
-}
-
-func (w *worker) withRetry(ctx context.Context, f func(context.Context) error, desc string) error {
-	r := retry{
-		desc:   desc,
-		retry:  w.retry,
-		random: w.random,
-		fxn: func() error {
-			return f(ctx)
-		},
-	}
-
-	return r.do(ctx)
-}
-
-// retry handles executing and retrying a function
-type retry struct {
-	desc   string
-	retry  int
-	random *rand.Rand
-	fxn    func() error
-}
-
-// do calls a function with exponential retry with a random delay. First
-// call also has random delay.
-func (r *retry) do(ctx context.Context) error {
-	count := r.retry + 1
-	var errs error
-
-	attempt := 0
-	wait := r.waitTime(attempt)
-	interval := time.NewTicker(time.Duration(wait))
-	defer interval.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Printf("[INFO] (task) stopping retry of '%s'", r.desc)
-			return ctx.Err()
-		case <-interval.C:
-			attempt++
-			if attempt > 1 {
-				log.Printf("[WARN]: (task) retrying '%s'. attempt #%d", r.desc, attempt)
-			}
-			err := r.fxn()
-			if err == nil {
-				return nil
-			}
-
-			err = fmt.Errorf("attempt #%d failed '%s'", attempt, err)
-
-			if errs == nil {
-				errs = err
-			} else {
-				errs = errors.Wrap(errs, err.Error())
-			}
-
-			wait := r.waitTime(attempt)
-			interval = time.NewTicker(time.Duration(wait))
-		}
-		if attempt >= count {
-			return errs
-		}
-	}
-}
-
-// waitTime calculates the wait time based off the attempt number based off
-// exponential backoff with a random delay.
-func (r *retry) waitTime(attempt int) int {
-	a := float64(attempt)
-	baseTimeSeconds := a * a
-	nextTimeSeconds := (a + 1) * (a + 1)
-	delayRange := (nextTimeSeconds - baseTimeSeconds) / 2
-	delay := r.random.Float64() * delayRange
-	total := (baseTimeSeconds + delay) * float64(time.Second)
-	return int(total)
 }

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -1,56 +1,15 @@
 package driver
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"math/rand"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/client"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-func TestNewWorker(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name        string
-		expectError bool
-		clientType  string
-	}{
-		{
-			"happy path (mock client)",
-			false,
-			testClient,
-		},
-		{
-			"error (default tf client)",
-			true,
-			"",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := newWorker(&workerConfig{
-				task:       Task{},
-				clientType: tc.clientType,
-			})
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestInitClient(t *testing.T) {
+func TestNewClient(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -81,7 +40,7 @@ func TestInitClient(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := initClient(&workerConfig{
+			actual, err := newClient(&clientConfig{
 				task:       Task{},
 				clientType: tc.clientType,
 			})
@@ -91,221 +50,6 @@ func TestInitClient(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, reflect.TypeOf(tc.expect), reflect.TypeOf(actual))
 			}
-		})
-	}
-}
-
-func TestWorkerInit(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name    string
-		initErr error
-	}{
-		{
-			"happy path",
-			nil,
-		},
-		{
-			"error",
-			errors.New("error"),
-		},
-	}
-
-	for _, tc := range cases {
-		ctx := context.Background()
-		t.Run(tc.name, func(t *testing.T) {
-			c := new(mocks.Client)
-			c.On("Init", mock.Anything).Return(tc.initErr)
-			w := worker{
-				client: c,
-				random: rand.New(rand.NewSource(1)),
-			}
-
-			err := w.init(ctx)
-			if tc.initErr != nil {
-				assert.Error(t, err)
-				assert.False(t, w.inited)
-				return
-			}
-			assert.NoError(t, err)
-			assert.True(t, w.inited)
-		})
-	}
-}
-
-func TestWithRetry_client(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		applyErr error
-	}{
-		{
-			"happy path",
-			nil,
-		},
-		{
-			"error",
-			errors.New("error"),
-		},
-	}
-
-	for _, tc := range cases {
-		ctx := context.Background()
-		t.Run(tc.name, func(t *testing.T) {
-			c := new(mocks.Client)
-			c.On("Apply", mock.Anything).Return(tc.applyErr)
-			w := worker{
-				client: c,
-				random: rand.New(rand.NewSource(1)),
-			}
-
-			err := w.withRetry(ctx, w.client.Apply, "apply")
-			if tc.applyErr != nil {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-		})
-	}
-}
-
-func TestWithRetry_context_cancel(t *testing.T) {
-	t.Parallel()
-
-	r := retry{
-		desc:   "fake fxn that never succeeds",
-		retry:  5,
-		random: rand.New(rand.NewSource(1)),
-		fxn: func() error {
-			return errors.New("test error")
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	errCh := make(chan error)
-	go func() {
-		err := r.do(ctx)
-		if err != nil {
-			errCh <- err
-		}
-	}()
-	cancel()
-
-	select {
-	case err := <-errCh:
-		if err != context.Canceled {
-			t.Error("wanted 'context canceled', got:", err)
-		}
-	case <-time.After(time.Second * 5):
-		t.Fatal("Run did not exit properly from cancelling context")
-	}
-}
-
-func TestWithRetry(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		retry     int
-		successOn int
-		expected  error
-	}{
-		{
-			"happy path: retry once, success on retry (2)",
-			1,
-			2,
-			nil,
-		},
-		{
-			"no success on retries: retry once",
-			1,
-			100,
-			errors.New("attempt #2 failed 'error on 2': attempt #1 failed 'error on 1'"),
-		},
-		{
-			"happy path: no retry",
-			0,
-			1,
-			nil,
-		},
-		{
-			"no retry, no success",
-			0,
-			100,
-			errors.New("attempt #1 failed 'error on 1'"),
-		},
-	}
-
-	ctx := context.Background()
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			// set up fake function
-			count := 0
-			fxn := func() error {
-				count++
-				if count == tc.successOn {
-					return nil
-				}
-				return fmt.Errorf("error on %d", count)
-			}
-
-			r := retry{
-				desc:   "test fxn",
-				retry:  tc.retry,
-				random: rand.New(rand.NewSource(1)),
-				fxn:    fxn,
-			}
-			err := r.do(ctx)
-			if tc.expected == nil {
-				assert.NoError(t, err)
-			} else {
-				assert.Equal(t, tc.expected.Error(), err.Error())
-			}
-		})
-	}
-}
-
-func TestWaitTime(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name      string
-		attempt   int
-		minReturn float64
-		maxReturn float64
-	}{
-		{
-			"first attempt",
-			0,
-			0,
-			0.5,
-		},
-		{
-			"second attempt",
-			1,
-			1,
-			2.5,
-		},
-		{
-			"third attempt",
-			2,
-			4,
-			6.5,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := retry{
-				random: rand.New(rand.NewSource(1)),
-			}
-			a := r.waitTime(tc.attempt)
-
-			actual := float64(a) / float64(time.Second)
-			assert.GreaterOrEqual(t, actual, tc.minReturn)
-			assert.LessOrEqual(t, actual, tc.maxReturn)
 		})
 	}
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -109,7 +109,7 @@ func (tf *Terraform) Version() string {
 
 // InitTask initializes the task by creating the Terraform root module and related
 // files to execute on.
-func (tf *Terraform) InitTask(ctx context.Context, force bool) error {
+func (tf *Terraform) InitTask(force bool) error {
 	task := tf.task
 
 	services := make([]*tftmpl.Service, len(task.Services))

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -43,7 +43,6 @@ type Terraform struct {
 
 	workingDir string
 	worker     *worker
-	clientType string
 	client     client.Client
 	postApply  handler.Handler
 
@@ -64,7 +63,8 @@ type TerraformConfig struct {
 	ClientType string
 }
 
-// NewTerraform configures and initializes a new Terraform driver
+// NewTerraform configures and initializes a new Terraform driver for a task.
+// The underlying Terraform CLI client and out-of-band handlers are prepared.
 func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 	if _, err := os.Stat(config.WorkingDir); os.IsNotExist(err) {
 		if err := os.Mkdir(config.WorkingDir, workingDirPerms); err != nil {
@@ -107,8 +107,8 @@ func (tf *Terraform) Version() string {
 	return TerraformVersion
 }
 
-// InitTask initializes the task by creating the Terraform root module, creating
-// client to execute task, and retrieving post-Terraform apply handlers
+// InitTask initializes the task by creating the Terraform root module and related
+// files to execute on.
 func (tf *Terraform) InitTask(ctx context.Context, force bool) error {
 	task := tf.task
 

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -80,13 +80,13 @@ func TestApplyTask(t *testing.T) {
 			c.On("Apply", ctx).Return(tc.applyReturn).Once()
 
 			tf := &Terraform{
+				task: Task{Name: "ApplyTaskTest"},
 				worker: &worker{
-					client: c,
-					task:   Task{Name: "ApplyTaskTest"},
-					inited: tc.inited,
 					random: rand.New(rand.NewSource(1)),
 				},
+				client:    c,
 				postApply: tc.postApply,
+				inited:    tc.inited,
 			}
 
 			err := tf.ApplyTask(ctx)

--- a/driver/worker.go
+++ b/driver/worker.go
@@ -10,9 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// worker executes a unit of work and has a one-to-one relationship with a client
-// that will be responsible for executing the work. Currently worker is not safe for
-// concurrent use by multiple goroutines
+// worker manages execution of a function and abstracts error handling and
+// retries for the function from the caller and function implementation.
 type worker struct {
 	random *rand.Rand
 	retry  int

--- a/driver/worker.go
+++ b/driver/worker.go
@@ -1,0 +1,103 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// worker executes a unit of work and has a one-to-one relationship with a client
+// that will be responsible for executing the work. Currently worker is not safe for
+// concurrent use by multiple goroutines
+type worker struct {
+	random *rand.Rand
+	retry  int
+}
+
+// retry handles executing and retrying a function
+type retry struct {
+	desc   string
+	retry  int
+	random *rand.Rand
+	fxn    func() error
+}
+
+// newWorker initializes a worker for a task
+func newWorker(retry int) *worker {
+	return &worker{
+		random: rand.New(rand.NewSource(time.Now().UnixNano())),
+		retry:  retry,
+	}
+}
+
+func (w *worker) withRetry(ctx context.Context, f func(context.Context) error, desc string) error {
+	r := retry{
+		desc:   desc,
+		retry:  w.retry,
+		random: w.random,
+		fxn: func() error {
+			return f(ctx)
+		},
+	}
+
+	return r.do(ctx)
+}
+
+// do calls a function with exponential retry with a random delay. First
+// call also has random delay.
+func (r *retry) do(ctx context.Context) error {
+	count := r.retry + 1
+	var errs error
+
+	attempt := 0
+	wait := r.waitTime(attempt)
+	interval := time.NewTicker(time.Duration(wait))
+	defer interval.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[INFO] (task) stopping retry of '%s'", r.desc)
+			return ctx.Err()
+		case <-interval.C:
+			attempt++
+			if attempt > 1 {
+				log.Printf("[WARN]: (task) retrying '%s'. attempt #%d", r.desc, attempt)
+			}
+			err := r.fxn()
+			if err == nil {
+				return nil
+			}
+
+			err = fmt.Errorf("attempt #%d failed '%s'", attempt, err)
+
+			if errs == nil {
+				errs = err
+			} else {
+				errs = errors.Wrap(errs, err.Error())
+			}
+
+			wait := r.waitTime(attempt)
+			interval = time.NewTicker(time.Duration(wait))
+		}
+		if attempt >= count {
+			return errs
+		}
+	}
+}
+
+// waitTime calculates the wait time based off the attempt number based off
+// exponential backoff with a random delay.
+func (r *retry) waitTime(attempt int) int {
+	a := float64(attempt)
+	baseTimeSeconds := a * a
+	nextTimeSeconds := (a + 1) * (a + 1)
+	delayRange := (nextTimeSeconds - baseTimeSeconds) / 2
+	delay := r.random.Float64() * delayRange
+	total := (baseTimeSeconds + delay) * float64(time.Second)
+	return int(total)
+}

--- a/driver/worker_test.go
+++ b/driver/worker_test.go
@@ -1,0 +1,189 @@
+package driver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWithRetry_context_cancel(t *testing.T) {
+	t.Parallel()
+
+	r := retry{
+		desc:   "fake fxn that never succeeds",
+		retry:  5,
+		random: rand.New(rand.NewSource(1)),
+		fxn: func() error {
+			return errors.New("test error")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error)
+	go func() {
+		err := r.do(ctx)
+		if err != nil {
+			errCh <- err
+		}
+	}()
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err != context.Canceled {
+			t.Error("wanted 'context canceled', got:", err)
+		}
+	case <-time.After(time.Second * 5):
+		t.Fatal("Run did not exit properly from cancelling context")
+	}
+}
+
+func TestWithRetry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		retry     int
+		successOn int
+		expected  error
+	}{
+		{
+			"happy path: retry once, success on retry (2)",
+			1,
+			2,
+			nil,
+		},
+		{
+			"no success on retries: retry once",
+			1,
+			100,
+			errors.New("attempt #2 failed 'error on 2': attempt #1 failed 'error on 1'"),
+		},
+		{
+			"happy path: no retry",
+			0,
+			1,
+			nil,
+		},
+		{
+			"no retry, no success",
+			0,
+			100,
+			errors.New("attempt #1 failed 'error on 1'"),
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// set up fake function
+			count := 0
+			fxn := func() error {
+				count++
+				if count == tc.successOn {
+					return nil
+				}
+				return fmt.Errorf("error on %d", count)
+			}
+
+			r := retry{
+				desc:   "test fxn",
+				retry:  tc.retry,
+				random: rand.New(rand.NewSource(1)),
+				fxn:    fxn,
+			}
+			err := r.do(ctx)
+			if tc.expected == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, tc.expected.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestWithRetry_client(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		applyErr error
+	}{
+		{
+			"happy path",
+			nil,
+		},
+		{
+			"error",
+			errors.New("error"),
+		},
+	}
+
+	for _, tc := range cases {
+		ctx := context.Background()
+		t.Run(tc.name, func(t *testing.T) {
+			c := new(mocks.Client)
+			c.On("Apply", mock.Anything).Return(tc.applyErr)
+			w := worker{
+				random: rand.New(rand.NewSource(1)),
+			}
+
+			err := w.withRetry(ctx, c.Apply, "apply")
+			if tc.applyErr != nil {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestWaitTime(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		attempt   int
+		minReturn float64
+		maxReturn float64
+	}{
+		{
+			"first attempt",
+			0,
+			0,
+			0.5,
+		},
+		{
+			"second attempt",
+			1,
+			1,
+			2.5,
+		},
+		{
+			"third attempt",
+			2,
+			4,
+			6.5,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := retry{
+				random: rand.New(rand.NewSource(1)),
+			}
+			a := r.waitTime(tc.attempt)
+
+			actual := float64(a) / float64(time.Second)
+			assert.GreaterOrEqual(t, actual, tc.minReturn)
+			assert.LessOrEqual(t, actual, tc.maxReturn)
+		})
+	}
+}

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -27,13 +27,13 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 	return r0
 }
 
-// InitTask provides a mock function with given fields: ctx, force
-func (_m *Driver) InitTask(ctx context.Context, force bool) error {
-	ret := _m.Called(ctx, force)
+// InitTask provides a mock function with given fields: force
+func (_m *Driver) InitTask(force bool) error {
+	ret := _m.Called(force)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, bool) error); ok {
-		r0 = rf(ctx, force)
+	if rf, ok := ret.Get(0).(func(bool) error); ok {
+		r0 = rf(force)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -5,7 +5,6 @@ package mocks
 import (
 	context "context"
 
-	driver "github.com/hashicorp/consul-terraform-sync/driver"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -28,27 +27,13 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 	return r0
 }
 
-// Init provides a mock function with given fields: ctx
-func (_m *Driver) Init(ctx context.Context) error {
-	ret := _m.Called(ctx)
+// InitTask provides a mock function with given fields: ctx, force
+func (_m *Driver) InitTask(ctx context.Context, force bool) error {
+	ret := _m.Called(ctx, force)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// InitTask provides a mock function with given fields: task, force
-func (_m *Driver) InitTask(task driver.Task, force bool) error {
-	ret := _m.Called(task, force)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(driver.Task, bool) error); ok {
-		r0 = rf(task, force)
+	if rf, ok := ret.Get(0).(func(context.Context, bool) error); ok {
+		r0 = rf(ctx, force)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
PR proposes to condense down the layers of abstraction. It started growing to where all information were being passed down to each level controller > driver > worker > task.

## Worker
* Moves worker code to separate file
* Refactors worker to reduce the context required for a worker - no longer needs info on client, init history, task.

## Driver
 * Moves driver install outside of controller workflow so it is only checked and installed once and earlier, instead of installing/verifying install for each task since there can only be one driver version used across all tasks
* Doubles down on the recent design choice for a driver instance per task.

### Terraform Driver
* TF driver now manages the TF client directly and initializes it within the constructor. This no longer requires the driver to store extra info that only pertains to the client (log info, path, client type). Previously the driver passed info to the worker to then initialize the client.
* Moves initialization calls outside of `InitTask` and into `NewTerraform`: worker, handlers
* Condensed redundant workspace init handling to a helper