### PR TITLE
Deprecate provider block for terraform_provider

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,7 +94,7 @@ var (
 				Source:      String("Y"),
 			},
 		},
-		Providers: &ProviderConfigs{{
+		TerraformProviders: &TerraformProviderConfigs{{
 			"X": map[string]interface{}{},
 		}},
 		BufferPeriod: &BufferPeriodConfig{

--- a/config/provider.go
+++ b/config/provider.go
@@ -5,21 +5,21 @@ import (
 	"strings"
 )
 
-// ProviderConfigs is an array of configuration for each provider.
-type ProviderConfigs []*ProviderConfig
+// TerraformProviderConfigs is an array of configuration for each provider.
+type TerraformProviderConfigs []*TerraformProviderConfig
 
-// ProviderConfig is a map representing the configuration for a single provider
-// where the key is the name of provider and value is the configuration.
-type ProviderConfig map[string]interface{}
+// TerraformProviderConfig is a map representing the configuration for a single
+// provider where the key is the name of provider and value is the configuration.
+type TerraformProviderConfig map[string]interface{}
 
-// DefaultProviderConfigs returns a configuration that is populated with the
-// default values.
-func DefaultProviderConfigs() *ProviderConfigs {
-	return &ProviderConfigs{}
+// DefaultTerraformProviderConfigs returns a configuration that is populated
+// with the default values.
+func DefaultTerraformProviderConfigs() *TerraformProviderConfigs {
+	return &TerraformProviderConfigs{}
 }
 
 // Len is a helper method to get the length of the underlying config list
-func (c *ProviderConfigs) Len() int {
+func (c *TerraformProviderConfigs) Len() int {
 	if c == nil {
 		return 0
 	}
@@ -28,14 +28,14 @@ func (c *ProviderConfigs) Len() int {
 }
 
 // Copy returns a deep copy of this configuration.
-func (c *ProviderConfigs) Copy() *ProviderConfigs {
+func (c *TerraformProviderConfigs) Copy() *TerraformProviderConfigs {
 	if c == nil {
 		return nil
 	}
 
-	o := make(ProviderConfigs, c.Len())
+	o := make(TerraformProviderConfigs, c.Len())
 	for i, t := range *c {
-		copy := make(ProviderConfig)
+		copy := make(TerraformProviderConfig)
 		for k, v := range *t {
 			copy[k] = v
 		}
@@ -48,7 +48,7 @@ func (c *ProviderConfigs) Copy() *ProviderConfigs {
 // configuration, with values in the other configuration taking precedence.
 // Maps and slices are merged, most other values are overwritten. Complex
 // structs define their own merge functionality.
-func (c *ProviderConfigs) Merge(o *ProviderConfigs) *ProviderConfigs {
+func (c *TerraformProviderConfigs) Merge(o *TerraformProviderConfigs) *TerraformProviderConfigs {
 	if c == nil {
 		if o == nil {
 			return nil
@@ -69,14 +69,14 @@ func (c *ProviderConfigs) Merge(o *ProviderConfigs) *ProviderConfigs {
 
 // Finalize ensures the configuration has no nil pointers and sets default
 // values.
-func (c *ProviderConfigs) Finalize() {
+func (c *TerraformProviderConfigs) Finalize() {
 	if c == nil {
-		*c = *DefaultProviderConfigs()
+		*c = *DefaultTerraformProviderConfigs()
 	}
 }
 
 // Validate validates the values and nested values of the configuration struct
-func (c *ProviderConfigs) Validate() error {
+func (c *TerraformProviderConfigs) Validate() error {
 	if c == nil {
 		// Uninitialized config is invalid. Although unlikely, no providers could
 		// still be valid if all of the tasks happen to not depend on a provider.
@@ -103,9 +103,9 @@ func (c *ProviderConfigs) Validate() error {
 // GoString defines the printable version of this struct. Provider configuration
 // is completely redacted since providers will have varying arguments containing
 // secrets
-func (c *ProviderConfigs) GoString() string {
+func (c *TerraformProviderConfigs) GoString() string {
 	if c == nil {
-		return "(*ProviderConfigs)(nil)"
+		return "(*TerraformProviderConfigs)(nil)"
 	}
 
 	s := make([]string, len(*c))
@@ -119,7 +119,7 @@ func (c *ProviderConfigs) GoString() string {
 }
 
 // Validate validates the values and nested values of the configuration struct.
-func (c *ProviderConfig) Validate() error {
+func (c *TerraformProviderConfig) Validate() error {
 	if c == nil {
 		return fmt.Errorf("invalid provider configuration")
 	}
@@ -140,7 +140,7 @@ func (c *ProviderConfig) Validate() error {
 
 // id returns the unique name to represent the provider configuration. If alias is set,
 // the ID is <name>.<alias>. Otherwise, the name is used as the ID.
-func (c *ProviderConfig) id() string {
+func (c *TerraformProviderConfig) id() string {
 	if c == nil || len(*c) == 0 {
 		return ""
 	}

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -12,7 +12,7 @@ func TestProviderConfigs_Copy(t *testing.T) {
 
 	cases := []struct {
 		name string
-		a    *ProviderConfigs
+		a    *TerraformProviderConfigs
 	}{
 		{
 			"nil",
@@ -20,11 +20,11 @@ func TestProviderConfigs_Copy(t *testing.T) {
 		},
 		{
 			"empty",
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
 		},
 		{
 			"same_enabled",
-			&ProviderConfigs{
+			&TerraformProviderConfigs{
 				{
 					"null": map[string]interface{}{
 						"attr":  "value",
@@ -43,26 +43,26 @@ func TestProviderConfigs_Copy(t *testing.T) {
 	}
 }
 
-func TestProviderConfigs_Merge(t *testing.T) {
+func TestTerraformProviderConfigs_Merge(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name string
-		a    *ProviderConfigs
-		b    *ProviderConfigs
-		r    *ProviderConfigs
+		a    *TerraformProviderConfigs
+		b    *TerraformProviderConfigs
+		r    *TerraformProviderConfigs
 	}{
 		{
 			"nil_a",
 			nil,
-			&ProviderConfigs{},
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{},
 		},
 		{
 			"nil_b",
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
 			nil,
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
 		},
 		{
 			"nil_both",
@@ -72,25 +72,25 @@ func TestProviderConfigs_Merge(t *testing.T) {
 		},
 		{
 			"empty",
-			&ProviderConfigs{},
-			&ProviderConfigs{},
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{},
 		},
 		{
 			"appends",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
 				},
 			}},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"template": map[string]interface{}{
 					"attr":  "t",
 					"count": 5,
 				},
 			}},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -104,14 +104,14 @@ func TestProviderConfigs_Merge(t *testing.T) {
 		},
 		{
 			"empty_one",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
 				},
 			}},
-			&ProviderConfigs{},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -120,14 +120,14 @@ func TestProviderConfigs_Merge(t *testing.T) {
 		},
 		{
 			"empty_two",
-			&ProviderConfigs{},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
 				},
 			}},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -149,23 +149,23 @@ func TestProviderConfigs_Finalize(t *testing.T) {
 
 	cases := []struct {
 		name string
-		i    *ProviderConfigs
-		r    *ProviderConfigs
+		i    *TerraformProviderConfigs
+		r    *TerraformProviderConfigs
 	}{
 		{
 			"empty",
-			&ProviderConfigs{},
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
+			&TerraformProviderConfigs{},
 		},
 		{
 			"with_name",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
 				},
 			}},
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -187,7 +187,7 @@ func TestProviderConfigs_Validate(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		i       *ProviderConfigs
+		i       *TerraformProviderConfigs
 		isValid bool
 	}{
 		{
@@ -197,12 +197,12 @@ func TestProviderConfigs_Validate(t *testing.T) {
 		},
 		{
 			"empty",
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
 			true,
 		},
 		{
 			"valid",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -212,11 +212,11 @@ func TestProviderConfigs_Validate(t *testing.T) {
 		},
 		{
 			"empty provider map",
-			&ProviderConfigs{{}},
+			&TerraformProviderConfigs{{}},
 			false,
 		}, {
 			"multiple",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -229,7 +229,7 @@ func TestProviderConfigs_Validate(t *testing.T) {
 			true,
 		}, {
 			"alias",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -244,7 +244,7 @@ func TestProviderConfigs_Validate(t *testing.T) {
 			true,
 		}, {
 			"duplicate",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr":  "n",
 					"count": 10,
@@ -258,7 +258,7 @@ func TestProviderConfigs_Validate(t *testing.T) {
 			false,
 		}, {
 			"duplicate alias",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"alias": "alias",
 					"attr":  "n",
@@ -293,22 +293,22 @@ func TestProviderConfigs_GoString(t *testing.T) {
 	// only testing provider cases with one argument since map order is random
 	cases := []struct {
 		name     string
-		i        *ProviderConfigs
+		i        *TerraformProviderConfigs
 		expected string
 	}{
 		{
 			"nil",
 			nil,
-			`(*ProviderConfigs)(nil)`,
+			`(*TerraformProviderConfigs)(nil)`,
 		},
 		{
 			"empty",
-			&ProviderConfigs{},
+			&TerraformProviderConfigs{},
 			`{}`,
 		},
 		{
 			"single config",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"count": "10",
 				},
@@ -317,7 +317,7 @@ func TestProviderConfigs_GoString(t *testing.T) {
 		},
 		{
 			"multiple configs, same provider",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
 					"attr": "n",
 				},
@@ -331,7 +331,7 @@ func TestProviderConfigs_GoString(t *testing.T) {
 		},
 		{
 			"multiple configs, different provider",
-			&ProviderConfigs{{
+			&TerraformProviderConfigs{{
 				"firewall": map[string]interface{}{
 					"hostname": "127.0.0.10",
 					"username": "username",

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -66,7 +66,7 @@ service {
   description = "descriptionB"
 }
 
-provider "X" {}
+terraform_provider "X" {}
 
 task {
   name = "task"

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -66,7 +66,7 @@
       "description": "descriptionB"
     }
   ],
-  "provider": [
+  "terraform_provider": [
     {
       "X": {}
     }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -173,7 +173,7 @@ func newDriverTasks(conf *config.Config) []driver.Task {
 		providers := make([]map[string]interface{}, len(t.Providers))
 		providerInfo := make(map[string]interface{})
 		for pi, providerID := range t.Providers {
-			providers[pi] = getProvider(conf.Providers, providerID)
+			providers[pi] = getProvider(conf.TerraformProviders, providerID)
 
 			// This is Terraform specific to pass version and source info for
 			// providers from the required_provider block
@@ -262,8 +262,8 @@ func splitProviderID(id string) (string, string) {
 // or <name>.<alias>. If a provider is not explicitly configured, it
 // assumes the default provider block that is empty.
 //
-// provider "name" { }
-func getProvider(providers *config.ProviderConfigs, id string) map[string]interface{} {
+// terraform_provider "name" { }
+func getProvider(providers *config.TerraformProviderConfigs, id string) map[string]interface{} {
 	name, alias := splitProviderID(id)
 
 	for _, p := range *providers {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -187,7 +187,7 @@ func TestNewDriverTasks(t *testing.T) {
 						},
 					},
 				},
-				Providers: &config.ProviderConfigs{
+				TerraformProviders: &config.TerraformProviderConfigs{
 					{"providerB": map[string]interface{}{
 						"var": "val",
 					}},
@@ -231,7 +231,7 @@ func TestNewDriverTasks(t *testing.T) {
 						},
 					},
 				},
-				Providers: &config.ProviderConfigs{
+				TerraformProviders: &config.TerraformProviderConfigs{
 					{"providerA": map[string]interface{}{
 						"alias": "alias1",
 						"foo":   "bar",

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -370,7 +370,7 @@ func singleTaskConfig() *config.Config {
 				Description: config.String("descriptionB"),
 			},
 		},
-		Providers: &config.ProviderConfigs{{
+		TerraformProviders: &config.TerraformProviderConfigs{{
 			"X": map[string]interface{}{},
 			handler.TerraformProviderFake: map[string]interface{}{
 				"name": "fake-provider",

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -134,13 +134,13 @@ service {
     description = "database"
 }
 
-provider "local" {}
+terraform_provider "local" {}
 `
 }
 
 func panosBadCredConfig() string {
 	return `log_level = "trace"
-provider "panos" {
+terraform_provider "panos" {
 	hostname = "10.10.10.10"
 	api_key = "badapikey_1234"
 }

--- a/examples/example-config.hcl
+++ b/examples/example-config.hcl
@@ -30,7 +30,7 @@ driver "terraform" {
   }
 }
 
-provider "myprovider" {
+terraform_provider "myprovider" {
   address = "myprovider.example.com"
   username = "admin"
   attr = "foobar"


### PR DESCRIPTION
This is to further distinguish the syntax and features supported by Terraform provider blocks and CTS terraform_provider blocks, like supporting dynamic configuration.

![image](https://user-images.githubusercontent.com/6362111/99699236-531f1780-2a57-11eb-924f-160f5f90e0e2.png)

related #53 