### PR TITLE
Rename health status language

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -16,53 +16,39 @@ import (
 const (
 	defaultAPIVersion = "v1"
 
-	// StatusHealthy is the healthy status. This is determined based on status
+	// StatusSuccessful is the successful status. This is determined based on status
 	// type.
 	//
 	// Task Status: Determined by the success of a task updating. The 5 most
-	// recent task updates are stored as an ‘event’ in CTS. A task is healthy
-	// when all the stored events are successful.
-	//
-	// Overall Status: Determined by the health across all task statuses.
-	// Overall status is healthy when all task statuses are healthy.
-	StatusHealthy = "healthy"
+	// recent task updates are stored as an ‘event’ in CTS. A task is successful
+	// when the most recent stored event is successful.
+	StatusSuccessful = "successful"
 
-	// StatusDegraded is the degraded status. This is determined based on status
+	// StatusErrored is the errored status. This is determined based on status
 	// type.
 	//
 	// Task Status: Determined by the success of a task updating. The 5 most
-	// recent task updates are stored as an ‘event’ in CTS. A task is degraded
-	// when more than half of the stored events are successful _or_ less than
-	// half of the stored events are successful but the most recent event is
-	// successful.
-	//
-	// Overall Status: Determined by the health across all task statuses.
-	// Overall status is degraded when at least one task status is degraded but
-	// none are critical.
-	StatusDegraded = "degraded"
+	// recent task updates are stored as an ‘event’ in CTS. A task is errored
+	// when the most recent stored event is not successful but all prior stored
+	// events are successful.
+	StatusErrored = "errored"
 
 	// StatusCritical is the critical status. This is determined based on status
 	// type.
 	//
 	// Task Status: Determined by the success of a task updating. The 5 most
 	// recent task updates are stored as an ‘event’ in CTS. A task is critical
-	// when less than half of the stored events are successful and the most
-	// recent event is not successful.
-	//
-	// Overall Status: Determined by the health across all task statuses.
-	// Overall status is critical when at least one task status is critical.
+	// when the most recent stored event is not successful and at least one prior
+	// stored event is all not succesful.
 	StatusCritical = "critical"
 
-	// StatusUndetermined is when the status is unknown. This is determined
+	// StatusUnknown is when the status is unknown. This is determined
 	// based on status type.
 	//
 	// Task Status: Determined by the success of a task updating. The 5 most
 	// recent task updates are stored as an ‘event’ in CTS. A task is
-	// undetermined when no event data has been collected yet.
-	//
-	// Overall Status: Determined by the health across all task statuses.
-	// Overall status is undetermined when no task status information exists yet.
-	StatusUndetermined = "undetermined"
+	// unknown when no event data has been collected yet.
+	StatusUnknown = "unknown"
 )
 
 // API supports api requests to the cts biniary

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -148,14 +148,14 @@ func TestJsonResponse(t *testing.T) {
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
 					TaskName:  "task_a",
-					Status:    StatusDegraded,
+					Status:    StatusErrored,
 					Providers: []string{"local", "null", "f5"},
 					Services:  []string{"api", "web", "db"},
 					EventsURL: "/v1/status/tasks/test_task?include=events",
 				},
 				"task_b": TaskStatus{
 					TaskName:  "task_b",
-					Status:    StatusUndetermined,
+					Status:    StatusUnknown,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "",
@@ -168,7 +168,7 @@ func TestJsonResponse(t *testing.T) {
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
 					TaskName:  "task_a",
-					Status:    StatusDegraded,
+					Status:    StatusErrored,
 					Providers: []string{"local", "null", "f5"},
 					Services:  []string{"api", "web", "db"},
 					EventsURL: "/v1/status/tasks/test_task?include=events",
@@ -207,7 +207,7 @@ func TestJsonResponse(t *testing.T) {
 		{
 			"overall status: success",
 			http.StatusOK,
-			OverallStatus{Status: StatusDegraded},
+			OverallStatus{Status: StatusErrored},
 		},
 	}
 	for _, tc := range cases {

--- a/api/overall_status.go
+++ b/api/overall_status.go
@@ -57,7 +57,7 @@ func (h *overallStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func taskStatusToOverall(statuses []string) string {
 	total := len(statuses)
 	if total == 0 {
-		return StatusUndetermined
+		return StatusUnknown
 	}
 
 	statCount := make(map[string]int)
@@ -65,15 +65,15 @@ func taskStatusToOverall(statuses []string) string {
 		statCount[status]++
 	}
 
-	healthy := statCount[StatusHealthy]
-	degraded := statCount[StatusDegraded]
+	successful := statCount[StatusSuccessful]
+	errored := statCount[StatusErrored]
 	critical := statCount[StatusCritical]
 
 	switch {
-	case healthy == total:
-		return StatusHealthy
-	case degraded > 0 && critical == 0:
-		return StatusDegraded
+	case successful == total:
+		return StatusSuccessful
+	case errored > 0 && critical == 0:
+		return StatusErrored
 	default:
 		return StatusCritical
 	}

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -86,24 +86,27 @@ func TestOverallStatus_TaskStatusToOverall(t *testing.T) {
 		expected string
 	}{
 		{
-			"healthy: all healthy",
-			[]string{StatusHealthy, StatusHealthy, StatusHealthy, StatusHealthy, StatusHealthy},
-			StatusHealthy,
+			"successful: all successful",
+			[]string{StatusSuccessful, StatusSuccessful, StatusSuccessful,
+				StatusSuccessful, StatusSuccessful},
+			StatusSuccessful,
 		},
 		{
-			"degraded: mix of degraded and healthy",
-			[]string{StatusHealthy, StatusHealthy, StatusDegraded, StatusHealthy, StatusDegraded},
-			StatusDegraded,
+			"errored: mix of errored and successful",
+			[]string{StatusSuccessful, StatusSuccessful, StatusErrored,
+				StatusSuccessful, StatusErrored},
+			StatusErrored,
 		},
 		{
 			"critical: at least one critical",
-			[]string{StatusHealthy, StatusHealthy, StatusDegraded, StatusHealthy, StatusCritical},
+			[]string{StatusSuccessful, StatusSuccessful, StatusErrored,
+				StatusSuccessful, StatusCritical},
 			StatusCritical,
 		},
 		{
 			"no data",
 			[]string{},
-			StatusUndetermined,
+			StatusUnknown,
 		},
 	}
 

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -144,7 +144,7 @@ func mapKeyToArray(m map[string]bool) []string {
 // successToStatus determines a status from an array of success/failures
 func successToStatus(successes []bool) string {
 	if len(successes) == 0 {
-		return StatusUndetermined
+		return StatusUnknown
 	}
 
 	total := len(successes)
@@ -159,11 +159,11 @@ func successToStatus(successes []bool) string {
 	percentSuccess := 100 * successCount / total
 	switch {
 	case percentSuccess == 100:
-		return StatusHealthy
+		return StatusSuccessful
 	case percentSuccess > 50:
-		return StatusDegraded
+		return StatusErrored
 	case mostRecentSuccess == true:
-		return StatusDegraded
+		return StatusErrored
 	default:
 		return StatusCritical
 	}
@@ -222,12 +222,12 @@ func statusFilter(r *http.Request) (string, error) {
 	value := keys[0]
 	value = strings.ToLower(value)
 	switch value {
-	case StatusHealthy, StatusDegraded, StatusCritical, StatusUndetermined:
+	case StatusSuccessful, StatusErrored, StatusCritical, StatusUnknown:
 		return value, nil
 	default:
 		return "", fmt.Errorf("unsupported status parameter value. only "+
 			"supporting status values %s, %s, %s, and %s but got %s",
-			StatusHealthy, StatusDegraded, StatusCritical, StatusUndetermined,
+			StatusSuccessful, StatusErrored, StatusCritical, StatusUnknown,
 			value)
 	}
 }

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -47,14 +47,14 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
 					TaskName:  "task_a",
-					Status:    "healthy",
+					Status:    StatusSuccessful,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "/v1/status/tasks/task_a?include=events",
 				},
 				"task_b": TaskStatus{
 					TaskName:  "task_b",
-					Status:    "critical",
+					Status:    StatusCritical,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "/v1/status/tasks/task_b?include=events",
@@ -68,7 +68,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
 					TaskName:  "task_a",
-					Status:    "healthy",
+					Status:    StatusSuccessful,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "/v1/status/tasks/task_a?include=events",
@@ -110,7 +110,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		},
 		{
 			"all task statuses filtered by status with no result",
-			"/v1/status/tasks?status=degraded",
+			"/v1/status/tasks?status=errored",
 			http.StatusOK,
 			map[string]TaskStatus{},
 		},
@@ -155,7 +155,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			map[string]TaskStatus{
 				"task_nonexistent": TaskStatus{
 					TaskName:  "task_nonexistent",
-					Status:    "undetermined",
+					Status:    StatusUnknown,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "",
@@ -169,7 +169,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			map[string]TaskStatus{
 				"task_nonexistent": TaskStatus{
 					TaskName:  "task_nonexistent",
-					Status:    "undetermined",
+					Status:    StatusUnknown,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "",
@@ -313,7 +313,7 @@ func TestTaskStatus_MakeStatus(t *testing.T) {
 			},
 			TaskStatus{
 				TaskName:  "test_task",
-				Status:    StatusDegraded,
+				Status:    StatusErrored,
 				Providers: []string{"local", "null", "f5"},
 				Services:  []string{"api", "web", "db"},
 				EventsURL: "/v1/status/tasks/test_task?include=events",
@@ -324,7 +324,7 @@ func TestTaskStatus_MakeStatus(t *testing.T) {
 			[]event.Event{},
 			TaskStatus{
 				TaskName:  "test_task",
-				Status:    StatusUndetermined,
+				Status:    StatusUnknown,
 				Providers: []string{},
 				Services:  []string{},
 				EventsURL: "",
@@ -405,12 +405,12 @@ func TestTaskStatus_SuccessToStatus(t *testing.T) {
 		{
 			"all successes",
 			[]bool{true, true, true, true, true},
-			StatusHealthy,
+			StatusSuccessful,
 		},
 		{
 			"more than half success",
 			[]bool{false, false, true, true, true},
-			StatusDegraded,
+			StatusErrored,
 		},
 		{
 			"less than half success - most recent failure",
@@ -420,7 +420,7 @@ func TestTaskStatus_SuccessToStatus(t *testing.T) {
 		{
 			"less than half success - most recent success",
 			[]bool{true, false, false, false, true},
-			StatusDegraded,
+			StatusErrored,
 		},
 		{
 			"no successes",
@@ -430,7 +430,7 @@ func TestTaskStatus_SuccessToStatus(t *testing.T) {
 		{
 			"no data",
 			[]bool{},
-			StatusUndetermined,
+			StatusUnknown,
 		},
 	}
 
@@ -538,14 +538,14 @@ func TestTaskStatus_StatusFilter(t *testing.T) {
 	}{
 		{
 			"happy path status",
-			"/v1/status/tasks?status=healthy",
-			StatusHealthy,
+			"/v1/status/tasks?status=successful",
+			StatusSuccessful,
 			false,
 		},
 		{
 			"happy path status with other parameters",
-			"/v1/status/tasks?&status=healthy&include=events",
-			StatusHealthy,
+			"/v1/status/tasks?&status=successful&include=events",
+			StatusSuccessful,
 			false,
 		},
 		{
@@ -556,8 +556,8 @@ func TestTaskStatus_StatusFilter(t *testing.T) {
 		},
 		{
 			"not lower case",
-			"/v1/status/tasks?status=HEALTHY",
-			StatusHealthy,
+			"/v1/status/tasks?status=SUCCESSFUL",
+			StatusSuccessful,
 			false,
 		},
 		{
@@ -568,7 +568,7 @@ func TestTaskStatus_StatusFilter(t *testing.T) {
 		},
 		{
 			"too many status parameters",
-			"/v1/status/tasks?status=healthy&status=critical",
+			"/v1/status/tasks?status=successful&status=critical",
 			"",
 			true,
 		},

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -68,7 +68,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			map[string]api.TaskStatus{
 				fakeSuccessTaskName: api.TaskStatus{
 					TaskName:  fakeSuccessTaskName,
-					Status:    api.StatusHealthy,
+					Status:    api.StatusSuccessful,
 					Providers: []string{"fake-sync"},
 					Services:  []string{"api"},
 					EventsURL: "/v1/status/tasks/fake_handler_success_task?include=events",
@@ -88,7 +88,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			map[string]api.TaskStatus{
 				fakeSuccessTaskName: api.TaskStatus{
 					TaskName:  fakeSuccessTaskName,
-					Status:    api.StatusHealthy,
+					Status:    api.StatusSuccessful,
 					Providers: []string{"fake-sync"},
 					Services:  []string{"api"},
 					EventsURL: "/v1/status/tasks/fake_handler_success_task?include=events",
@@ -101,7 +101,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			map[string]api.TaskStatus{
 				"non-existing-task": api.TaskStatus{
 					TaskName:  "non-existing-task",
-					Status:    api.StatusUndetermined,
+					Status:    api.StatusUnknown,
 					Providers: []string{},
 					Services:  []string{},
 					EventsURL: "",


### PR DESCRIPTION
 - 'healthy' => 'successful'
 - 'degraded' => 'errored'
 - 'undetermined' => 'unknown'

Subsequent PRs will update with the new 'calculation' of these statuses