### PR TITLE
Add task_env to provider blocks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,9 @@ import "context"
 // Client describes the interface for a driver's client that interacts
 // with network infrastructure.
 type Client interface {
+	// Set the environment for the client
+	SetEnv(map[string]string) error
+
 	// Init initializes the client and environment
 	Init(ctx context.Context) error
 

--- a/client/printer.go
+++ b/client/printer.go
@@ -42,6 +42,13 @@ func NewPrinter(config *PrinterConfig) (*Printer, error) {
 	}, nil
 }
 
+// SetEnv logs out 'setenv'
+func (p *Printer) SetEnv(map[string]string) error {
+	p.logger.Printf("[INFO] (client.printer) setting workspace environment: "+
+		"'%s', workingdir: '%s'", p.workspace, p.workingDir)
+	return nil
+}
+
 // Init logs out 'init'
 func (p *Printer) Init(ctx context.Context) error {
 	p.logger.Printf("[INFO] (client.printer) initing workspace: '%s', workingdir: '%s'",

--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -87,6 +87,11 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 	return client, nil
 }
 
+// SetEnv sets the environment for the Terraform workspace
+func (t *TerraformCLI) SetEnv(env map[string]string) error {
+	return t.tf.SetEnv(env)
+}
+
 // Init initializes by executing the cli command `terraform init` and
 // `terraform workspace new <name>`
 func (t *TerraformCLI) Init(ctx context.Context) error {

--- a/config/provider.go
+++ b/config/provider.go
@@ -135,6 +135,14 @@ func (c *TerraformProviderConfig) Validate() error {
 		return fmt.Errorf("unexpected provider block labels: %s", strings.Join(labels, ","))
 	}
 
+	taskEnv, exists := (*c)["task_env"]
+	if exists {
+		_, okType := taskEnv.(map[string]string)
+		if !okType {
+			return fmt.Errorf("unexpected task_env block format")
+		}
+	}
+
 	return nil
 }
 

--- a/config/provider.go
+++ b/config/provider.go
@@ -126,20 +126,30 @@ func (c *TerraformProviderConfig) Validate() error {
 
 	numLabels := len(*c)
 	if numLabels == 0 {
-		return fmt.Errorf("missing provider name for the provider block")
+		return fmt.Errorf("missing provider name for the terraform_provider block")
 	} else if numLabels > 1 {
 		labels := make([]string, 0, numLabels)
 		for l := range *c {
 			labels = append(labels, l)
 		}
-		return fmt.Errorf("unexpected provider block labels: %s", strings.Join(labels, ","))
+		return fmt.Errorf("unexpected terraform_provider block labels: %s", strings.Join(labels, ","))
 	}
 
-	taskEnv, exists := (*c)["task_env"]
-	if exists {
-		_, okType := taskEnv.(map[string]string)
-		if !okType {
-			return fmt.Errorf("unexpected task_env block format")
+	for label := range *c {
+		// Validate block format
+		rawBlock := (*c)[label]
+		block, ok := rawBlock.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected terraform_provider block format")
+		}
+
+		// Validate task_env format if exists
+		taskEnv, exists := block["task_env"]
+		if exists {
+			_, ok := taskEnv.(map[string]string)
+			if !ok {
+				return fmt.Errorf("unexpected task_env block format")
+			}
 		}
 	}
 

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -272,11 +272,33 @@ func TestProviderConfigs_Validate(t *testing.T) {
 				},
 			}},
 			false,
+		}, {
+			"task_env",
+			&TerraformProviderConfigs{{
+				"null": map[string]interface{}{
+					"task_env": map[string]string{
+						"NULL_TOKEN": "{{ env \"MY_CTS_NULL_TOKEN\" }}",
+						"NULL_BOOL":  "true",
+						"NULL_NUM":   "10",
+					},
+				},
+			}},
+			true,
+		}, {
+			"task_env invalid",
+			&TerraformProviderConfigs{{
+				"null": map[string]interface{}{
+					"task_env": map[string]interface{}{
+						"NULL_BOOL": true,
+					},
+				},
+			}},
+			false,
 		},
 	}
 
