### PR TITLE
Support `?include=events` parameter for task status

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -148,6 +148,48 @@ func TestJsonResponse(t *testing.T) {
 			},
 		},
 		{
+			"task status: success with events",
+			http.StatusOK,
+			map[string]TaskStatus{
+				"task_a": TaskStatus{
+					TaskName:  "task_a",
+					Status:    StatusDegraded,
+					Providers: []string{"local", "null", "f5"},
+					Services:  []string{"api", "web", "db"},
+					EventsURL: "/v1/status/tasks/test_task?include=events",
+					Events: []event.Event{
+						event.Event{
+							ID:        "123",
+							TaskName:  "task_a",
+							StartTime: time.Now(),
+							EndTime:   time.Now(),
+							Success:   true,
+							Config: &event.Config{
+								Providers: []string{"local", "null", "f5"},
+								Services:  []string{"api", "web", "db"},
+								Source:    "../../test_modules/e2e_basic_task",
+							},
+						},
+						event.Event{
+							ID:        "456",
+							TaskName:  "task_a",
+							StartTime: time.Now(),
+							EndTime:   time.Now(),
+							Success:   false,
+							EventError: &event.Error{
+								Message: "there was an error :(",
+							},
+							Config: &event.Config{
+								Providers: []string{"local", "null", "f5"},
+								Services:  []string{"api", "web", "db"},
+								Source:    "../../test_modules/e2e_basic_task",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			"overall status: success",
 			http.StatusOK,
 			OverallStatus{Status: StatusDegraded},


### PR DESCRIPTION
Update task status endpoint to support a `?include=events` parameter. When this
parameter is included, the task status payload will include an `Event` field
containing an array of the events that inform the task status.

Example:

`GET /v1/status/tasks/task_a?include=events`

```
{
  "task_a": {
    "task_name": "task_a",
    "status": "healthy",
    "providers": [
      "local"
    ],
    "services": [
      "api",
    ],
    "events_url": "/v1/status/tasks/task_a?include=events",
    "events": [
      {
        "id": "44137ba2-8fc9-6cbe-0e0e-e9305ee4f7f9",
        "success": true,
        "start_time": "2020-11-24T12:06:51.858292-05:00",
        "end_time": "2020-11-24T12:06:52.770165-05:00",
        "task_name": "task_a",
        "error": null,
        "config": {
          "providers": [
            "local"
          ],
          "services": [
            "api",
          ],
          "source": "../modules/e2e_basic_task"
        }
      }
    ]
  }
}
```