### PR TITLE
Pull in hcat bug fix on Consul connect timeouts

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -57,10 +57,13 @@ func newBaseController(conf *config.Config) (*baseController, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	log.Printf("[INFO] (ctrl) initializing Consul client and testing connection")
 	watcher, err := newWatcher(conf)
 	if err != nil {
 		return nil, err
 	}
+
 	return &baseController{
 		conf:       conf,
 		newDriver:  nd,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20201015182053-2f8b92f7986a
+	github.com/hashicorp/hcat v0.0.0-20201102235459-09d8cd851630
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20201015182053-2f8b92f7986a h1:EKlyS6TZYOeN4QMF2ViZfRYgb5HIp/jDAdgucR8R7Aw=
-github.com/hashicorp/hcat v0.0.0-20201015182053-2f8b92f7986a/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
+github.com/hashicorp/hcat v0.0.0-20201102235459-09d8cd851630 h1:G2tn+rLFEtxN+2Ibk3vDZ+7Kxc+VtNOg9Lu8v6URr6o=
+github.com/hashicorp/hcat v0.0.0-20201102235459-09d8cd851630/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/templates/tftmpl/template_funcs.go
+++ b/templates/tftmpl/template_funcs.go
@@ -4,12 +4,16 @@ import (
 	"strings"
 
 	"github.com/hashicorp/hcat/dep"
+	"github.com/hashicorp/hcat/tfunc"
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )
 
 // HCLTmplFuncMap are template functions for rendering HCL
 var HCLTmplFuncMap = map[string]interface{}{
+	"indent":   tfunc.Helpers()["indent"],
+	"subtract": tfunc.Math()["subtract"],
+
 	"joinStrings": joinStringsFunc,
 	"HCLService":  hclServiceFunc,
 }


### PR DESCRIPTION
The changes fixes the case where CTS would hang indefinitely when
running on a machine with DNS issues that cause timeouts while
connecting to Consul. Added a log line to provide users context
about attempting Consul connection for easier debugging connection
issues instead of hanging silently.

Context: https://github.com/hashicorp/hcat/issues/23