### PR TITLE
Support api port configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-integration:
 # test-e2e runs e2e tests
 test-e2e:
 	@echo "==> Testing ${NAME} (e2e)"
-	@go test ./e2e -count=1 -timeout=60s -tags=e2e -v ./... ${TESTARGS}
+	@go test ./e2e -count=1 -timeout=80s -tags=e2e -v ./... ${TESTARGS}
 .PHONY: test-e2e
 
 # test-setup-e2e sets up the sync binary and permissions to run in circle

--- a/cli.go
+++ b/cli.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -195,24 +194,8 @@ func (cli *CLI) Run(args []string) int {
 		if isOnce || isInspect {
 			return
 		}
-		// start up api at free port (for now)
-		// TODO: make port configurable with default to port 8501
-		var l net.Listener
-		l, err = net.Listen("tcp", ":0")
-		if err != nil {
-			log.Printf("[ERR] (cli) error retrieving port for server: %s", err)
-			errCh <- err
-			return
-		}
-		port := l.Addr().(*net.TCPAddr).Port
-		if err = l.Close(); err != nil {
-			log.Printf("[ERR] (cli) error retrieving port for server: %s", err)
-			errCh <- err
-			return
-		}
-
-		log.Printf("[INFO] (cli) starting up api server at port: %d", port)
-		api := api.NewAPI(store, port)
+		log.Printf("[INFO] (cli) starting up api server at port: %d", conf.Port)
+		api := api.NewAPI(store, config.IntVal(conf.Port))
 		if err = api.Serve(ctx); err != nil {
 			if err == context.Canceled {
 				exitCh <- struct{}{}

--- a/config/config.go
+++ b/config/config.go
@@ -18,12 +18,16 @@ import (
 const (
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "WARN"
+
+	// defaultPort is the default port to use for api server.
+	defaultPort = 8501
 )
 
 // Config is used to configure Sync
 type Config struct {
 	LogLevel   *string `mapstructure:"log_level"`
 	ClientType *string `mapstructure:"client_type"`
+	Port       *int    `mapstructure:"port"`
 
 	Syslog              *SyslogConfig             `mapstructure:"syslog"`
 	Consul              *ConsulConfig             `mapstructure:"consul"`
@@ -66,6 +70,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		LogLevel:            String(DefaultLogLevel),
 		Syslog:              DefaultSyslogConfig(),
+		Port:                Int(defaultPort),
 		Consul:              consul,
 		Driver:              DefaultDriverConfig(),
 		Tasks:               DefaultTaskConfigs(),
@@ -86,6 +91,7 @@ func (c *Config) Copy() *Config {
 	return &Config{
 		LogLevel:            StringCopy(c.LogLevel),
 		Syslog:              c.Syslog.Copy(),
+		Port:                IntCopy(c.Port),
 		Consul:              c.Consul.Copy(),
 		Vault:               c.Vault.Copy(),
 		Driver:              c.Driver.Copy(),
@@ -117,6 +123,10 @@ func (c *Config) Merge(o *Config) *Config {
 
 	if o.LogLevel != nil {
 		r.LogLevel = StringCopy(o.LogLevel)
+	}
+
+	if o.Port != nil {
+		r.Port = IntCopy(o.Port)
 	}
 
 	if o.Syslog != nil {
@@ -162,6 +172,10 @@ func (c *Config) Merge(o *Config) *Config {
 func (c *Config) Finalize() {
 	if c == nil {
 		return
+	}
+
+	if c.Port == nil {
+		c.Port = Int(defaultPort)
 	}
 
 	if c.ClientType == nil {
@@ -264,6 +278,7 @@ func (c *Config) GoString() string {
 
 	return fmt.Sprintf("&Config{"+
 		"LogLevel:%s, "+
+		"Port:%d, "+
 		"Syslog:%s, "+
 		"Consul:%s, "+
 		"Vault:%s, "+
@@ -274,6 +289,7 @@ func (c *Config) GoString() string {
 		"BufferPeriod:%s"+
 		"}",
 		StringVal(c.LogLevel),
+		IntVal(c.Port),
 		c.Syslog.GoString(),
 		c.Consul.GoString(),
 		c.Vault.GoString(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ var (
 
 	longConfig = Config{
 		LogLevel: String("ERR"),
+		Port:     Int(8502),
 		Syslog: &SyslogConfig{
 			Enabled: Bool(true),
 			Name:    String("syslog"),
@@ -180,6 +181,7 @@ func TestFromPath(t *testing.T) {
 			"testdata/simple",
 			&Config{
 				LogLevel: String("ERR"),
+				Port:     Int(8503),
 				BufferPeriod: &BufferPeriodConfig{
 					Enabled: Bool(true),
 					Min:     TimeDuration(time.Duration(10 * time.Second)),
@@ -218,6 +220,7 @@ func TestFromPath(t *testing.T) {
 			"testdata/override",
 			&Config{
 				LogLevel: String("DEBUG"),
+				Port:     Int(8505),
 			},
 		}, {
 			"file DNE",
@@ -258,6 +261,7 @@ func TestConfig_Finalize(t *testing.T) {
 	// Backfill expected values
 	expected := longConfig.Copy()
 	expected.ClientType = String("")
+	expected.Port = Int(8502)
 	expected.Syslog.Facility = String("LOCAL0")
 	expected.BufferPeriod.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")

--- a/config/convert.go
+++ b/config/convert.go
@@ -48,6 +48,15 @@ func IntVal(i *int) int {
 	return *i
 }
 
+// IntCopy returns a copy of the int pointer
+func IntCopy(i *int) *int {
+	if i == nil {
+		return nil
+	}
+
+	return Int(*i)
+}
+
 // String returns a pointer to the given string.
 func String(s string) *string {
 	return &s

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -1,4 +1,5 @@
 log_level = "ERR"
+port = 8502
 
 syslog {
   enabled = true

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -1,5 +1,6 @@
 {
   "log_level": "ERR",
+  "port": "8502",
   "syslog": {
     "enabled": true,
     "name": "syslog"

--- a/config/testdata/override/a.hcl
+++ b/config/testdata/override/a.hcl
@@ -1,1 +1,2 @@
 log_level = "ERR"
+port = 8504

--- a/config/testdata/override/b.hcl
+++ b/config/testdata/override/b.hcl
@@ -1,1 +1,2 @@
 log_level = "DEBUG"
+port = 8505

--- a/config/testdata/simple/a.hcl
+++ b/config/testdata/simple/a.hcl
@@ -1,1 +1,2 @@
 log_level = "ERR"
+port = 8503

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -45,12 +45,13 @@ func TestNewControllers(t *testing.T) {
 		},
 	}
 	// fake consul server
-	addr := "127.0.0.1:8500"
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, `"test"`) }))
 	var err error
-	ts.Listener, err = net.Listen("tcp", addr)
+	ts.Listener, err = net.Listen("tcp", ":0")
 	require.NoError(t, err)
+	port := ts.Listener.Addr().(*net.TCPAddr).Port
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ts.Start()
 	defer ts.Close()
 

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -118,6 +118,8 @@ task {
 
 func baseConfig() string {
 	return `log_level = "trace"
+# port 0 will automatically select next free port
+port = 0
 
 service {
   name = "api"

--- a/examples/example-config.hcl
+++ b/examples/example-config.hcl
@@ -6,6 +6,7 @@
 #
 
 log_level = "info"
+port = 8502
 
 consul {
   address = "consul.example.com"


### PR DESCRIPTION
 - Add new `port` config at top-level
 - Update api to consume new port config
 - Update e2e test config to dynamically choose next free port
 - Fix a controller test to dynamically choose next free port