### PR TITLE
Support `?status=<health_status>` parameter for task status

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -172,6 +172,42 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 				},
 			},
 		},
+		{
+			"all task status filtered by status and include events",
+			"status/tasks?status=critical&include=events",
+			map[string]api.TaskStatus{
+				fakeFailureTaskName: api.TaskStatus{
+					TaskName:  fakeFailureTaskName,
+					Status:    api.StatusCritical,
+					Providers: []string{"fake-sync"},
+					Services:  []string{"api"},
+					EventsURL: "/v1/status/tasks/fake_handler_failure_task?include=events",
+					Events: []event.Event{
+						event.Event{
+							TaskName: fakeFailureTaskName,
+							Success:  false,
+							EventError: &event.Error{
+								Message: "error failure",
+							},
+							Config: &event.Config{
+								Providers: []string{"fake-sync"},
+								Services:  []string{"api"},
+								Source:    "../../test_modules/e2e_basic_task",
+							},
+						},
+						event.Event{
+							TaskName: fakeFailureTaskName,
+							Success:  true,
+							Config: &event.Config{
+								Providers: []string{"fake-sync"},
+								Services:  []string{"api"},
+								Source:    "../../test_modules/e2e_basic_task",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range taskCases {


### PR DESCRIPTION
Update task status endpoint to support a `?status=<health_status>` parameter
where `<health_status>` values are: healthy, degraded, critical, undetermined. When the
parameter is included, the task statuses will be filtered to only include those
which have a status that matches the status query parameter value.

Example:

`GET /v1/status/tasks?status=critical`

```
{
  "task_b": {
    "task_name": "task_b",
    "status": "critical",
    "providers": [
      "local"
    ],
    "services": [
      "api",
    ],
    "events_url": "/v1/status/tasks/task_b?include=events"
  },
}
```