### PR TITLE
Configurable Terraform version and v0.14 support

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -264,6 +264,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.Consul.TLS.Cert = String("")
 	expected.Consul.Transport.MaxIdleConns = Int(100)
 	expected.Driver.consul = expected.Consul
+	expected.Driver.Terraform.Version = String("")
 	expected.Driver.Terraform.PersistLog = Bool(false)
 	backend := expected.Driver.Terraform.Backend["consul"].(map[string]interface{})
 	backend["scheme"] = "https"

--- a/config/driver_test.go
+++ b/config/driver_test.go
@@ -151,6 +151,7 @@ func TestDriverConfig_Finalize(t *testing.T) {
 			&DriverConfig{},
 			&DriverConfig{
 				Terraform: &TerraformConfig{
+					Version:           String(""),
 					Log:               Bool(false),
 					PersistLog:        Bool(false),
 					Path:              String(wd),
@@ -169,6 +170,7 @@ func TestDriverConfig_Finalize(t *testing.T) {
 			},
 			&DriverConfig{
 				Terraform: &TerraformConfig{
+					Version:           String(""),
 					Log:               Bool(true),
 					PersistLog:        Bool(false),
 					Path:              String(wd),

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -263,7 +263,8 @@ func (c *TerraformConfig) Validate() error {
 
 		if !ctsVersion.TerraformConstraint.Check(v) {
 			return fmt.Errorf("Terraform version is not supported by Consul "+
-				"Terraform Sync, try updating to a newer version (>=0.13): %s", *c.Version)
+				"Terraform Sync, try updating to a different version (%s): %s",
+				ctsVersion.CompatibleTerraformVersionConstraint, *c.Version)
 		}
 	}
 

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -417,6 +417,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 			&TerraformConfig{},
 			nil,
 			&TerraformConfig{
+				Version:           String(""),
 				Log:               Bool(false),
 				PersistLog:        Bool(false),
 				Path:              String(wd),
@@ -430,6 +431,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 			&TerraformConfig{},
 			consul,
 			&TerraformConfig{
+				Version:    String(""),
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
@@ -455,6 +457,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				},
 			},
 			&TerraformConfig{
+				Version:    String(""),
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
@@ -481,6 +484,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				KVPath:  String("custom-path"),
 			},
 			&TerraformConfig{
+				Version:    String(""),
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
@@ -548,49 +552,6 @@ func TestTerraformConfig_Validate(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			err := tc.i.Validate()
 			if tc.isValid {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-			}
-		})
-	}
-}
-
-func TestTerraformConfig_CheckVersionCompatibility(t *testing.T) {
-	cases := []struct {
-		name       string
-		version    string
-		config     TerraformConfig
-		compatible bool
-	}{
-		{
-			"valid",
-			"0.13.2",
-			TerraformConfig{
-				Backend: make(map[string]interface{}),
-			},
-			true,
-		}, {
-			"pg backend compatible",
-			"0.14.0",
-			TerraformConfig{
-				Backend: map[string]interface{}{"pg": nil},
-			},
-			true,
-		}, {
-			"pg backend incompatible",
-			"0.13.5",
-			TerraformConfig{
-				Backend: map[string]interface{}{"pg": nil},
-			},
-			false,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.config.CheckVersionCompatibility(tc.version)
-			if tc.compatible {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -85,6 +85,30 @@ func TestTerraformConfig_Merge(t *testing.T) {
 			&TerraformConfig{},
 		},
 		{
+			"version_overrides",
+			&TerraformConfig{Version: String("version")},
+			&TerraformConfig{Version: String("")},
+			&TerraformConfig{Version: String("")},
+		},
+		{
+			"version_empty_one",
+			&TerraformConfig{Version: String("version")},
+			&TerraformConfig{},
+			&TerraformConfig{Version: String("version")},
+		},
+		{
+			"version_empty_two",
+			&TerraformConfig{},
+			&TerraformConfig{Version: String("version")},
+			&TerraformConfig{Version: String("version")},
+		},
+		{
+			"version_same",
+			&TerraformConfig{Version: String("version")},
+			&TerraformConfig{Version: String("version")},
+			&TerraformConfig{Version: String("version")},
+		},
+		{
 			"log_overrides",
 			&TerraformConfig{Log: Bool(false)},
 			&TerraformConfig{Log: Bool(true)},

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -115,13 +115,7 @@ func (ctrl *baseController) init(ctx context.Context) error {
 // InstallDriver installs necessary drivers based on user configuration.
 func InstallDriver(ctx context.Context, conf *config.Config) error {
 	if conf.Driver.Terraform != nil {
-		tfConf := *conf.Driver.Terraform
-		err := driver.InstallTerraform(ctx, *tfConf.Path, *tfConf.WorkingDir)
-		if err != nil {
-			return err
-		}
-
-		return tfConf.CheckVersionCompatibility(driver.TerraformVersion)
+		return driver.InstallTerraform(ctx, conf.Driver.Terraform)
 	}
 	return errors.New("unsupported driver")
 }

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -2,27 +2,32 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/consul-terraform-sync/version"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	ctsVersion "github.com/hashicorp/consul-terraform-sync/version"
 	"github.com/hashicorp/go-checkpoint"
 	goVersion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/hashicorp/terraform-exec/tfinstall"
 )
 
-const fallbackTFVersion = "0.13.2"
+const fallbackTFVersion = "0.13.5"
 
 // TerraformVersion is the version of Terraform CLI for the Terraform driver.
 var TerraformVersion string
 
 // InstallTerraform installs the Terraform binary to the configured path.
 // If an existing Terraform exists in the path, it is checked for compatibility.
-func InstallTerraform(ctx context.Context, path, workingDir string) error {
+func InstallTerraform(ctx context.Context, conf *config.TerraformConfig) error {
+	workingDir := *conf.WorkingDir
+	path := *conf.Path
+
 	if _, err := os.Stat(workingDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(workingDir, workingDirPerms); err != nil {
 			log.Printf("[ERR] (driver.terraform) error creating base work directory: %s", err)
@@ -31,7 +36,7 @@ func InstallTerraform(ctx context.Context, path, workingDir string) error {
 	}
 
 	if isTFInstalled(path) {
-		tfVersion, compatible, err := isTFCompatible(ctx, workingDir, path)
+		tfVersion, compatible, err := verifyInstalledTF(ctx, conf)
 		if err != nil {
 			if strings.Contains(err.Error(), "exec format error") {
 				return errIncompatibleTerraformBinary
@@ -52,7 +57,7 @@ func InstallTerraform(ctx context.Context, path, workingDir string) error {
 	}
 
 	log.Printf("[INFO] (driver.terraform) installing terraform to path '%s'", path)
-	version, err := installTerraform(ctx, path)
+	tfVersion, err := installTerraform(ctx, conf)
 	if err != nil {
 		log.Printf("[ERR] (driver.terraform) error installing terraform: %s", err)
 		return err
@@ -60,7 +65,7 @@ func InstallTerraform(ctx context.Context, path, workingDir string) error {
 	log.Printf("[INFO] (driver.terraform) successfully installed terraform")
 
 	// Set the global variable to the installed version
-	TerraformVersion = version
+	TerraformVersion = tfVersion.String()
 	return nil
 }
 
@@ -87,9 +92,12 @@ func isTFInstalled(tfPath string) bool {
 	return false
 }
 
-// isTFCompatible checks if the installed Terraform is compatible with the
+// verifyInstalledTF checks if the installed Terraform is compatible with the
 // current architecture and is valid within Sync version constraints.
-func isTFCompatible(ctx context.Context, workingDir, tfPath string) (*goVersion.Version, bool, error) {
+func verifyInstalledTF(ctx context.Context, conf *config.TerraformConfig) (*goVersion.Version, bool, error) {
+	workingDir := *conf.WorkingDir
+	tfPath := *conf.Path
+
 	// Verify version for existing terraform
 	tf, err := tfexec.NewTerraform(workingDir, filepath.Join(tfPath, "terraform"))
 	if err != nil {
@@ -105,54 +113,86 @@ func isTFCompatible(ctx context.Context, workingDir, tfPath string) (*goVersion.
 		return nil, false, err
 	}
 
-	if !version.TerraformConstraint.Check(tfVersion) {
+	if !ctsVersion.TerraformConstraint.Check(tfVersion) {
 		log.Printf("[ERR] (driver.terraform) Terraform found in path %s is "+
 			"version %q and does not satisfy the constraint %q.",
-			tfPath, tfVersion.String(), version.CompatibleTerraformVersionConstraint)
+			tfPath, tfVersion.String(), ctsVersion.CompatibleTerraformVersionConstraint)
 		return tfVersion, false, nil
+	}
+
+	if err := isTFCompatible(conf, tfVersion); err != nil {
+		return tfVersion, false, err
+	}
+
+	if conf.Version != nil && *conf.Version != tfVersion.String() {
+		log.Printf("[WARN] (driver.terraform) Terraform found in path %s is "+
+			"version %q and does not match the configured version %q. Remove the "+
+			"existing Terraform to install the selected version.",
+			tfPath, tfVersion.String(), *conf.Version)
 	}
 
 	return tfVersion, true, nil
 }
 
-// installTerraform attempts to install the latest version of Terraform into
-// the path. If the latest version is outside of the known supported range for
-//  Sync, the fall back version 0.13.2 is downloaded.
-func installTerraform(ctx context.Context, path string) (string, error) {
-	resp, err := checkpoint.Check(&checkpoint.CheckParams{Product: "terraform"})
-	if err != nil {
-		log.Printf("[ERR] (driver.terraform) error fetching Terraform versions "+
-			"from Checkpoint: %s", err)
-		return "", err
-	}
+// isTFCompatible checks compatibility of the version of Terraform with the
+// features of Consul Terraform Sync
+func isTFCompatible(conf *config.TerraformConfig, version *goVersion.Version) error {
+	// https://github.com/hashicorp/terraform/issues/23121
+	if _, ok := conf.Backend["pg"]; ok {
+		pgBackendConstraint, err := goVersion.NewConstraint(">= 0.14")
+		if err != nil {
+			return err
+		}
 
-	var v string
-	if resp.CurrentVersion == "" {
-		log.Printf("[WARN] (driver.terrform) could not determine latest version "+
-			"of terraform using checkpoint, fallback to version %s", fallbackTFVersion)
-		v = fallbackTFVersion
-	} else {
-		// Check if the latest version is within support range for Sync.
-		latest := goVersion.Must(goVersion.NewVersion(resp.CurrentVersion))
-		if version.TerraformConstraint.Check(latest) {
-			v = resp.CurrentVersion
-		} else {
-			// At this point we cannot guarantee compatibility for the latest
-			// Terraform version, so we will move forward with a safe fallback
-			// version.
-			v = fallbackTFVersion
+		if !pgBackendConstraint.Check(version) {
+			return fmt.Errorf("Consul-Terraform-Sync does not support pg "+
+				"backend in automation with Terraform <= 0.13: %s", version.String())
 		}
 	}
 
-	// Create path if doesn't already exist
-	os.MkdirAll(path, os.ModePerm)
+	return nil
+}
 
-	installedPath, err := tfinstall.ExactVersion(v, path).ExecPath(ctx)
-	if err != nil {
-		log.Printf("[ERR] (driver.terraform) error installing terraform")
-		return "", err
+// installTerraform attempts to install the latest version of Terraform into
+// the path. If the latest version is outside of the known supported range for
+//  Sync, the fall back version 0.13.5 is downloaded.
+func installTerraform(ctx context.Context, conf *config.TerraformConfig) (*goVersion.Version, error) {
+	var v *goVersion.Version
+	if conf.Version != nil && *conf.Version != "" {
+		v = goVersion.Must(goVersion.NewVersion(*conf.Version))
+	} else {
+		// Fetch the latest
+		resp, err := checkpoint.Check(&checkpoint.CheckParams{Product: "terraform"})
+		if err != nil {
+			log.Printf("[ERR] (driver.terraform) error fetching Terraform versions "+
+				"from Checkpoint: %s", err)
+		} else if resp.CurrentVersion != "" {
+			v = goVersion.Must(goVersion.NewVersion(resp.CurrentVersion))
+		}
+	}
+	if v == nil || !ctsVersion.TerraformConstraint.Check(v) {
+		// Configured version shouldn't be invalid our outside of the constraint at
+		// this point if the configuration was validated.
+		//
+		// At this point we cannot guarantee compatibility of the latest Terraform
+		// version, so we will move forward with a safe fallback version.
+		log.Printf("[WARN] (driver.terrform) could not determine latest version "+
+			"of terraform using checkpoint, fallback to version %s", fallbackTFVersion)
+		v = goVersion.Must(goVersion.NewVersion(fallbackTFVersion))
 	}
 
-	log.Printf("[DEBUG] (driver.terraform) successfully installed terraform %s: %s", v, installedPath)
+	if err := isTFCompatible(conf, v); err != nil {
+		return nil, err
+	}
+
+	// Create path if doesn't already exist
+	os.MkdirAll(*conf.Path, os.ModePerm)
+
+	installedPath, err := tfinstall.ExactVersion(v.String(), *conf.Path).ExecPath(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] (driver.terraform) successfully installed terraform %s: %s", v.String(), installedPath)
 	return v, nil
 }

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -124,7 +124,7 @@ func verifyInstalledTF(ctx context.Context, conf *config.TerraformConfig) (*goVe
 		return tfVersion, false, err
 	}
 
-	if conf.Version != nil && *conf.Version != tfVersion.String() {
+	if *conf.Version != "" && *conf.Version != tfVersion.String() {
 		log.Printf("[WARN] (driver.terraform) Terraform found in path %s is "+
 			"version %q and does not match the configured version %q. Remove the "+
 			"existing Terraform to install the selected version.",

--- a/driver/terraform_download_test.go
+++ b/driver/terraform_download_test.go
@@ -1,0 +1,52 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTFCompatible(t *testing.T) {
+	cases := []struct {
+		name       string
+		version    *version.Version
+		config     *config.TerraformConfig
+		compatible bool
+	}{
+		{
+			"valid",
+			version.Must(version.NewSemver("0.13.2")),
+			&config.TerraformConfig{
+				Backend: make(map[string]interface{}),
+			},
+			true,
+		}, {
+			"pg backend compatible",
+			version.Must(version.NewSemver("0.14.0")),
+			&config.TerraformConfig{
+				Backend: map[string]interface{}{"pg": nil},
+			},
+			true,
+		}, {
+			"pg backend incompatible",
+			version.Must(version.NewSemver("0.13.5")),
+			&config.TerraformConfig{
+				Backend: map[string]interface{}{"pg": nil},
+			},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isTFCompatible(tc.config, tc.version)
+			if tc.compatible {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/examples/sync-tasks/my-task/main.tf
+++ b/examples/sync-tasks/my-task/main.tf
@@ -5,7 +5,7 @@
 # may not be preserved and could be clobbered by a subsequent update.
 
 terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   required_providers {
     myprovider = {
       source  = "namespace/myprovider"

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/hashicorp/consul-terraform-sync/version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -19,7 +20,7 @@ const (
 	// TerraformRequiredVersion is the version constraint pinned to the generated
 	// root module to ensure compatibility across Sync, Terraform, and
 	// modules.
-	TerraformRequiredVersion = "~>0.13.0"
+	TerraformRequiredVersion = version.CompatibleTerraformVersionConstraint
 
 	// RootFilename is the file name for the root module.
 	RootFilename = "main.tf"

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -30,14 +30,14 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"nil",
 			nil,
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
 }
 `,
 		}, {
 			"empty",
 			map[string]interface{}{"empty": map[string]interface{}{}},
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   backend "empty" {
   }
 }
@@ -46,7 +46,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"invalid structure",
 			map[string]interface{}{"invalid": "unexpected type"},
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
 }
 `,
 		}, {
@@ -55,7 +55,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"path": "relative/path/to/terraform.tfstate",
 			}},
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   backend "local" {
     path = "relative/path/to/terraform.tfstate"
   }
@@ -65,7 +65,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"consul",
 			consulBackend,
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   backend "consul" {
     address   = "consul.example.com"
     ca_file   = "ca_cert"
@@ -83,7 +83,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"conn_str": "postgres://user:pass@db.example.com/terraform_backend",
 			}},
 			`terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   backend "pg" {
     conn_str = "postgres://user:pass@db.example.com/terraform_backend"
   }

--- a/templates/tftmpl/testdata/main.tf
+++ b/templates/tftmpl/testdata/main.tf
@@ -5,7 +5,7 @@
 # may not be preserved and could be overwritten by a subsequent update.
 
 terraform {
-  required_version = "~>0.13.0"
+  required_version = ">= 0.13.0, < 0.15"
   required_providers {
     testProvider = {
       source  = "namespace/testProvider"

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -15,6 +15,8 @@ import (
 // and enhancements between versions.
 const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 0.15"
 
+// TerraformConstraint is the go-version constraint variable for
+// CompatibleTerraformVersionConstraint
 var TerraformConstraint version.Constraints
 
 func init() {

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const CompatibleTerraformVersionConstraint = ">=0.13.0,<0.15"
+const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 0.15"
 
 var TerraformConstraint version.Constraints
 

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -6,6 +6,13 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+// CompatibleTerraformVersionConstraint is the version constraint
+// imposed for running Terraform in automation with CTS. This is
+// currently upward bounded to prevent using newer versions of
+// Terraform that may introduce breaking changes CTS currently does not
+// account for. The upper bound may be removed once CTS has protocols
+// set in place for compatible modules and can handle Terraform syntax changes
+// and enhancements between versions.
 const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 0.15"
 
 var TerraformConstraint version.Constraints

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const CompatibleTerraformVersionConstraint = ">=0.13.0"
+const CompatibleTerraformVersionConstraint = ">=0.13.0,<0.15"
 
 var TerraformConstraint version.Constraints
 

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
-const CompatibleTerraformVersionConstraint = "~>0.13.0"
+const CompatibleTerraformVersionConstraint = ">=0.13.0"
 
 var TerraformConstraint version.Constraints
 

--- a/version/terraform_test.go
+++ b/version/terraform_test.go
@@ -1,0 +1,46 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformConstraint(t *testing.T) {
+	testCases := []struct {
+		name      string
+		version   string
+		supported bool
+	}{
+		{
+			"valid 0.13",
+			"0.13.5",
+			true,
+		}, {
+			"valid 0.14",
+			"0.14.1",
+			true,
+		}, {
+			"invalid lower bound",
+			"0.12.12",
+			false,
+		}, {
+			"invalid upper bound",
+			"0.15.2",
+			false,
+		}, {
+			"unsupported beta release",
+			"0.14.0-beta1",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := version.Must(version.NewSemver(tc.version))
+			supported := TerraformConstraint.Check(v)
+			assert.Equal(t, tc.supported, supported, tc.version)
+		})
+	}
+}


### PR DESCRIPTION
I did a first pass at reading through the [Terraform 0.14 changelog](https://github.com/hashicorp/terraform/blob/v0.14/CHANGELOG.md) and did preliminary tests with changing versions with existing tasks. Nothing strikes me as breaking changes with regards to CTS usage of Terraform.

## Changes
* Adds configuration option to select Terraform version
  * Configured version mismatch with existing TF in path will skip installation and use the existing one. If users choose to update TF versions, they will need to resolve this manually by removing the existing version first.

  ```hcl
  driver "terraform" {
    version = "0.13.5"
  }
  ```

* Allows CTS to run Terraform 0.14 in automation (when released).
  * Prereleases are incompatible with CTS (alpha, beta, etc), e.g. the current 0.14-beta2 cannot be ran in automation with CTS

## Improvements
* Validates Terraform version is compatible before installing per https://github.com/hashicorp/consul-terraform-sync/pull/129#discussion_r513704441

## Caveats
* Upgrading from 0.13 to 0.14 for existing tasks will work seamlessly, seems like providers and modules will be reinstalled due to slight difference in dependency management.
* Downgrading from 0.14 to 0.13 for existing tasks will result in an error due to differences in state snapshots and requires manual resolving.
* CTS running Terraform 0.13 with modules containing 0.14 syntax will defer to the Terraform handling of unsupported/new syntax.
* I kept the minor version bounded to 0.13 - 0.14 until we can design a protocol for CTS to version the generated root module and integration modules. This is needed before Terraform releases a new version with breaking changes (like 0.12 to 0.13)
* Users will need to run the Terraform version that is within range across all modules until CTS is smarter about detecting required TF versions across modules 
* Suggestion for module authors to add a Terraform version constraint within the module if newer syntax is used.

Resolves #127