### PR TITLE
Update default transport configurations

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -51,7 +51,7 @@ var (
 				DialTimeout:         TimeDuration(10 * time.Second),
 				DisableKeepAlives:   Bool(false),
 				IdleConnTimeout:     TimeDuration(1 * time.Minute),
-				MaxIdleConnsPerHost: Int(5),
+				MaxIdleConnsPerHost: Int(100),
 				TLSHandshakeTimeout: TimeDuration(10 * time.Second),
 			},
 		},
@@ -266,7 +266,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.BufferPeriod.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")
 	expected.Consul.TLS.Cert = String("")
-	expected.Consul.Transport.MaxIdleConns = Int(100)
+	expected.Consul.Transport.MaxIdleConns = Int(0)
 	expected.Vault = DefaultVaultConfig()
 	expected.Vault.Finalize()
 	expected.Driver.consul = expected.Consul

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -33,7 +33,7 @@ consul {
     dial_timeout = "10s"
     disable_keep_alives = false
     idle_conn_timeout = "1m"
-    max_idle_conns_per_host = 5
+    max_idle_conns_per_host = 100
     tls_handshake_timeout = "10s"
   }
 }

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -31,7 +31,7 @@
       "dial_timeout": "10s",
       "disable_keep_alives": false,
       "idle_conn_timeout": "1m",
-      "max_idle_conns_per_host": 5,
+      "max_idle_conns_per_host": 100,
       "tls_handshake_timeout": "10s"
     }
   },

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20201102235459-09d8cd851630 h1:G2tn+rLFEtxN+2Ibk3vDZ+7Kxc+VtNOg9Lu8v6URr6o=
-github.com/hashicorp/hcat v0.0.0-20201102235459-09d8cd851630/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
 github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72 h1:U69JSA5apZmu/N9luM/sJtFYWJIzEVavIvBOomeDaIg=
 github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=


### PR DESCRIPTION
`http.MaxIdleConnsPerHost` was default to a very low value that caused TCP connections to not be reused across hcat dependency monitoring. Only ~1 connections were being reused from the initial set of hcat requests to Consul, and the remaining dependencies required establishing a new connection.

Changes:
* `DefaultMaxIdleConnsPerHost`: CTS default changed from 1 to 100 (the [transport default is 2](https://golang.org/pkg/net/http/#Transport) and [setting -1 disables keep alives altogether](https://golang.org/src/net/http/transport.go?s=3396:10951#L878)). This increases the # of reusable TCP connections for service monitoring. From 1:2 connections per service now to 1:1.
* `DefaultMaxIdleConns` default changed from 100 to 0, which disables the the limit. The previous limit not only caps all the requests to Consul but also requests to other hosts, which is not needed at this time.
* `DefaultIdleConnTimeout`: from 90s to 5s. hcat monitoring of dependencies should theoretically have 1 connection per 1 dependency for blocking queries. Any idle connections not immediately used would likely never be reused, so close it out earlier.

~For example, 100 services required about 200 connections at startup (normal request and then blocking query).~

~This is the primary bug in #146 when monitoring 100 services always errored with EOF/429 when the Consul agent has a default [`http_max_conns_per_client=200`](https://www.consul.io/docs/agent/options#http_max_conns_per_client). This should now allow up to 198 services by default without resulting in connection limits.~

See [comment below](https://github.com/hashicorp/consul-terraform-sync/pull/164#issuecomment-758195773) for updates on ^

Operators can increase `consul.transport.max_idle_conns_per_host` value to reduce the delay between detecting updates and task execution when monitoring 200 services or more.