### PR TITLE
Fix leaky idle connections on shutdown

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -185,6 +185,7 @@ func (cli *CLI) Run(args []string) int {
 		log.Printf("[ERR] (cli) error setting up controller: %s", err)
 		return ExitCodeConfigError
 	}
+	defer ctrl.Stop()
 
 	errCh := make(chan error, 1)
 	exitBufLen := 2 // exit api & controller

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -166,6 +166,19 @@ func (ctrl *baseController) loadProviderConfigs(ctx context.Context) ([]hcltmpl.
 	return providerConfigs, nil
 }
 
+// logDepSize logs the watcher dependency size every nth iteration. Set the
+// iterator to a negative value to log each iteration.
+func (ctrl *baseController) logDepSize(n uint, i int64) {
+	depSize := ctrl.watcher.Size()
+	if i%int64(n) == 0 || i < 0 {
+		log.Printf("[DEBUG] (ctrl) watching %d dependencies", depSize)
+		if depSize > templates.DepSizeWarning {
+			log.Printf("[WARN] (ctrl) watching more than %d dependencies could "+
+				"DDoS your Consul cluster: %d", templates.DepSizeWarning, depSize)
+		}
+	}
+}
+
 // InstallDriver installs necessary drivers based on user configuration.
 func InstallDriver(ctx context.Context, conf *config.Config) error {
 	if conf.Driver.Terraform != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -29,6 +29,9 @@ type Controller interface {
 
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
 	Run(ctx context.Context) error
+
+	// Stop stops underlying clients and connections
+	Stop()
 }
 
 // Oncer describes the interface a controller that can run in once mode
@@ -75,6 +78,10 @@ func newBaseController(conf *config.Config) (*baseController, error) {
 		watcher:    watcher,
 		resolver:   hcat.NewResolver(),
 	}, nil
+}
+
+func (ctrl *baseController) Stop() {
+	ctrl.watcher.Stop()
 }
 
 func (ctrl *baseController) init(ctx context.Context) error {

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -51,7 +51,7 @@ func (ctrl *ReadOnly) Run(ctx context.Context) error {
 	log.Println("[INFO] (ctrl) inspecting all tasks")
 
 	completed := make(map[string]bool, len(ctrl.units))
-	for {
+	for i := int64(0); ; i++ {
 		done := true
 		for _, u := range ctrl.units {
 			if !completed[u.taskName] {
@@ -65,6 +65,7 @@ func (ctrl *ReadOnly) Run(ctx context.Context) error {
 				}
 			}
 		}
+		ctrl.logDepSize(50, i)
 		if done {
 			log.Println("[INFO] (ctrl) completed task inspections")
 			return nil

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -66,7 +66,8 @@ func TestReadOnlyRun(t *testing.T) {
 				Return(hcat.ResolveEvent{Complete: true}, tc.resolverRunErr)
 
 			w := new(mocks.Watcher)
-			w.On("Wait", mock.Anything).Return(tc.watcherWaitErr)
+			w.On("Wait", mock.Anything).Return(tc.watcherWaitErr).
+				On("Size").Return(5)
 
 			d := new(mocksD.Driver)
 			d.On("InspectTask", mock.Anything).Return(tc.inspectTaskErr)
@@ -97,6 +98,7 @@ func TestReadOnlyRun_context_cancel(t *testing.T) {
 
 	w := new(mocks.Watcher)
 	w.On("WaitCh", mock.Anything, mock.Anything).Return(nil).
+		On("Size").Return(5).
 		On("Stop").Return()
 
 	ctrl := ReadOnly{baseController: &baseController{

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -47,7 +47,7 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 	// mode so it can immediately render the first time.
 	rw.setTemplateBufferPeriods()
 
-	for {
+	for i := int64(1); ; i++ {
 		// Blocking on Wait is first as we just ran in Once mode so we want
 		// to wait for updates before re-running. Doing it the other way is
 		// basically a noop as it checks if templates have been changed but
@@ -68,6 +68,8 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 			// aggregate error collector for runUnits, just logs everything for now
 			log.Printf("[ERR] (ctrl) %s", err)
 		}
+
+		rw.logDepSize(50, i)
 	}
 }
 
@@ -102,7 +104,7 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 	log.Println("[INFO] (ctrl) executing all tasks once through")
 
 	completed := make(map[string]bool, len(rw.units))
-	for {
+	for i := int64(0); ; i++ {
 		done := true
 		for _, u := range rw.units {
 			if !completed[u.taskName] {
@@ -116,6 +118,7 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 				}
 			}
 		}
+		rw.logDepSize(50, i)
 		if done {
 			log.Println("[INFO] (ctrl) all tasks completed once")
 			return nil
@@ -163,7 +166,7 @@ func (rw *ReadWrite) checkApply(ctx context.Context, u unit) (bool, error) {
 	}
 	ev.Start()
 
-	log.Printf("[TRACE] (ctrl) checking dependencies changes for task %s", taskName)
+	log.Printf("[TRACE] (ctrl) checking dependency changes for task %s", taskName)
 	var result hcat.ResolveEvent
 	if result, storedErr = rw.resolver.Run(tmpl, rw.watcher); storedErr != nil {
 		defer storeEvent()

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -60,7 +60,6 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 
 		case <-ctx.Done():
 			log.Printf("[INFO] (ctrl) stopping controller")
-			rw.watcher.Stop()
 			return ctx.Err()
 		}
 

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -190,6 +190,7 @@ func TestOnce(t *testing.T) {
 		var errChRc <-chan error = errCh
 		go func() { errCh <- nil }()
 		w.On("WaitCh", mock.Anything).Return(errChRc).Once()
+		w.On("Size").Return(5)
 
 		d := new(mocksD.Driver)
 		d.On("InitTask", mock.Anything).Return(nil).Once()
@@ -251,7 +252,8 @@ func TestReadWriteUnits(t *testing.T) {
 		Return(hcat.ResolveEvent{Complete: true}, nil)
 
 	w := new(mocks.Watcher)
-	w.On("Wait", mock.Anything).Return(nil)
+	w.On("Wait", mock.Anything).Return(nil).
+		On("Size").Return(5)
 
 	t.Run("simple-success", func(t *testing.T) {
 		d := new(mocksD.Driver)
@@ -306,6 +308,7 @@ func TestReadWriteUnits(t *testing.T) {
 func TestReadWriteRun_context_cancel(t *testing.T) {
 	w := new(mocks.Watcher)
 	w.On("WaitCh", mock.Anything, mock.Anything).Return(nil).
+		On("Size").Return(5).
 		On("Stop").Return()
 
 	ctl := ReadWrite{

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -105,6 +105,20 @@ func (_m *Watcher) SetBufferPeriod(min time.Duration, max time.Duration, tmplIDs
 	_m.Called(_ca...)
 }
 
+// Size provides a mock function with given fields:
+func (_m *Watcher) Size() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
 // Stop provides a mock function with given fields:
 func (_m *Watcher) Stop() {
 	_m.Called()

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -16,6 +16,10 @@ var _ hcat.Templater = (Template)(nil)
 var _ hcat.Renderer = (Template)(nil)
 var _ Watcher = (*hcat.Watcher)(nil)
 
+// DepSizeWarning is the threshold of dependencies that we warn the user
+// of CTS potentially DDoSing their Consul cluster.
+const DepSizeWarning = 128
+
 // Template describes the interface for hashicat's Template structure
 // which implements the interfaces Templater and Renderer
 // https://github.com/hashicorp/hcat

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -43,5 +43,6 @@ type Watcher interface {
 	Recall(id string) (interface{}, bool)
 	Register(tmplID string, deps ...dep.Dependency)
 	SetBufferPeriod(min, max time.Duration, tmplIDs ...string)
+	Size() int
 	Stop()
 }


### PR DESCRIPTION
`hcat.Watcher.Stop()` closes out client idle connections. It was not being called for 3 shutdown scenarios
* Errors
* Once mode
* Inspect mode

Changes now ensure the controller calls stop on its watcher. Also adds conditional logging on the hcat dependency size. This PR doesn't fix #146 where CTS quickly reaches the connection limit for the Consul agent, but is related to help debug.

Resolves #149