-	for i, tc := range cases {
-		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			err := tc.i.Validate()
 			if tc.isValid {
 				assert.NoError(t, err)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -197,12 +197,13 @@ func TestNewDriverTasks(t *testing.T) {
 			},
 			[]driver.Task{{
 				Name: "name",
-				Providers: hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
-					{"providerA": map[string]interface{}{}},
-					{"providerB": map[string]interface{}{
-						"var": "val",
-					}},
-				}),
+				Providers: driver.NewTerraformProviderBlocks(
+					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
+						{"providerA": map[string]interface{}{}},
+						{"providerB": map[string]interface{}{
+							"var": "val",
+						}},
+					})),
 				ProviderInfo: map[string]interface{}{
 					"providerA": map[string]string{
 						"source": "source/providerA",
@@ -249,15 +250,16 @@ func TestNewDriverTasks(t *testing.T) {
 			},
 			[]driver.Task{{
 				Name: "name",
-				Providers: hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
-					{"providerA": map[string]interface{}{
-						"alias": "alias1",
-						"foo":   "bar",
-					}},
-					{"providerB": map[string]interface{}{
-						"var": "val",
-					}},
-				}),
+				Providers: driver.NewTerraformProviderBlocks(
+					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
+						{"providerA": map[string]interface{}{
+							"alias": "alias1",
+							"foo":   "bar",
+						}},
+						{"providerB": map[string]interface{}{
+							"var": "val",
+						}},
+					})),
 				ProviderInfo: map[string]interface{}{
 					"providerA": map[string]string{
 						"source": "source/providerA",
@@ -274,10 +276,11 @@ func TestNewDriverTasks(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.conf.Finalize()
 
-			var providerConfigs []hcltmpl.NamedBlock
+			var providerConfigs []driver.TerraformProviderBlock
 			if tc.conf != nil && tc.conf.TerraformProviders != nil {
 				for _, pconf := range *tc.conf.TerraformProviders {
-					providerConfigs = append(providerConfigs, hcltmpl.NewNamedBlockTest(*pconf))
+					providerBlock := driver.NewTerraformProviderBlock(hcltmpl.NewNamedBlockTest(*pconf))
+					providerConfigs = append(providerConfigs, providerBlock)
 				}
 			}
 

--- a/driver/task.go
+++ b/driver/task.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/client"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
-	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 )
 
 // Service contains service configuration information
@@ -21,8 +20,8 @@ type Service struct {
 type Task struct {
 	Description  string
 	Name         string
-	Providers    []hcltmpl.NamedBlock   // task.providers config info
-	ProviderInfo map[string]interface{} // driver.required_provider config info
+	Providers    TerraformProviderBlocks // task.providers config info
+	ProviderInfo map[string]interface{}  // driver.required_provider config info
 	Services     []Service
 	Source       string
 	VarFiles     []string
@@ -33,7 +32,7 @@ type Task struct {
 func (t *Task) ProviderNames() []string {
 	names := make([]string, len(t.Providers))
 	for ix, p := range t.Providers {
-		names[ix] = p.Name
+		names[ix] = p.Name()
 	}
 	return names
 }

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -71,12 +71,13 @@ func TestTask_ProviderNames(t *testing.T) {
 		{
 			"happy path",
 			Task{
-				Providers: hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
-					{"local": map[string]interface{}{
-						"configs": "stuff",
-					}},
-					{"null": map[string]interface{}{}},
-				}),
+				Providers: NewTerraformProviderBlocks(
+					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
+						{"local": map[string]interface{}{
+							"configs": "stuff",
+						}},
+						{"null": map[string]interface{}{}},
+					})),
 			},
 			[]string{"local", "null"},
 		},

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -237,13 +237,13 @@ func getTerraformHandlers(task Task) (handler.Handler, error) {
 		if err != nil {
 			log.Printf(
 				"[ERR] (driver.terraform) could not initialize handler for "+
-					"provider '%s': %s", p.Name, err)
+					"provider '%s': %s", p.Name(), err)
 			return nil, err
 		}
 		if h != nil {
 			counter++
 			log.Printf(
-				"[INFO] (driver.terraform) retrieved handler for provider '%s'", p.Name)
+				"[INFO] (driver.terraform) retrieved handler for provider '%s'", p.Name())
 			h.SetNext(next)
 			next = h
 		}

--- a/driver/terraform_provider.go
+++ b/driver/terraform_provider.go
@@ -2,13 +2,19 @@ package driver
 
 import "github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 
+// TerraformProviderBlock contains provider arguments and environment variables
+// for the Terraform provider.
 type TerraformProviderBlock struct {
 	block hcltmpl.NamedBlock
 	env   map[string]string
 }
 
+// TerraformProviderBlocks are a list of providers and their arguments and env
 type TerraformProviderBlocks []TerraformProviderBlock
 
+// NewTerraformProviderBlocks creates a new list of provider blocks with the
+// environment variables separated from provider arguments from the base hcl
+// block.
 func NewTerraformProviderBlocks(blocks []hcltmpl.NamedBlock) TerraformProviderBlocks {
 	providers := make([]TerraformProviderBlock, len(blocks))
 	for i, p := range blocks {
@@ -17,6 +23,8 @@ func NewTerraformProviderBlocks(blocks []hcltmpl.NamedBlock) TerraformProviderBl
 	return providers
 }
 
+// NewTerraformProviderBlock creates a provider block with the environment
+// variables separated from provider arguments from the base hcl block.
 func NewTerraformProviderBlock(b hcltmpl.NamedBlock) TerraformProviderBlock {
 	env := make(map[string]string)
 
@@ -37,18 +45,25 @@ func NewTerraformProviderBlock(b hcltmpl.NamedBlock) TerraformProviderBlock {
 	}
 }
 
+// Name returns the name of the provider. This is the label of the HCL named
+// block.
 func (p TerraformProviderBlock) Name() string {
 	return p.block.Name
 }
 
+// ProviderBlock returns the arguments for the Terraform provider block.
 func (p TerraformProviderBlock) ProviderBlock() hcltmpl.NamedBlock {
 	return p.block
 }
 
+// Env returns the configured environment variables for the Terraform provider.
+// These values are set for the task workspace and are not written to any
+// generated Terraform configuration file.
 func (p TerraformProviderBlock) Env() map[string]string {
 	return p.env
 }
 
+// ProviderBlocks returns a list of the provider blocks.
 func (p TerraformProviderBlocks) ProviderBlocks() []hcltmpl.NamedBlock {
 	blocks := make([]hcltmpl.NamedBlock, len(p))
 	for i, b := range p {
@@ -57,6 +72,7 @@ func (p TerraformProviderBlocks) ProviderBlocks() []hcltmpl.NamedBlock {
 	return blocks
 }
 
+// Env returns a merged map of environment variables across all providers.
 func (p TerraformProviderBlocks) Env() map[string]string {
 	env := make(map[string]string)
 	for _, b := range p {

--- a/driver/terraform_provider.go
+++ b/driver/terraform_provider.go
@@ -1,0 +1,68 @@
+package driver
+
+import "github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
+
+type TerraformProviderBlock struct {
+	block hcltmpl.NamedBlock
+	env   map[string]string
+}
+
+type TerraformProviderBlocks []TerraformProviderBlock
+
+func NewTerraformProviderBlocks(blocks []hcltmpl.NamedBlock) TerraformProviderBlocks {
+	providers := make([]TerraformProviderBlock, len(blocks))
+	for i, p := range blocks {
+		providers[i] = NewTerraformProviderBlock(p)
+	}
+	return providers
+}
+
+func NewTerraformProviderBlock(b hcltmpl.NamedBlock) TerraformProviderBlock {
+	env := make(map[string]string)
+
+	copy := b.Copy()
+	for k, v := range copy.Variables {
+		if k == "task_env" && v.Type().IsObjectType() {
+			for envKey, envVal := range v.AsValueMap() {
+				env[envKey] = envVal.AsString()
+			}
+			delete(copy.Variables, k)
+			break
+		}
+	}
+
+	return TerraformProviderBlock{
+		block: copy,
+		env:   env,
+	}
+}
+
+func (p TerraformProviderBlock) Name() string {
+	return p.block.Name
+}
+
+func (p TerraformProviderBlock) ProviderBlock() hcltmpl.NamedBlock {
+	return p.block
+}
+
+func (p TerraformProviderBlock) Env() map[string]string {
+	return p.env
+}
+
+func (p TerraformProviderBlocks) ProviderBlocks() []hcltmpl.NamedBlock {
+	blocks := make([]hcltmpl.NamedBlock, len(p))
+	for i, b := range p {
+		blocks[i] = b.ProviderBlock()
+	}
+	return blocks
+}
+
+func (p TerraformProviderBlocks) Env() map[string]string {
+	env := make(map[string]string)
+	for _, b := range p {
+		for k, v := range b.Env() {
+			env[k] = v
+		}
+	}
+	return env
+}

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -113,12 +113,12 @@ func TestGetTerraformHandlers(t *testing.T) {
 			true,
 			true,
 			Task{
-				Providers: []hcltmpl.NamedBlock{
+				Providers: NewTerraformProviderBlocks([]hcltmpl.NamedBlock{
 					hcltmpl.NewNamedBlock(map[string]interface{}{
 						handler.TerraformProviderFake: map[string]interface{}{
 							"required-config": "missing",
 						},
-					})},
+					})}),
 			},
 		},
 		{
@@ -126,10 +126,10 @@ func TestGetTerraformHandlers(t *testing.T) {
 			false,
 			true,
 			Task{
-				Providers: []hcltmpl.NamedBlock{
+				Providers: NewTerraformProviderBlocks([]hcltmpl.NamedBlock{
 					hcltmpl.NewNamedBlock(map[string]interface{}{
 						"provider-no-handler": map[string]interface{}{},
-					})},
+					})}),
 			},
 		},
 		{
@@ -137,12 +137,12 @@ func TestGetTerraformHandlers(t *testing.T) {
 			false,
 			false,
 			Task{
-				Providers: []hcltmpl.NamedBlock{
+				Providers: NewTerraformProviderBlocks([]hcltmpl.NamedBlock{
 					hcltmpl.NewNamedBlock(map[string]interface{}{
 						handler.TerraformProviderFake: map[string]interface{}{
 							"name": "happy-path",
 						},
-					})},
+					})}),
 			},
 		},
 	}

--- a/mocks/client/client.go
+++ b/mocks/client/client.go
@@ -68,3 +68,17 @@ func (_m *Client) Plan(ctx context.Context) error {
 
 	return r0
 }
+
+// SetEnv provides a mock function with given fields: _a0
+func (_m *Client) SetEnv(_a0 map[string]string) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(map[string]string) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/templates/hcltmpl/block.go
+++ b/templates/hcltmpl/block.go
@@ -7,6 +7,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+// Variables are the cty value representation of HCL block arguments
 type Variables map[string]cty.Value
 
 // NamedBlock represents an HCL block with one label and an arbitrary number of
@@ -62,6 +63,20 @@ func NewNamedBlock(b map[string]interface{}) NamedBlock {
 		Name:      name,
 		Variables: vars,
 		rawConfig: rawBlock,
+	}
+}
+
+// Copy creates a copy of the NamedBlock with a shallow copy of the raw config
+func (b *NamedBlock) Copy() NamedBlock {
+	vars := make(map[string]cty.Value)
+	for k, v := range b.Variables {
+		vars[k] = v
+	}
+
+	return NamedBlock{
+		Name:      b.Name,
+		Variables: vars,
+		rawConfig: b.rawConfig,
 	}
 }
 

