### PR TITLE
Add overall status endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 # test-integration runs the test suite and integration tests
 test-integration:
 	@echo "==> Testing ${NAME} (test suite & integration)"
-	@go test -count=1 -timeout=60s -tags=integration -cover ./... ${TESTARGS}
+	@go test -count=1 -timeout=80s -tags=integration -cover ./... ${TESTARGS}
 .PHONY: test-all
 
 # test-e2e runs e2e tests

--- a/api/api.go
+++ b/api/api.go
@@ -21,6 +21,9 @@ const (
 	// Task Status: Determined by the success of a task updating. The 5 most
 	// recent task updates are stored as an ‘event’ in CTS. A task is healthy
 	// when all the stored events are successful.
+	//
+	// Overall Status: Determined by the health across all task statuses.
+	// Overall status is healthy when all task statuses are healthy.
 	StatusHealthy = "healthy"
 
 	// StatusDegraded is the degraded status. This is determined based on status
@@ -31,6 +34,10 @@ const (
 	// when more than half of the stored events are successful _or_ less than
 	// half of the stored events are successful but the most recent event is
 	// successful.
+	//
+	// Overall Status: Determined by the health across all task statuses.
+	// Overall status is degraded when at least one task status is degraded but
+	// none are critical.
 	StatusDegraded = "degraded"
 
 	// StatusCritical is the critical status. This is determined based on status
@@ -39,7 +46,10 @@ const (
 	// Task Status: Determined by the success of a task updating. The 5 most
 	// recent task updates are stored as an ‘event’ in CTS. A task is critical
 	// when less than half of the stored events are successful and the most
-	// recent event is not successful
+	// recent event is not successful.
+	//
+	// Overall Status: Determined by the health across all task statuses.
+	// Overall status is critical when at least one task status is critical.
 	StatusCritical = "critical"
 
 	// StatusUndetermined is when the status is unknown. This is determined
@@ -48,6 +58,9 @@ const (
 	// Task Status: Determined by the success of a task updating. The 5 most
 	// recent task updates are stored as an ‘event’ in CTS. A task is
 	// undetermined when no event data has been collected yet.
+	//
+	// Overall Status: Determined by the health across all task statuses.
+	// Overall status is undetermined when no task status information exists yet.
 	StatusUndetermined = "undetermined"
 )
 
@@ -63,6 +76,9 @@ type API struct {
 func NewAPI(store *event.Store, port int) *API {
 	mux := http.NewServeMux()
 
+	// retrieve overall status
+	mux.Handle(fmt.Sprintf("/%s/%s", defaultAPIVersion, overallStatusPath),
+		newOverallStatusHandler(store, defaultAPIVersion))
 	// retrieve task status for a task-name
 	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskStatusPath),
 		newTaskStatusHandler(store, defaultAPIVersion))

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,9 +24,9 @@ func TestServe(t *testing.T) {
 		statusCode int
 	}{
 		{
-			"overall status TODO",
+			"overall status",
 			"status",
-			http.StatusNotFound,
+			http.StatusOK,
 		},
 		{
 			"task status: all",
@@ -130,6 +130,11 @@ func TestJsonResponse(t *testing.T) {
 					EventsURL: "",
 				},
 			},
+		},
+		{
+			"overall status: success",
+			http.StatusOK,
+			OverallStatus{Status: StatusDegraded},
 		},
 	}
 	for _, tc := range cases {

--- a/api/overall_status.go
+++ b/api/overall_status.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+)
+
+const overallStatusPath = "status"
+
+// OverallStatus is the overall status information across all the tasks
+type OverallStatus struct {
+	Status string `json:"status"`
+}
+
+// overallStatusHandler handles the overall status endpoint
+type overallStatusHandler struct {
+	store   *event.Store
+	version string
+}
+
+// newOverallStatusHandler returns a new overall status handler
+func newOverallStatusHandler(store *event.Store, version string) *overallStatusHandler {
+	return &overallStatusHandler{
+		store:   store,
+		version: version,
+	}
+}
+
+// ServeHTTP serves the overall status endpoint which returns a struct
+// containing overall information across all tasks
+func (h *overallStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[TRACE] (api.overallstatus) requesting task status '%s'", r.URL.Path)
+
+	tasks := h.store.Read("")
+	statuses := make([]string, len(tasks))
+	ix := 0
+	for _, events := range tasks {
+		successes := make([]bool, len(events))
+		for i, event := range events {
+			successes[i] = event.Success
+		}
+
+		status := successToStatus(successes)
+		statuses[ix] = status
+		ix++
+	}
+
+	jsonResponse(w, http.StatusOK, OverallStatus{
+		Status: taskStatusToOverall(statuses),
+	})
+}
+
+// taskStatusToOverall determines an overall status from the health of all the
+// task statuses
+func taskStatusToOverall(statuses []string) string {
+	total := len(statuses)
+	if total == 0 {
+		return StatusUndetermined
+	}
+
+	statCount := make(map[string]int)
+	for _, status := range statuses {
+		statCount[status]++
+	}
+
+	healthy := statCount[StatusHealthy]
+	degraded := statCount[StatusDegraded]
+	critical := statCount[StatusCritical]
+
+	switch {
+	case healthy == total:
+		return StatusHealthy
+	case degraded > 0 && critical == 0:
+		return StatusDegraded
+	default:
+		return StatusCritical
+	}
+}

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverallStatus_New(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+	}{
+		{
+			"happy path",
+			"v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newOverallStatusHandler(event.NewStore(), tc.version)
+			assert.Equal(t, tc.version, h.version)
+		})
+	}
+}
+
+func TestOverallStatus_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		path       string
+		statusCode int
+		expected   OverallStatus
+	}{
+		{
+			"happy path",
+			"/v1/status",
+			http.StatusOK,
+			OverallStatus{Status: StatusCritical},
+		},
+	}
+
+	// set up store and handler
+	store := event.NewStore()
+	eventA := event.Event{TaskName: "task_a", Success: true}
+	store.Add(eventA)
+	eventB := event.Event{TaskName: "task_b", Success: false}
+	store.Add(eventB)
+
+	handler := newOverallStatusHandler(store, "v1")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", tc.path, nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			require.Equal(t, tc.statusCode, resp.Code)
+			if tc.statusCode != http.StatusOK {
+				return
+			}
+
+			decoder := json.NewDecoder(resp.Body)
+			var actual OverallStatus
+			err = decoder.Decode(&actual)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestOverallStatus_TaskStatusToOverall(t *testing.T) {
+	cases := []struct {
+		name     string
+		statuses []string
+		expected string
+	}{
+		{
+			"healthy: all healthy",
+			[]string{StatusHealthy, StatusHealthy, StatusHealthy, StatusHealthy, StatusHealthy},
+			StatusHealthy,
+		},
+		{
+			"degraded: mix of degraded and healthy",
+			[]string{StatusHealthy, StatusHealthy, StatusDegraded, StatusHealthy, StatusDegraded},
+			StatusDegraded,
+		},
+		{
+			"critical: at least one critical",
+			[]string{StatusHealthy, StatusHealthy, StatusDegraded, StatusHealthy, StatusCritical},
+			StatusCritical,
+		},
+		{
+			"no data",
+			[]string{},
+			StatusUndetermined,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := taskStatusToOverall(tc.statuses)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Part of a series of changes to support status api. Adds an endpoint that gives the overall status of all the tasks that cts executes. Overall status is determined by task status information for all tasks

Example:

`GET /v1/status`

`
{"status":"healthy"}
`