### PR TITLE
Capture data on process of updating network infrastructure in `Event`

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -27,6 +27,7 @@ type Controller interface {
 	Run(ctx context.Context) error
 }
 
+// Oncer describes the interface a controller that can run in once mode
 type Oncer interface {
 	Once(ctx context.Context) error
 }
@@ -36,6 +37,10 @@ type unit struct {
 	taskName string
 	driver   driver.Driver
 	template template
+
+	providers []string
+	services  []string
+	source    string
 }
 
 type baseController struct {
@@ -101,9 +106,12 @@ func (ctrl *baseController) init(ctx context.Context) error {
 		}
 
 		units = append(units, unit{
-			taskName: task.Name,
-			template: template,
-			driver:   d,
+			taskName:  task.Name,
+			template:  template,
+			driver:    d,
+			providers: task.ProviderNames(),
+			services:  task.ServiceNames(),
+			source:    task.Source,
 		})
 	}
 	ctrl.units = units

--- a/driver/task.go
+++ b/driver/task.go
@@ -28,6 +28,26 @@ type Task struct {
 	Version      string
 }
 
+// ProviderNames returns the list of providers that the task has configured
+func (t *Task) ProviderNames() []string {
+	names := make([]string, len(t.Providers))
+	for ix, p := range t.Providers {
+		for name := range p {
+			names[ix] = name
+		}
+	}
+	return names
+}
+
+// ServiceNames returns the list of services that the task has configured
+func (t *Task) ServiceNames() []string {
+	names := make([]string, len(t.Services))
+	for ix, s := range t.Services {
+		names[ix] = s.Name
+	}
+	return names
+}
+
 // clientConfig configures a driver client for a task
 type clientConfig struct {
 	task       Task

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -53,3 +53,71 @@ func TestNewClient(t *testing.T) {
 		})
 	}
 }
