### PR TITLE
Store event data

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/event"
+	"github.com/hashicorp/hcat"
 )
 
 var _ Controller = (*ReadWrite)(nil)
@@ -15,16 +16,20 @@ var _ Controller = (*ReadWrite)(nil)
 // ReadWrite is the controller to run in read-write mode
 type ReadWrite struct {
 	*baseController
+	store *event.Store
 }
 
 // NewReadWrite configures and initializes a new ReadWrite controller
-func NewReadWrite(conf *config.Config) (Controller, error) {
+func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 	baseCtrl, err := newBaseController(conf)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ReadWrite{baseController: baseCtrl}, nil
+	return &ReadWrite{
+		baseController: baseCtrl,
+		store:          store,
+	}, nil
 }
 
 // Init initializes the controller before it can be run. Ensures that
@@ -149,7 +154,11 @@ func (rw *ReadWrite) checkApply(ctx context.Context, u unit) (bool, error) {
 		return false, fmt.Errorf("error creating event for task %s: %s",
 			taskName, err)
 	}
-	defer ev.End(err)
+	defer func() {
+		ev.End(err)
+		log.Printf("[TRACE] (ctrl) adding event %s", ev.GoString())
+		err = rw.store.Add(ev)
+	}()
 
 	// result.Complete is only `true` if the template has new data that has been
 	// completely fetched. Rendering a template for the first time may take several
@@ -157,7 +166,8 @@ func (rw *ReadWrite) checkApply(ctx context.Context, u unit) (bool, error) {
 	if result.Complete {
 		log.Printf("[DEBUG] (ctrl) change detected for task %s", taskName)
 		ev.Start()
-		rendered, err := tmpl.Render(result.Contents)
+		var rendered hcat.RenderResult
+		rendered, err = tmpl.Render(result.Contents)
 		if err != nil {
 			return false, fmt.Errorf("error rendering template for task %s: %s",
 				taskName, err)

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -157,7 +157,7 @@ func (rw *ReadWrite) checkApply(ctx context.Context, u unit) (bool, error) {
 	defer func() {
 		ev.End(err)
 		log.Printf("[TRACE] (ctrl) adding event %s", ev.GoString())
-		err = rw.store.Add(ev)
+		err = rw.store.Add(*ev)
 	}()
 
 	// result.Complete is only `true` if the template has new data that has been

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -119,7 +119,6 @@ func TestReadWrite_CheckApply(t *testing.T) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.name)
 				assert.False(t, event.Success)
-				fmt.Println(event)
 				assert.NotNil(t, event.EventError.Message)
 				assert.Contains(t, event.EventError.Message, tc.name)
 			} else {

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/handler"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/controller"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
@@ -27,7 +28,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 		resolverRunErr    error
 		templateRenderErr error
 		taskName          string
-		config            *config.Config
+		addToStore        bool
 	}{
 		{
 			"error on resolver.Run()",
@@ -36,7 +37,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			errors.New("error on resolver.Run()"),
 			nil,
 			"task_apply",
-			singleTaskConfig(),
+			false,
 		},
 		{
 			"error on driver.ApplyTask()",
@@ -45,7 +46,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			nil,
 			nil,
 			"task_apply",
-			singleTaskConfig(),
+			true,
 		},
 		{
 			"error on template.Render()",
@@ -54,7 +55,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			nil,
 			errors.New("error on template.Render()"),
 			"task_apply",
-			singleTaskConfig(),
+			true,
 		},
 		{
 			"error creating new event",
@@ -63,7 +64,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			nil,
 			nil,
 			"",
-			singleTaskConfig(),
+			false,
 		},
 		{
 			"happy path",
@@ -72,7 +73,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			nil,
 			nil,
 			"task_apply",
-			singleTaskConfig(),
+			true,
 		},
 	}
 
@@ -89,22 +90,82 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			d := new(mocksD.Driver)
 			d.On("ApplyTask", mock.Anything).Return(tc.applyTaskErr)
 
-			controller := ReadWrite{baseController: &baseController{
-				resolver: r,
-			}}
+			controller := ReadWrite{
+				baseController: &baseController{
+					resolver: r,
+				},
+				store: event.NewStore(),
+			}
 			u := unit{taskName: tc.taskName, template: tmpl, driver: d}
 			ctx := context.Background()
 
 			_, err := controller.checkApply(ctx, u)
-			if tc.expectError {
-				if assert.Error(t, err) {
-					assert.Contains(t, err.Error(), tc.name)
-				}
+			events := controller.store.Read(tc.taskName)
+
+			if !tc.addToStore {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.name)
+				assert.Equal(t, 0, len(events))
 				return
 			}
-			assert.NoError(t, err)
+
+			assert.Equal(t, 1, len(events))
+			event := events[0]
+			assert.Equal(t, tc.taskName, event.TaskName)
+			assert.False(t, event.StartTime.IsZero())
+			assert.False(t, event.EndTime.IsZero())
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.name)
+				assert.False(t, event.Success)
+				fmt.Println(event)
+				assert.NotNil(t, event.EventError.Message)
+				assert.Contains(t, event.EventError.Message, tc.name)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, event.Success)
+			}
 		})
 	}