--- a/templates/hcltmpl/block.go
+++ b/templates/hcltmpl/block.go
@@ -106,7 +106,7 @@ func (b *NamedBlock) ObjectVal() *cty.Value {
 	return b.objectValueCache
 }
 
-func (b *NamedBlock) RawConfig() map[string]interface{} {
+func (b NamedBlock) RawConfig() map[string]interface{} {
 	return b.rawConfig
 }
 

--- a/templates/hcltmpl/dynamic_test.go
+++ b/templates/hcltmpl/dynamic_test.go
@@ -152,6 +152,23 @@ func TestLoadDynamicConfig(t *testing.T) {
 					"list": cty.TupleVal([]cty.Value{tmplVal, cty.StringVal("item")}),
 				},
 			},
+		}, {
+			"dynamic task_env",
+			map[string]interface{}{
+				"foo": map[string]interface{}{
+					"task_env": map[string]interface{}{
+						"FOO_TOKEN": "{{ env \"CTS_FOO_TOKEN\" }}",
+					},
+				},
+			},
+			NamedBlock{
+				Name: "foo",
+				Variables: map[string]cty.Value{
+					"task_env": cty.ObjectVal(map[string]cty.Value{
+						"FOO_TOKEN": tmplVal,
+					}),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Adds support for `terraform_provider` blocks to configure provider environment variables using the meta block `task_env`. Dynamic config source is supported within the `task_env` block.

```hcl
terraform_provider "foo" {
  address = "foo.example.com"
  task_env {
     "FOO_TOKEN" = "{{ env \"CTS_FOO_TOKEN\" }}"
  }
}
```

This is useful to keep sensitive provider arguments out of the generated `terraform.tfvars` for each task. The environment variables are passed to Terraform workspaces that use that provider. The envvars are not accessible to other tasks or set to the global env scope.

The `task_env` is also useful to decouple the expected environment name for Terraform providers. A few use cases here:
* CTS configuring multiple instances of a provider for different tasks. Without the `task_env` block, the provider instances would consume from the same environment value which may not be desired in preference for different tokens per instance.
* An existing process is consuming from an env name that a provider in CTS also consumes from but requires different configuration.