+
+func TestTask_ProviderNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		task     Task
+		expected []string
+	}{
+		{
+			"no provider",
+			Task{},
+			[]string{},
+		},
+		{
+			"happy path",
+			Task{
+				Providers: []map[string]interface{}{
+					{"local": map[string]interface{}{
+						"configs": "stuff",
+					}},
+					{"null": map[string]interface{}{}},
+				},
+			},
+			[]string{"local", "null"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.task.ProviderNames()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestTask_ServiceNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		task     Task
+		expected []string
+	}{
+		{
+			"no services",
+			Task{},
+			[]string{},
+		},
+		{
+			"happy path",
+			Task{
+				Services: []Service{
+					Service{Name: "web"},
+					Service{Name: "api"},
+				},
+			},
+			[]string{"web", "api"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.task.ServiceNames()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/event/event.go
+++ b/event/event.go
@@ -1,0 +1,83 @@
+package event
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-uuid"
+)
+
+// Event captures the series of actions that needs to happen to update network
+// infrastructure for a given task when it receives a service change from Consul.
+// An event should encompass: rendering the task’s templates, creating/updating
+// resources, and executing any handlers.
+type Event struct {
+	ID         string    `json:"id"`
+	Success    bool      `json:"success"`
+	StartTime  time.Time `json:"start_time"`
+	EndTime    time.Time `json:"end_time"`
+	TaskName   string    `json:"task_name"`
+	EventError *Error    `json:"error"`
+	Config     *Config   `json:"config"`
+}
+
+// Error captures an event's error information
+type Error struct {
+	// Code    string `json:"code"` TODO: future work
+	Message string `json:"message"`
+}
+
+// Config provides details on an event's task configuration
+type Config struct {
+	Providers []string `json:"providers"`
+	Services  []string `json:"services"`
+	Source    string   `json:"source"`
+}
+
+// NewEvent configures a new event with a task name and any relevant information
+// that the task is configured with
+func NewEvent(taskName string, config *Config) (*Event, error) {
+	if taskName == "" {
+		return nil, errors.New("error creating new event: taskname cannot be empty")
+	}
+	uuid, err := uuid.GenerateUUID()
+	if err != nil {
+		return nil, err
+	}
+	return &Event{
+		ID:       uuid,
+		TaskName: taskName,
+		Config:   config,
+	}, nil
+}
+
+// Start sets the start time on an event. Can only be called once.
+func (e *Event) Start() {
+	if !e.StartTime.IsZero() {
+		log.Printf("[WARN] (event) event already started. unable to restart")
+		return
+	}
+	e.StartTime = time.Now()
+}
+
+// End sets the end time and captures any end results e.g. error, success status.
+// Can only be called once
+func (e *Event) End(err error) {
+	if !e.EndTime.IsZero() {
+		log.Printf("[WARN] (event) event already ended. unable to re-end")
+		return
+	}
+
+	e.EndTime = time.Now()
+
+	if err == nil {
+		e.Success = true
+		return
+	}
+
+	e.Success = false
+	e.EventError = &Error{
+		Message: err.Error(),
+	}
+}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -1,0 +1,202 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ExampleEvent() {
+	examples := []struct {
+		name      string
+		taskName  string
+		expectErr bool
+	}{
+		{
+			"Event captures task erroring",
+			"task_fail",
+			true,
+		},
+		{
+			"Event captures task succeeding",
+			"task_success",
+			false,
+		},
+	}
+
+	for _, ex := range examples {
+		fmt.Println("\nExample:", ex.name)
+
+		func() (string, error) {
+			// setup capturing event
+			event, err := NewEvent(ex.taskName, nil)
+			if err != nil {
+				fmt.Println(err)
+				return "", err
+			}
+
+			// capture end result before returning function
+			defer func() {
+				event.End(err)
+				fmt.Println("Task Name:", event.TaskName)
+				fmt.Println("Success:", event.Success)
+				fmt.Println("Error:", event.EventError)
+			}()
+
+			// function body
+			ret, err := businessLogic(ex.expectErr)
+			if err != nil {
+				return "", err
+			}
+			return ret, nil
+		}()
+	}
+
+	// Output:
+	//
+	// Example: Event captures task erroring
+	// Task Name: task_fail
+	// Success: false
+	// Error: &{error}
+	//
+	// Example: Event captures task succeeding
+	// Task Name: task_success
+	// Success: true
+	// Error: <nil>
+}
+
+func TestNewEvent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		taskName  string
+		config    *Config
+		expectErr bool
+	}{
+		{
+			"happy path",
+			"task_a",
+			&Config{
+				Providers: []string{"local"},
+				Services:  []string{"web", "api"},
+				Source:    "/my-module",
+			},
+			false,
+		},
+		{
+			"nil config",
+			"task_b",
+			nil,
+			false,
+		},
+		{
+			"error: no taskname",
+			"",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event, err := NewEvent(tc.taskName, tc.config)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, event)
+				assert.Equal(t, tc.taskName, event.TaskName)
+				assertEqualConfig(t, tc.config, event.Config)
+			}
+		})
+	}
+}
+
+func TestEvent_Start(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+	}{
+		{
+			"happy path",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := &Event{}
+			event.Start()
+			assert.False(t, event.StartTime.IsZero())
+
+			// test that calling Start() again does not reset start time
+			firstStartTime := event.StartTime
+			event.Start()
+			assert.Equal(t, firstStartTime, event.StartTime)
+		})
+	}
+}
+
+func TestEvent_End(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			"task succeeded",
+			nil,
+		},
+		{
+			"task failed",
+			errors.New("error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			event := &Event{}
+			event.End(tc.err)
+
+			assert.False(t, event.EndTime.IsZero())
+			if tc.err == nil {
+				assert.True(t, event.Success)
+				assert.Nil(t, event.EventError)
+			} else {
+				assert.False(t, event.Success)
+				assert.NotNil(t, event.EventError)
+				assert.Equal(t, tc.err.Error(), event.EventError.Message)
+			}
+
+			// test that calling End() again does not reset end time
+			firstEndTime := event.EndTime
+			event.End(tc.err)
+			assert.Equal(t, firstEndTime, event.EndTime)
+		})
+	}
+}
+
+func businessLogic(expectError bool) (string, error) {
+	if expectError {
+		return "", errors.New("error")
+	}
+	return "mock", nil
+}
+
+func assertEqualConfig(t *testing.T, exp, act *Config) {
+	if exp == nil {
+		assert.Nil(t, act)
+		return
+	}
+	if act == nil {
+		assert.Nil(t, exp)
+		return
+	}
+	assert.Equal(t, exp.Providers, act.Providers)
+	assert.Equal(t, exp.Services, act.Services)
+	assert.Equal(t, exp.Source, act.Source)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/consul/sdk v0.5.0
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-syslog v1.0.0
+	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/hcat v0.0.0-20201015182053-2f8b92f7986a
 	github.com/hashicorp/hcl v1.0.0


### PR DESCRIPTION
First part in a series of changes to support a status api. This captures data in
an `Event` struct each time CTS goes through the process needed for updating
network infrastructure for a task. Future changes will store the event data and
return various aggregations of the data at the api endpoint

Changes
 - Create `event` package & structure
 - Consume event in controller checkApply()
 - Update `unit` with provider, service, and source in order to configure `event`
 - Update `Task` with ProviderNames() & ServicesNames to help configure `event`