### PR TITLE
Change default port that API is served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ FEATURES:
   * azurerm, cos, gcs, kubernetes, local, manta, pg, s3
 * Add configuration option to select Terraform version to install and run [[GH-131](https://github.com/hashicorp/consul-terraform-sync/pull/131)]
   * Add support to run Terraform version 0.14
-* Add status api to view status information about task execution
+* Add status api to view status information about task execution. Served by default at port 8558
   * Task-status api for status of each task [[GH-138](https://github.com/hashicorp/consul-terraform-sync/pull/138)]
   * Overall-status api for the overall status across tasks [[GH-142](https://github.com/hashicorp/consul-terraform-sync/pull/142)]
   * Support configuring `port` on which the api is served [[GH-141](https://github.com/hashicorp/consul-terraform-sync/pull/141)]

--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ const (
 	DefaultLogLevel = "WARN"
 
 	// defaultPort is the default port to use for api server.
-	defaultPort = 8501
+	defaultPort = 8558
 )
 
 // Config is used to configure Sync


### PR DESCRIPTION
 - Anticipate that CTS will be run on the same node as Consul
 - Port 8501 is reserved by Consul. Other Consul reserved ports:
 https://www.consul.io/docs/install/ports#ports-table
 - Consul team recommends using port in 8500s for http api and has no
 reservations for 8558 for current and future work as of now
 - 8558 is not a known/taken/reserved port with IANA