### PR TITLE
Update Overall Status to return status count summary

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -207,7 +207,13 @@ func TestJsonResponse(t *testing.T) {
 		{
 			"overall status: success",
 			http.StatusOK,
-			OverallStatus{Status: StatusErrored},
+			OverallStatus{
+				TaskSummary: TaskSummary{
+					Successful: 1,
+					Errored:    0,
+					Critical:   1,
+				},
+			},
 		},
 	}
 	for _, tc := range cases {

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -178,16 +178,12 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	}
 
 	overallCases := []struct {
-		name     string
-		path     string
-		expected api.OverallStatus
+		name string
+		path string
 	}{
 		{
 			"overall status",
 			"status",
-			api.OverallStatus{
-				Status: api.StatusErrored,
-			},
 		},
 	}
 
@@ -205,7 +201,10 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			err = decoder.Decode(&overallStatus)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expected, overallStatus)
+			assert.Equal(t, 1, overallStatus.TaskSummary.Successful)
+			// failed task might be errored/critical by now depending on number of events
+			assert.Equal(t, 1, overallStatus.TaskSummary.Errored+
+				overallStatus.TaskSummary.Critical)
 		})
 	}
 


### PR DESCRIPTION
Rather than returning a status value to represent the overall status across all
tasks, return a field 'task_summary' that shows how many tasks have each health
status value.

Example: `curl localhost:8558/status`

```
{
	"task_summary": {
		"successful":8,
		"errored":2,
		"critical":1
	}
}
```

Note: currently didn't add "unknown" status in the summary since that would require retrieving tasks that we don't have event information for yet. Doable but omitted in this PR. Open to feedback on adding it before release!