### PR TITLE
Change events status logic to focus on latest event

### DIFF
--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -43,7 +43,7 @@ func TestOverallStatus_ServeHTTP(t *testing.T) {
 			"happy path",
 			"/v1/status",
 			http.StatusOK,
-			OverallStatus{Status: StatusCritical},
+			OverallStatus{Status: StatusErrored},
 		},
 	}
 

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -147,26 +147,24 @@ func successToStatus(successes []bool) string {
 		return StatusUnknown
 	}
 
-	total := len(successes)
-	mostRecentSuccess := successes[0]
-	successCount := 0
-	for _, s := range successes {
-		if s {
-			successCount++
+	latest := successes[0]
+	if latest {
+		// Last event was successful
+		return StatusSuccessful
+	}
+
+	// Last event had errored, determine if the task is in critical state.
+	var errorsCount int
+	for _, success := range successes {
+		if !success {
+			errorsCount++
 		}
 	}
 
-	percentSuccess := 100 * successCount / total
-	switch {
-	case percentSuccess == 100:
-		return StatusSuccessful
-	case percentSuccess > 50:
-		return StatusErrored
-	case mostRecentSuccess == true:
-		return StatusErrored
-	default:
+	if errorsCount > 1 {
 		return StatusCritical
 	}
+	return StatusErrored
 }
 
 // makeEventsURL returns an events URL for a task. Returns an empty string

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -75,7 +75,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 				},
 				fakeFailureTaskName: api.TaskStatus{
 					TaskName:  fakeFailureTaskName,
-					Status:    api.StatusCritical,
+					Status:    api.StatusErrored,
 					Providers: []string{"fake-sync"},
 					Services:  []string{"api"},
 					EventsURL: "/v1/status/tasks/fake_handler_failure_task?include=events",
@@ -152,7 +152,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 		},
 		{
 			"events: all task statuses filtered by status",
-			"status/tasks?status=critical&include=events",
+			"status/tasks?status=errored&include=events",
 			false,
 			true,
 		},
@@ -186,7 +186,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			"overall status",
 			"status",
 			api.OverallStatus{
-				Status: api.StatusCritical,
+				Status: api.StatusErrored,
 			},
 		},
 	}

--- a/event/store.go
+++ b/event/store.go
@@ -43,7 +43,8 @@ func (s *Store) Add(e Event) error {
 }
 
 // Read returns events for a task name. If no task name is specified, return
-// events for all tasks. Returned events are ordered by decending end time
+// events for all tasks. Returned events are sorted in reverse chronological
+// order based on the end time.
 func (s *Store) Read(taskName string) map[string][]Event {
 	s.mu.RLock()
 	defer s.mu.RUnlock()


### PR DESCRIPTION
The last task execution determines if the network infra is synchronized with Consul.

**Note**: the logic for Overall status is not updated within this PR and do not reflect the end goal of overall. The tests are updated just to pass.