### PR TITLE
Expand usage of Terraform backends for state store

### DIFF
--- a/config/terraform.go
+++ b/config/terraform.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"path"
+
+	"github.com/hashicorp/go-version"
 )
 
 const (
@@ -294,4 +296,28 @@ func mergeMaps(c, o map[string]interface{}) map[string]interface{} {
 	}
 
 	return r
+}
+
+// CheckVersionCompatibility checks compatibility of the version of Terraform
+// with features of Consul Terraform Sync
+func (c TerraformConfig) CheckVersionCompatibility(versionStr string) error {
+	// https://github.com/hashicorp/terraform/issues/23121
+	if _, ok := c.Backend["pg"]; ok {
+		v, err := version.NewSemver(versionStr)
+		if err != nil {
+			return err
+		}
+
+		constraint, err := version.NewConstraint(">= 0.14")
+		if err != nil {
+			return err
+		}
+
+		if !constraint.Check(v) {
+			return fmt.Errorf("Consul-Terraform-Sync does not support pg " +
+				"backend in automation with Terraform <= 0.13")
+		}
+	}
+
+	return nil
 }

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -238,9 +238,20 @@ func (c *TerraformConfig) Validate() error {
 		return fmt.Errorf("missing Terraform backend configuration")
 	}
 
+	// Backend is only validated for supported backend label. The backend
+	// configuration options are verified at run time. The allowed backends
+	// for state store have state locking and workspace suppport.
 	for k := range c.Backend {
 		switch k {
-		case "consul", "local":
+		case "azurerm",
+			"consul",
+			"cos",
+			"gcs",
+			"kubernetes",
+			"local",
+			"manta",
+			"pg",
+			"s3":
 		default:
 			return fmt.Errorf("unsupported Terraform backend by Sync %q", k)
 		}

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -482,7 +482,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 	}
 }
 
-func TestTerraformValidate(t *testing.T) {
+func TestTerraformConfig_Validate(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -524,6 +524,49 @@ func TestTerraformValidate(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			err := tc.i.Validate()
 			if tc.isValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestTerraformConfig_CheckVersionCompatibility(t *testing.T) {
+	cases := []struct {
+		name       string
+		version    string
+		config     TerraformConfig
+		compatible bool
+	}{
+		{
+			"valid",
+			"0.13.2",
+			TerraformConfig{
+				Backend: make(map[string]interface{}),
+			},
+			true,
+		}, {
+			"pg backend compatible",
+			"0.14.0",
+			TerraformConfig{
+				Backend: map[string]interface{}{"pg": nil},
+			},
+			true,
+		}, {
+			"pg backend incompatible",
+			"0.13.5",
+			TerraformConfig{
+				Backend: map[string]interface{}{"pg": nil},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.CheckVersionCompatibility(tc.version)
+			if tc.compatible {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -507,6 +507,13 @@ func TestTerraformValidate(t *testing.T) {
 			&TerraformConfig{Backend: map[string]interface{}{"local": nil}},
 			true,
 		}, {
+			"valid kubernetes backend",
+			&TerraformConfig{Backend: map[string]interface{}{"kubernetes": map[string]interface{}{
+				"secret_suffix":    "state",
+				"load_config_file": true,
+			}}},
+			true,
+		}, {
 			"backend_invalid",
 			&TerraformConfig{Backend: map[string]interface{}{"unsupported": nil}},
 			false,

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -116,7 +116,12 @@ func (ctrl *baseController) init(ctx context.Context) error {
 func InstallDriver(ctx context.Context, conf *config.Config) error {
 	if conf.Driver.Terraform != nil {
 		tfConf := *conf.Driver.Terraform
-		return driver.InstallTerraform(ctx, *tfConf.Path, *tfConf.WorkingDir)
+		err := driver.InstallTerraform(ctx, *tfConf.Path, *tfConf.WorkingDir)
+		if err != nil {
+			return err
+		}
+
+		return tfConf.CheckVersionCompatibility(driver.TerraformVersion)
 	}
 	return errors.New("unsupported driver")
 }

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -1,0 +1,111 @@
+package tftmpl
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendRootTerraformBlock_backend(t *testing.T) {
+	consulBackend, err := config.DefaultTerraformBackend(&config.ConsulConfig{
+		Address: config.String("consul.example.com"),
+		TLS: &config.TLSConfig{
+			Enabled: config.Bool(true),
+			CACert:  config.String("ca_cert"),
+			Cert:    config.String("cert"),
+			Key:     config.String("key"),
+		},
+	})
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name       string
+		rawBackend map[string]interface{}
+		expected   string
+	}{
+		{
+			"nil",
+			nil,
+			`terraform {
+  required_version = "~>0.13.0"
+}
+`,
+		}, {
+			"empty",
+			map[string]interface{}{"empty": map[string]interface{}{}},
+			`terraform {
+  required_version = "~>0.13.0"
+  backend "empty" {
+  }
+}
+`,
+		}, {
+			"invalid structure",
+			map[string]interface{}{"invalid": "unexpected type"},
+			`terraform {
+  required_version = "~>0.13.0"
+}
+`,
+		}, {
+			"local",
+			map[string]interface{}{"local": map[string]interface{}{
+				"path": "relative/path/to/terraform.tfstate",
+			}},
+			`terraform {
+  required_version = "~>0.13.0"
+  backend "local" {
+    path = "relative/path/to/terraform.tfstate"
+  }
+}
+`,
+		}, {
+			"consul",
+			consulBackend,
+			`terraform {
+  required_version = "~>0.13.0"
+  backend "consul" {
+    address   = "consul.example.com"
+    ca_file   = "ca_cert"
+    cert_file = "cert"
+    gzip      = true
+    key_file  = "key"
+    path      = "consul-terraform-sync/terraform"
+    scheme    = "https"
+  }
+}
+`,
+		}, {
+			"postgres",
+			map[string]interface{}{"pg": map[string]interface{}{
+				"conn_str": "postgres://user:pass@db.example.com/terraform_backend",
+			}},
+			`terraform {
+  required_version = "~>0.13.0"
+  backend "pg" {
+    conn_str = "postgres://user:pass@db.example.com/terraform_backend"
+  }
+}
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hclFile := hclwrite.NewEmptyFile()
+			body := hclFile.Body()
+
+			var backend *namedBlock
+			if tc.rawBackend != nil {
+				backend = newNamedBlock(tc.rawBackend)
+			}
+			appendRootTerraformBlock(body, backend, nil)
+
+			content := hclFile.Bytes()
+			content = hclwrite.Format(content)
+			assert.Equal(t, tc.expected, string(content))
+		})
+	}
+}


### PR DESCRIPTION
Enables usage of other Terraform backends for state store that support [workspaces](https://www.terraform.io/docs/state/workspaces.html) and state locking.

Tests capture testing the integration of passing through backend configuration to the generated root main.tf file. Validity of the backend configuration options are done at task execution time. Each backend were not tested directly to avoid testing Terraform functionality, but I did test the [postgres](https://www.terraform.io/docs/backends/types/pg.html) and came across a bug that prevents CTS from allowing it to be used with Terraform 0.13.

This PR does not allow usage of the pg backend since CTS is currently bounded to Terraform 0.13. However it will be accessible soon as we're looking to expand support for Terraform 0.14 (#127).