+}
+
+func TestReadWrite_CheckApply_Store(t *testing.T) {
+	t.Run("mult-checkapply-store", func(t *testing.T) {
+		tmpl := new(mocks.Template)
+		tmpl.On("Render", mock.Anything).Return(hcat.RenderResult{}, nil)
+
+		r := new(mocks.Resolver)
+		r.On("Run", mock.Anything, mock.Anything).
+			Return(hcat.ResolveEvent{Complete: true}, nil)
+
+		d := new(mocksD.Driver)
+		d.On("ApplyTask", mock.Anything).Return(nil)
+
+		controller := ReadWrite{
+			baseController: &baseController{
+				resolver: r,
+			},
+			store: event.NewStore(),
+		}
+
+		unitA := unit{taskName: "task_a", template: tmpl, driver: d}
+		unitB := unit{taskName: "task_b", template: tmpl, driver: d}
+		ctx := context.Background()
+
+		controller.checkApply(ctx, unitA)
+		controller.checkApply(ctx, unitB)
+		controller.checkApply(ctx, unitA)
+		controller.checkApply(ctx, unitA)
+		controller.checkApply(ctx, unitA)
+		controller.checkApply(ctx, unitB)
+
+		eventsA := controller.store.Read("task_a")
+		eventsB := controller.store.Read("task_b")
+
+		assert.Equal(t, 4, len(eventsA))
+		assert.Equal(t, 2, len(eventsB))
+	})
 }
 
 func TestOnce(t *testing.T) {
@@ -134,15 +195,18 @@ func TestOnce(t *testing.T) {
 		d.On("InitTask", mock.Anything).Return(nil).Once()
 		d.On("ApplyTask", mock.Anything).Return(nil).Once()
 
-		rw := &ReadWrite{baseController: &baseController{
-			watcher:  w,
-			resolver: r,
-			newDriver: func(*config.Config, driver.Task) (driver.Driver, error) {
-				return d, nil
+		rw := &ReadWrite{
+			baseController: &baseController{
+				watcher:  w,
+				resolver: r,
+				newDriver: func(*config.Config, driver.Task) (driver.Driver, error) {
+					return d, nil
+				},
+				conf:       conf,
+				fileReader: func(string) ([]byte, error) { return []byte{}, nil },
 			},
-			conf:       conf,
-			fileReader: func(string) ([]byte, error) { return []byte{}, nil },
-		}}
+			store: event.NewStore(),
+		}
 
 		ctx := context.Background()
 		err := rw.Init(ctx)
@@ -196,11 +260,14 @@ func TestReadWriteUnits(t *testing.T) {
 		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
 
 		u := unit{taskName: "foo", template: tmpl, driver: d}
-		controller := ReadWrite{baseController: &baseController{
-			watcher:  w,
-			resolver: r,
-			units:    []unit{u},
-		}}
+		controller := ReadWrite{
+			baseController: &baseController{
+				watcher:  w,
+				resolver: r,
+				units:    []unit{u},
+			},
+			store: event.NewStore(),
+		}
 
 		ctx := context.Background()
 		errCh := controller.runUnits(ctx)
@@ -216,11 +283,14 @@ func TestReadWriteUnits(t *testing.T) {
 		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
 
 		u := unit{taskName: "foo", template: tmpl, driver: d}
-		controller := ReadWrite{baseController: &baseController{
-			watcher:  w,
-			resolver: r,
-			units:    []unit{u},
-		}}
+		controller := ReadWrite{
+			baseController: &baseController{
+				watcher:  w,
+				resolver: r,
+				units:    []unit{u},
+			},
+			store: event.NewStore(),
+		}
 
 		ctx := context.Background()
 		errCh := controller.runUnits(ctx)
@@ -238,10 +308,13 @@ func TestReadWriteRun_context_cancel(t *testing.T) {
 	w.On("WaitCh", mock.Anything, mock.Anything).Return(nil).
 		On("Stop").Return()
 
-	ctl := ReadWrite{baseController: &baseController{
-		units:   []unit{},
-		watcher: w,
-	}}
+	ctl := ReadWrite{
+		baseController: &baseController{
+			units:   []unit{},
+			watcher: w,
+		},
+		store: event.NewStore(),
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)

--- a/event/event.go
+++ b/event/event.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -80,4 +81,29 @@ func (e *Event) End(err error) {
 	e.EventError = &Error{
 		Message: err.Error(),
 	}
+}
+
+// GoString defines the printable version of this struct.
+func (e *Event) GoString() string {
+	if e == nil {
+		return "(*Event)(nil)"
+	}
+
+	return fmt.Sprintf("&Event{"+
+		"ID:%s, "+
+		"TaskName:%s, "+
+		"Success:%t, "+
+		"StartTime:%s, "+
+		"EndTime:%s, "+
+		"EventError:%s, "+
+		"Config:%s, "+
+		"}",
+		e.ID,
+		e.TaskName,
+		e.Success,
+		e.StartTime,
+		e.EndTime,
+		e.EventError,
+		e.Config,
+	)
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -187,6 +187,50 @@ func businessLogic(expectError bool) (string, error) {
 	return "mock", nil
 }
 
+func TestEvent_GoString(t *testing.T) {
+	cases := []struct {
+		name  string
+		event *Event
+	}{
+		{
+			"nil event",
+			nil,
+		},
+		{
+			"happy path",
+			&Event{
+				ID:       "123",
+				TaskName: "happy",
+				Success:  false,
+				EventError: &Error{
+					Message: "error!",
+				},
+				Config: &Config{
+					Providers: []string{"local"},
+					Services:  []string{"web", "api"},
+					Source:    "/my-module",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.event == nil {
+				assert.Contains(t, tc.event.GoString(), "nil")
+				return
+			}
+
+			assert.Contains(t, tc.event.GoString(), "&Event")
+			assert.Contains(t, tc.event.GoString(), tc.event.ID)
+			assert.Contains(t, tc.event.GoString(), tc.event.TaskName)
+			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%t", tc.event.Success))
+			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%s", tc.event.EventError))
+			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%s", tc.event.Config))
+		})
+	}
+}
+
 func assertEqualConfig(t *testing.T, exp, act *Config) {
 	if exp == nil {
 		assert.Nil(t, act)

--- a/event/store.go
+++ b/event/store.go
@@ -1,0 +1,60 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+const defaultEventCountLimit = 5
+
+// Store stores events
+type Store struct {
+	*sync.RWMutex
+
+	events map[string][]*Event // taskname => events
+	limit  int
+}
+
+// NewStore returns a new store
+func NewStore() *Store {
+	return &Store{
+		RWMutex: &sync.RWMutex{},
+		events:  make(map[string][]*Event),
+		limit:   defaultEventCountLimit,
+	}
+}
+
+// Add adds an event and manages the limit of number of events stored per task.
+func (s *Store) Add(e *Event) error {
+	if e == nil {
+		return errors.New("error adding event: nil event")
+	}
+	if e.TaskName == "" {
+		return fmt.Errorf("error adding event: taskname cannot be empty %s", e.GoString())
+	}
+
+	s.Lock()
+	defer s.Unlock()
+
+	events := s.events[e.TaskName]
+	events = append([]*Event{e}, events...) // prepend
+	if len(events) > s.limit {
+		events = events[:len(events)-1]
+	}
+	s.events[e.TaskName] = events
+	return nil
+}
+
+// Read returns events given a task name. Returned events are ordered by
+// decending end time
+func (s *Store) Read(taskName string) []Event {
+	s.RLock()
+	defer s.RUnlock()
+
+	events := make([]Event, len(s.events[taskName]))
+	for ix, event := range s.events[taskName] {
+		events[ix] = *event
+	}
+	return events
+}

--- a/event/store_test.go
+++ b/event/store_test.go
@@ -1,0 +1,105 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStore_Add(t *testing.T) {
+	cases := []struct {
+		name      string
+		event     *Event
+		expectErr bool
+	}{
+		{
+			"happy path",
+			&Event{TaskName: "happy"},
+			false,
+		},
+		{
+			"error: no taskname",
+			&Event{},
+			true,
+		},
+		{
+			"nil even",
+			nil,
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewStore()
+			err := store.Add(tc.event)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				events := store.events[tc.event.TaskName]
+				assert.Equal(t, 1, len(events))
+				event := events[0]
+				assert.Equal(t, tc.event, event)
+			}
+		})
+	}
+
+	t.Run("limit-and-order", func(t *testing.T) {
+		store := NewStore()
+		store.limit = 2
+
+		// fill store
+		store.Add(&Event{ID: "1", TaskName: "task"})
+		assert.Equal(t, 1, len(store.events["task"]))
+
+		store.Add(&Event{ID: "2", TaskName: "task"})
+		assert.Equal(t, 2, len(store.events["task"]))
+
+		// check store did not grow beyond limit
+		store.Add(&Event{ID: "3", TaskName: "task"})
+		assert.Equal(t, 2, len(store.events["task"]))
+
+		// confirm events in store
+		event3 := store.events["task"][0]
+		assert.Equal(t, "3", event3.ID)
+		event2 := store.events["task"][1]
+		assert.Equal(t, "2", event2.ID)
+	})
+}
+
+func TestStore_Read(t *testing.T) {
+	cases := []struct {
+		name     string
+		values   []*Event
+		expected []Event
+	}{
+		{
+			"no events",
+			[]*Event{},
+			[]Event{},
+		},
+		{
+			"multiple events",
+			[]*Event{
+				&Event{TaskName: "1"},
+				&Event{TaskName: "2"},
+				&Event{TaskName: "3"},
+			},
+			[]Event{
+				Event{TaskName: "1"},
+				Event{TaskName: "2"},
+				Event{TaskName: "3"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := NewStore()
+			store.events["key"] = tc.values
+
+			actual := store.Read("key")
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/event/store_test.go
+++ b/event/store_test.go
@@ -9,22 +9,17 @@ import (
 func TestStore_Add(t *testing.T) {
 	cases := []struct {
 		name      string
-		event     *Event
+		event     Event
 		expectErr bool
 	}{
 		{
 			"happy path",
-			&Event{TaskName: "happy"},
+			Event{TaskName: "happy"},
 			false,
 		},
 		{
 			"error: no taskname",
-			&Event{},
-			true,
-		},
-		{
-			"nil even",
-			nil,
+			Event{},
 			true,
 		},
 	}
@@ -39,7 +34,7 @@ func TestStore_Add(t *testing.T) {
 				events := store.events[tc.event.TaskName]
 				assert.Equal(t, 1, len(events))
 				event := events[0]
-				assert.Equal(t, tc.event, event)
+				assert.Equal(t, tc.event, *event)
 			}
 		})
 	}
@@ -49,14 +44,14 @@ func TestStore_Add(t *testing.T) {
 		store.limit = 2
 
 		// fill store
-		store.Add(&Event{ID: "1", TaskName: "task"})
+		store.Add(Event{ID: "1", TaskName: "task"})
 		assert.Equal(t, 1, len(store.events["task"]))
 
-		store.Add(&Event{ID: "2", TaskName: "task"})
+		store.Add(Event{ID: "2", TaskName: "task"})
 		assert.Equal(t, 2, len(store.events["task"]))
 
 		// check store did not grow beyond limit
-		store.Add(&Event{ID: "3", TaskName: "task"})
+		store.Add(Event{ID: "3", TaskName: "task"})
 		assert.Equal(t, 2, len(store.events["task"]))
 
 		// confirm events in store

--- a/main.go
+++ b/main.go
@@ -1,8 +1,13 @@
 package main
 
-import "os"
+import (
+	"os"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+)
 
 func main() {
-	cli := NewCLI(os.Stdout, os.Stderr)
+	store := event.NewStore()
+	cli := NewCLI(os.Stdout, os.Stderr, store)
 	os.Exit(cli.Run(os.Args))
 }


### PR DESCRIPTION
Second part in a series of changes to support a status api. This stores event
data in memory when running in daemon mode. Future changes will return
aggregations of the stored events at the api endpoint.

Changes
 - Create `store` struct with ability to add and read
 - Update readwrite controller (+ tests) with a `store` field
 - Store events that are crated in checkApply()