### PR TITLE
Add basic task status endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+)
+
+const (
+	defaultAPIVersion = "v1"
+
+	statusHealthy      = "healthy"
+	statusDegraded     = "degraded"
+	statusCritical     = "critical"
+	statusUndetermined = "undetermined"
+)
+
+// API supports api requests to the cts biniary
+type API struct {
+	store   *event.Store
+	port    int
+	version string
+}
+
+// NewAPI create a new API object
+func NewAPI(store *event.Store, port int) *API {
+	return &API{
+		port:    port,
+		store:   store,
+		version: defaultAPIVersion,
+	}
+}
+
+// Serve starts up and handles shutdown for the http server to serve
+// API requests
+func (api *API) Serve(ctx context.Context) {
+	mux := http.NewServeMux()
+
+	// retrieve task status for a task-name
+	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskStatusPath),
+		newTaskStatusHandler(api.store, api.version))
+	// retrieve all task statuses
+	mux.Handle(fmt.Sprintf("/%s/%s", defaultAPIVersion, taskStatusPath),
+		newTaskStatusHandler(api.store, api.version))
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", api.port),
+		WriteTimeout: time.Second * 15,
+		ReadTimeout:  time.Second * 15,
+		IdleTimeout:  time.Second * 60,
+		Handler:      mux,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			// go ahead and stop cts from continuing
+			log.Fatalf("error starting api server at '%d': '%s'\n", api.port, err)
+		}
+	}()
+
+	log.Printf("[INFO] (api) server started at port %d", api.port)
+
+	ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				log.Printf("[INFO] (api) stopping api server")
+				if err := srv.Shutdown(ctxShutDown); err != nil {
+					log.Printf("[ERROR] (api) error stopping api server: '%s'", err)
+				}
+				cancel()
+				return
+			}
+		}
+	}()
+}
+
+// jsonResponse adds the return response for handlers
+func jsonResponse(w http.ResponseWriter, code int, response interface{}) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(response)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+)
+
+func TestServe(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		path       string
+		statusCode int
+	}{
+		{
+			"overall status TODO",
+			"status",
+			http.StatusNotFound,
+		},
+		{
+			"task status: all",
+			"status/tasks",
+			http.StatusOK,
+		},
+		{
+			"task status: single",
+			"status/tasks/task_b",
+			http.StatusOK,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer ctx.Done()
+	defer cancel()
+
+	// find a free port
+	listener, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+
+	api := NewAPI(event.NewStore(), port)
+	go api.Serve(ctx)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := fmt.Sprintf("http://localhost:%d/%s/%s",
+				port, defaultAPIVersion, tc.path)
+
+			resp, err := http.Get(u)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, tc.statusCode, resp.StatusCode)
+		})
+	}
+}

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+)
+
+const taskStatusPath = "status/tasks"
+
+// TaskStatus is the status for a single task
+type TaskStatus struct {
+	TaskName  string   `json:"task_name"`
+	Status    string   `json:"status"`
+	Providers []string `json:"providers"`
+	Services  []string `json:"services"`
+	EventsURL string   `json:"events_url"`
+}
+
+// taskStatusHandler handles the task status endpoint
+type taskStatusHandler struct {
+	store   *event.Store
+	version string
+}
+
+// newTaskStatusHandler returns a new TaskStatusHandler
+func newTaskStatusHandler(store *event.Store, version string) *taskStatusHandler {
+	return &taskStatusHandler{
+		store:   store,
+		version: version,
+	}
+}
+
+// ServeHTTP serves the task status endpoint which returns a map of taskname to
+// task status
+func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[TRACE] (api.taskstatus) requesting task status '%s'", r.URL.Path)
+
+	taskName, err := getTaskName(r.URL.Path, h.version)
+	if err != nil {
+		log.Printf("[TRACE] (api.taskstatus) bad request: '%s'", err)
+		jsonResponse(w, http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	data := h.store.Read(taskName)
+	statuses := make(map[string]TaskStatus)
+	for taskName, events := range data {
+		statuses[taskName] = makeTaskStatus(taskName, events, h.version)
+	}
+
+	jsonResponse(w, http.StatusOK, statuses)
+}
+
+// getTaskName retrieves the taskname from the url. Returns empty string if no
+// taskname is specified
+func getTaskName(path, version string) (string, error) {
+	taskPathNoID := fmt.Sprintf("/%s/%s", version, taskStatusPath)
+	if path == taskPathNoID {
+		return "", nil
+	}
+
+	taskPathWithID := taskPathNoID + "/"
+	taskName := strings.TrimPrefix(path, taskPathWithID)
+	if invalid := strings.ContainsRune(taskName, '/'); invalid {
+		return "", fmt.Errorf("unsupported path '%s'. request must be format "+
+			"'/status/tasks/{task-name}'. task name cannot have '/ ' and api "+
+			"does not support further resources", path)
+	}
+
+	return taskName, nil
+}
+
+// makeTaskStatus takes event data for a task and returns an overall task status
+func makeTaskStatus(taskName string, events []event.Event, version string) TaskStatus {
+	successes := make([]bool, len(events))
+	uniqProviders := make(map[string]bool)
+	uniqServices := make(map[string]bool)
+
+	for i, event := range events {
+		successes[i] = event.Success
+		if event.Config == nil {
+			continue
+		}
+		for _, p := range event.Config.Providers {
+			uniqProviders[p] = true
+		}
+		for _, s := range event.Config.Services {
+			uniqServices[s] = true
+		}
+	}
+
+	return TaskStatus{
+		TaskName:  taskName,
+		Status:    successToStatus(successes),
+		Providers: mapKeyToArray(uniqProviders),
+		Services:  mapKeyToArray(uniqServices),
+		EventsURL: makeEventsURL(events, version, taskName),
+	}
+}
+
+// mapKeyToArray returns an array of map keys
+func mapKeyToArray(m map[string]bool) []string {
+	arr := make([]string, len(m))
+	ix := 0
+	for k := range m {
+		arr[ix] = k
+		ix++
+	}
+	return arr
+}
+
+// successToStatus determines a status from an array of success/failures
+func successToStatus(successes []bool) string {
+	if len(successes) == 0 {
+		return statusUndetermined
+	}
+
+	total := len(successes)
+	mostRecentSuccess := successes[0]
+	successCount := 0
+	for _, s := range successes {
+		if s {
+			successCount++
+		}
+	}
+
+	percentSuccess := 100 * successCount / total
+	switch {
+	case percentSuccess == 100:
+		return statusHealthy
+	case percentSuccess > 50:
+		return statusDegraded
+	case mostRecentSuccess == true:
+		return statusDegraded
+	default:
+		return statusCritical
+	}
+}
+
+// makeEventsURL returns an events URL for a task. Returns an empty string
+// if the task has no events i.e. no events to look into
+func makeEventsURL(events []event.Event, version, taskName string) string {
+	if len(events) == 0 {
+		return ""
+	}
+
+	return fmt.Sprintf("/%s/%s/%s?include=events",
+		version, taskStatusPath, taskName)
+}

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -41,7 +41,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	taskName, err := getTaskName(r.URL.Path, h.version)
 	if err != nil {
-		log.Printf("[TRACE] (api.taskstatus) bad request: '%s'", err)
+		log.Printf("[TRACE] (api.taskstatus) bad request: %s", err)
 		jsonResponse(w, http.StatusBadRequest, map[string]string{
 			"error": err.Error(),
 		})
@@ -118,7 +118,7 @@ func mapKeyToArray(m map[string]bool) []string {
 // successToStatus determines a status from an array of success/failures
 func successToStatus(successes []bool) string {
 	if len(successes) == 0 {
-		return statusUndetermined
+		return StatusUndetermined
 	}
 
 	total := len(successes)
@@ -133,13 +133,13 @@ func successToStatus(successes []bool) string {
 	percentSuccess := 100 * successCount / total
 	switch {
 	case percentSuccess == 100:
-		return statusHealthy
+		return StatusHealthy
 	case percentSuccess > 50:
-		return statusDegraded
+		return StatusDegraded
 	case mostRecentSuccess == true:
-		return statusDegraded
+		return StatusDegraded
 	default:
-		return statusCritical
+		return StatusCritical
 	}
 }
 

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -1,0 +1,370 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskStatus_New(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+	}{
+		{
+			"happy path",
+			"v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTaskStatusHandler(event.NewStore(), tc.version)
+			assert.Equal(t, tc.version, h.version)
+		})
+	}
+}
+
+func TestTaskStatus_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		path       string
+		statusCode int
+		expected   map[string]TaskStatus
+	}{
+		{
+			"all task statuses",
+			"/v1/status/tasks",
+			http.StatusOK,
+			map[string]TaskStatus{
+				"task_a": TaskStatus{
+					TaskName:  "task_a",
+					Status:    "healthy",
+					Providers: []string{},
+					Services:  []string{},
+					EventsURL: "/v1/status/tasks/task_a?include=events",
+				},
+				"task_b": TaskStatus{
+					TaskName:  "task_b",
+					Status:    "critical",
+					Providers: []string{},
+					Services:  []string{},
+					EventsURL: "/v1/status/tasks/task_b?include=events",
+				},
+			},
+		},
+		{
+			"single task",
+			"/v1/status/tasks/task_b",
+			http.StatusOK,
+			map[string]TaskStatus{
+				"task_b": TaskStatus{
+					TaskName:  "task_b",
+					Status:    "critical",
+					Providers: []string{},
+					Services:  []string{},
+					EventsURL: "/v1/status/tasks/task_b?include=events",
+				},
+			},
+		},
+		{
+			"non-existent task",
+			"/v1/status/tasks/task_nonexistent",
+			http.StatusOK,
+			map[string]TaskStatus{
+				"task_nonexistent": TaskStatus{
+					TaskName:  "task_nonexistent",
+					Status:    "undetermined",
+					Providers: []string{},
+					Services:  []string{},
+					EventsURL: "",
+				},
+			},
+		},
+		{
+			"bad url path",
+			"/v1/status/tasks/task_b/events",
+			http.StatusBadRequest,
+			map[string]TaskStatus{},
+		},
+	}
+
+	// set up store and handler
+	store := event.NewStore()
+	eventA := event.Event{TaskName: "task_a", Success: true}
+	store.Add(eventA)
+	eventB := event.Event{TaskName: "task_b", Success: false}
+	store.Add(eventB)
+
+	handler := newTaskStatusHandler(store, "v1")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tc.path, nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			require.Equal(t, tc.statusCode, resp.Code)
+			if tc.statusCode != http.StatusOK {
+				return
+			}
+
+			decoder := json.NewDecoder(resp.Body)
+			var actual map[string]TaskStatus
+			err = decoder.Decode(&actual)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+
+}
+
+func TestTaskStatus_GetTaskName(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		expectErr bool
+		expected  string
+	}{
+		{
+			"all task statuses",
+			"/v1/status/tasks",
+			false,
+			"",
+		},
+		{
+			"task status for a specific task",
+			"/v1/status/tasks/my_specific_task",
+			false,
+			"my_specific_task",
+		},
+		{
+			"empty task name",
+			"/v1/status/tasks/",
+			false,
+			"",
+		},
+		{
+			"tasks task name",
+			"/v1/status/tasks/tasks",
+			false,
+			"tasks",
+		},
+		{
+			"invalid name",
+			"/v1/status/tasks/mytask/stuff",
+			true,
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getTaskName(tc.path, "v1")
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestTaskStatus_MakeStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		events   []event.Event
+		expected TaskStatus
+	}{
+		{
+			"happy path",
+			[]event.Event{
+				event.Event{
+					Success: true,
+					Config: &event.Config{
+						Providers: []string{"local", "null"},
+						Services:  []string{"api", "web"},
+					},
+				},
+				event.Event{
+					Success: false,
+					Config: &event.Config{
+						Providers: []string{"local"},
+					},
+				},
+				event.Event{
+					Success: false,
+					Config: &event.Config{
+						Providers: []string{"f5"},
+						Services:  []string{"db"},
+					},
+				},
+			},
+			TaskStatus{
+				TaskName:  "test_task",
+				Status:    statusDegraded,
+				Providers: []string{"local", "null", "f5"},
+				Services:  []string{"api", "web", "db"},
+				EventsURL: "/v1/status/tasks/test_task?include=events",
+			},
+		},
+		{
+			"no events",
+			[]event.Event{},
+			TaskStatus{
+				TaskName:  "test_task",
+				Status:    statusUndetermined,
+				Providers: []string{},
+				Services:  []string{},
+				EventsURL: "",
+			},
+		},
+		{
+			"no config",
+			[]event.Event{
+				event.Event{
+					Success: false,
+					Config:  nil,
+				},
+				event.Event{
+					Success: false,
+					Config:  nil,
+				},
+			},
+			TaskStatus{
+				TaskName:  "test_task",
+				Status:    statusCritical,
+				Providers: []string{},
+				Services:  []string{},
+				EventsURL: "/v1/status/tasks/test_task?include=events",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := makeTaskStatus("test_task", tc.events, "v1")
+			sort.Strings(tc.expected.Providers)
+			sort.Strings(tc.expected.Services)
+			sort.Strings(actual.Providers)
+			sort.Strings(actual.Services)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestTaskStatus_MapKeyToArray(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    map[string]bool
+		expected []string
+	}{
+		{
+			"happy path",
+			map[string]bool{
+				"api":     true,
+				"web":     true,
+				"service": true,
+			},
+			[]string{"api", "service", "web"},
+		},
+		{
+			"empty map",
+			map[string]bool{},
+			[]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := mapKeyToArray(tc.input)
+			sort.Strings(actual)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestTaskStatus_SuccessToStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		successes []bool
+		status    string
+	}{
+		{
+			"all successes",
+			[]bool{true, true, true, true, true},
+			statusHealthy,
+		},
+		{
+			"more than half success",
+			[]bool{false, false, true, true, true},
+			statusDegraded,
+		},
+		{
+			"less than half success - most recent failure",
+			[]bool{false, false, false, true, true},
+			statusCritical,
+		},
+		{
+			"less than half success - most recent success",
+			[]bool{true, false, false, false, true},
+			statusDegraded,
+		},
+		{
+			"no successes",
+			[]bool{false, false, false, false, false},
+			statusCritical,
+		},
+		{
+			"no data",
+			[]bool{},
+			statusUndetermined,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := successToStatus(tc.successes)
+			assert.Equal(t, tc.status, actual)
+		})
+	}
+}
+
+func TestTaskStatus_MakeEventsURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		events   []event.Event
+		expected string
+	}{
+		{
+			"no events",
+			[]event.Event{},
+			"",
+		},
+		{
+			"events",
+			[]event.Event{event.Event{}},
+			"/v1/status/tasks/my_task?include=events",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := makeEventsURL(tc.events, "v1", "my_task")
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -214,7 +214,7 @@ func TestTaskStatus_MakeStatus(t *testing.T) {
 			},
 			TaskStatus{
 				TaskName:  "test_task",
-				Status:    statusDegraded,
+				Status:    StatusDegraded,
 				Providers: []string{"local", "null", "f5"},
 				Services:  []string{"api", "web", "db"},
 				EventsURL: "/v1/status/tasks/test_task?include=events",
@@ -225,7 +225,7 @@ func TestTaskStatus_MakeStatus(t *testing.T) {
 			[]event.Event{},
 			TaskStatus{
 				TaskName:  "test_task",
-				Status:    statusUndetermined,
+				Status:    StatusUndetermined,
 				Providers: []string{},
 				Services:  []string{},
 				EventsURL: "",
@@ -245,7 +245,7 @@ func TestTaskStatus_MakeStatus(t *testing.T) {
 			},
 			TaskStatus{
 				TaskName:  "test_task",
-				Status:    statusCritical,
+				Status:    StatusCritical,
 				Providers: []string{},
 				Services:  []string{},
 				EventsURL: "/v1/status/tasks/test_task?include=events",
@@ -306,32 +306,32 @@ func TestTaskStatus_SuccessToStatus(t *testing.T) {
 		{
 			"all successes",
 			[]bool{true, true, true, true, true},
-			statusHealthy,
+			StatusHealthy,
 		},
 		{
 			"more than half success",
 			[]bool{false, false, true, true, true},
-			statusDegraded,
+			StatusDegraded,
 		},
 		{
 			"less than half success - most recent failure",
 			[]bool{false, false, false, true, true},
-			statusCritical,
+			StatusCritical,
 		},
 		{
 			"less than half success - most recent success",
 			[]bool{true, false, false, false, true},
-			statusDegraded,
+			StatusDegraded,
 		},
 		{
 			"no successes",
 			[]bool{false, false, false, false, false},
-			statusCritical,
+			StatusCritical,
 		},
 		{
 			"no data",
 			[]bool{},
-			statusUndetermined,
+			StatusUndetermined,
 		},
 	}
 

--- a/cli.go
+++ b/cli.go
@@ -172,6 +172,7 @@ func (cli *CLI) Run(args []string) int {
 
 	// Set up controller
 	conf.ClientType = config.String(clientType)
+	store := event.NewStore()
 	var ctrl controller.Controller
 	if isInspect {
 		log.Printf("[DEBUG] (cli) inspect mode enabled, processing then exiting")
@@ -179,17 +180,7 @@ func (cli *CLI) Run(args []string) int {
 		ctrl, err = controller.NewReadOnly(conf)
 	} else {
 		log.Printf("[INFO] (cli) setting up controller: readwrite")
-		store := event.NewStore()
 		ctrl, err = controller.NewReadWrite(conf, store)
-
-		// start up api at free port (for now)
-		// TODO: make port configurable with default to port 8501
-		var l net.Listener
-		l, err = net.Listen("tcp", ":0")
-		port := l.Addr().(*net.TCPAddr).Port
-		err = l.Close()
-		api := api.NewAPI(store, port)
-		api.Serve(ctx)
 	}
 	if err != nil {
 		log.Printf("[ERR] (cli) error setting up controller: %s", err)
@@ -197,7 +188,40 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	errCh := make(chan error, 1)
-	exitCh := make(chan struct{}, 1)
+	exitBufLen := 2 // exit api & controller
+	exitCh := make(chan struct{}, exitBufLen)
+
+	go func() {
+		if isOnce || isInspect {
+			return
+		}
+		// start up api at free port (for now)
+		// TODO: make port configurable with default to port 8501
+		var l net.Listener
+		l, err = net.Listen("tcp", ":0")
+		if err != nil {
+			log.Printf("[ERR] (cli) error retrieving port for server: %s", err)
+			errCh <- err
+			return
+		}
+		port := l.Addr().(*net.TCPAddr).Port
+		if err = l.Close(); err != nil {
+			log.Printf("[ERR] (cli) error retrieving port for server: %s", err)
+			errCh <- err
+			return
+		}
+
+		log.Printf("[INFO] (cli) starting up api server at port: %d", port)
+		api := api.NewAPI(store, port)
+		if err = api.Serve(ctx); err != nil {
+			if err == context.Canceled {
+				exitCh <- struct{}{}
+				return
+			}
+			errCh <- err
+			return
+		}
+	}()
 
 	go func() {
 		log.Printf("[INFO] (cli) initializing controller")
@@ -255,13 +279,21 @@ func (cli *CLI) Run(args []string) int {
 			// shutdown
 			log.Printf("[INFO] (cli) signal received to initiate graceful shutdown: %v", sig)
 			cancel()
-			select {
-			case <-exitCh:
-				log.Printf("[INFO] (cli) graceful shutdown")
-				return ExitCodeOK
-			case <-time.After(10 * time.Second):
-				log.Printf("[INFO] (cli) graceful shutdown timed out, exiting")
-				return ExitCodeInterrupt
+			counter := 0
+			start := time.Now()
+			for {
+				since := time.Since(start)
+				select {
+				case <-exitCh:
+					counter++
+					if counter >= exitBufLen {
+						log.Printf("[INFO] (cli) graceful shutdown")
+						return ExitCodeOK
+					}
+				case <-time.After(10*time.Second - since):
+					log.Printf("[INFO] (cli) graceful shutdown timed out, exiting")
+					return ExitCodeInterrupt
+				}
 			}
 
 		case <-exitCh:

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -100,7 +100,8 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			ctx := context.Background()
 
 			_, err := controller.checkApply(ctx, u)
-			events := controller.store.Read(tc.taskName)
+			data := controller.store.Read(tc.taskName)
+			events := data[tc.taskName]
 
 			if !tc.addToStore {
 				assert.Error(t, err)
@@ -159,11 +160,10 @@ func TestReadWrite_CheckApply_Store(t *testing.T) {
 		controller.checkApply(ctx, unitA)
 		controller.checkApply(ctx, unitB)
 
-		eventsA := controller.store.Read("task_a")
-		eventsB := controller.store.Read("task_b")
+		taskStatuses := controller.store.Read("")
 
-		assert.Equal(t, 4, len(eventsA))
-		assert.Equal(t, 2, len(eventsB))
+		assert.Equal(t, 4, len(taskStatuses["task_a"]))
+		assert.Equal(t, 2, len(taskStatuses["task_b"]))
 	})
 }
 

--- a/event/event.go
+++ b/event/event.go
@@ -96,7 +96,7 @@ func (e *Event) GoString() string {
 		"StartTime:%s, "+
 		"EndTime:%s, "+
 		"EventError:%s, "+
-		"Config:%s, "+
+		"Config:%s"+
 		"}",
 		e.ID,
 		e.TaskName,

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -189,12 +189,14 @@ func businessLogic(expectError bool) (string, error) {
 
 func TestEvent_GoString(t *testing.T) {
 	cases := []struct {
-		name  string
-		event *Event
+		name     string
+		event    *Event
+		expected string
 	}{
 		{
 			"nil event",
 			nil,
+			"(*Event)(nil)",
 		},
 		{
 			"happy path",
@@ -211,22 +213,17 @@ func TestEvent_GoString(t *testing.T) {
 					Source:    "/my-module",
 				},
 			},
+			"&Event{ID:123, TaskName:happy, Success:false, " +
+				"StartTime:0001-01-01 00:00:00 +0000 UTC, " +
+				"EndTime:0001-01-01 00:00:00 +0000 UTC, EventError:&{error!}, " +
+				"Config:&{[local] [web api] /my-module}}",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.event == nil {
-				assert.Contains(t, tc.event.GoString(), "nil")
-				return
-			}
-
-			assert.Contains(t, tc.event.GoString(), "&Event")
-			assert.Contains(t, tc.event.GoString(), tc.event.ID)
-			assert.Contains(t, tc.event.GoString(), tc.event.TaskName)
-			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%t", tc.event.Success))
-			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%s", tc.event.EventError))
-			assert.Contains(t, tc.event.GoString(), fmt.Sprintf("%s", tc.event.Config))
+			actual := tc.event.GoString()
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/event/store.go
+++ b/event/store.go
@@ -42,15 +42,26 @@ func (s *Store) Add(e Event) error {
 	return nil
 }
 
-// Read returns events given a task name. Returned events are ordered by
-// decending end time
-func (s *Store) Read(taskName string) []Event {
+// Read returns events for a task name. If no task name is specified, return
+// events for all tasks. Returned events are ordered by decending end time
+func (s *Store) Read(taskName string) map[string][]Event {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	events := make([]Event, len(s.events[taskName]))
-	for ix, event := range s.events[taskName] {
-		events[ix] = *event
+	data := make(map[string][]*Event)
+	if taskName != "" {
+		data[taskName] = s.events[taskName]
+	} else {
+		data = s.events
 	}
-	return events
+
+	ret := make(map[string][]Event)
+	for k, v := range data {
+		events := make([]Event, len(v))
+		for ix, event := range v {
+			events[ix] = *event
+		}
+		ret[k] = events
+	}
+	return ret
 }

--- a/event/store_test.go
+++ b/event/store_test.go
@@ -65,25 +65,70 @@ func TestStore_Add(t *testing.T) {
 func TestStore_Read(t *testing.T) {
 	cases := []struct {
 		name     string
-		values   []*Event
-		expected []Event
+		input    string
+		values   []Event
+		expected map[string][]Event
 	}{
 		{
-			"no events",
-			[]*Event{},
+			"read all - no events",
+			"",
 			[]Event{},
+			map[string][]Event{},
 		},
 		{
-			"multiple events",
-			[]*Event{
-				&Event{TaskName: "1"},
-				&Event{TaskName: "2"},
-				&Event{TaskName: "3"},
-			},
+			"read all - happy path",
+			"",
 			[]Event{
 				Event{TaskName: "1"},
 				Event{TaskName: "2"},
+				Event{TaskName: "2"},
 				Event{TaskName: "3"},
+				Event{TaskName: "3"},
+				Event{TaskName: "3"},
+			},
+			map[string][]Event{
+				"1": []Event{
+					Event{TaskName: "1"},
+				},
+				"2": []Event{
+					Event{TaskName: "2"},
+					Event{TaskName: "2"},
+				},
+				"3": []Event{
+					Event{TaskName: "3"},
+					Event{TaskName: "3"},
+					Event{TaskName: "3"},
+				},
+			},
+		},
+		{
+			"read task - happy path",
+			"4",
+			[]Event{
+				Event{TaskName: "4"},
+				Event{TaskName: "4"},
+				Event{TaskName: "5"},
+				Event{TaskName: "5"},
+				Event{TaskName: "4"},
+				Event{TaskName: "4"},
+				Event{TaskName: "5"},
+			},
+			map[string][]Event{
+
+				"4": []Event{
+					Event{TaskName: "4"},
+					Event{TaskName: "4"},
+					Event{TaskName: "4"},
+					Event{TaskName: "4"},
+				},
+			},
+		},
+		{
+			"read task - no event",
+			"4",
+			[]Event{},
+			map[string][]Event{
+				"4": []Event{},
 			},
 		},
 	}
@@ -91,9 +136,11 @@ func TestStore_Read(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			store := NewStore()
-			store.events["key"] = tc.values
+			for _, event := range tc.values {
+				store.Add(event)
+			}
 
-			actual := store.Read("key")
+			actual := store.Read(tc.input)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"os"
-
-	"github.com/hashicorp/consul-terraform-sync/event"
 )
 
 func main() {
-	store := event.NewStore()
-	cli := NewCLI(os.Stdout, os.Stderr, store)
+	cli := NewCLI(os.Stdout, os.Stderr)
 	os.Exit(cli.Run(os.Args))
 }


### PR DESCRIPTION
Third part in a series of changes to support status api. This adds basic use
case for task status endpoints `/status/tasks` and `/status/tasks/{task_name}`.
Future work listed below.

Changes
 - Change event store.Read() to support read-all when empty task name is passed
 - Change event store.Read() to return map[string][]Event instead of []Event
 - Add api package that serves the api and contains handlers
 - Removed store from main.go and serve api in cli.go rather than main.go

Since this PR was growing a bit large, subsequent PRs will have:
 - configuring the api port
 - e2e test
 - filter by status e.g. ?status=critical
 - include events in payload e.g. ?include=events
 - overall status endpoint

Examples:
`/v1/status/tasks`:
```
{
  "test_a": {
    "task_name": "test_a",
    "status": "healthy",
    "providers": [
      "local"
    ],
    "services": [
      "api",
    ],
    "events_url": "/v1/status/tasks/test_a?include=events"
  },
  "test_b": {
    "task_name": "test_b",
    "status": "critical",
    "providers": [
      "null"
    ],
    "services": [
      "web",
    ],
    "events_url": "/v1/status/tasks/test_b?include=events"
  }
}
```

`/v1/status/tasks/test_a`:
```
{
  "test_a": {
    "task_name": "test_a",
    "status": "healthy",
    "providers": [
      "local"
    ],
    "services": [
      "api",
    ],
    "events_url": "/v1/status/tasks/test_a?include=events"
  }
}
```