### PR TITLE
Fix Consul KV path appending terraform suffix 2x

### DIFF
--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -98,7 +98,7 @@ func (t *TerraformCLI) Init(ctx context.Context) error {
 	var wsCreated bool
 
 	// This is special handling for when the workspace has been detected in
-	// .terraform/environment without a non-empty state. This case is common
+	// .terraform/environment with a non-existing state. This case is common
 	// when the state for the workspace has been deleted.
 	// https://github.com/hashicorp/terraform/issues/21393
 TF_INIT_AGAIN:

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -57,9 +57,16 @@ func DefaultTerraformBackend(consul *ConsulConfig) (map[string]interface{}, erro
 		return nil, fmt.Errorf("Consul is not configured to set the default backend for Terraform")
 	}
 
-	kvPath := DefaultTFBackendKVPath
+	kvPath := DefaultTFBackendKVPath // "consul-terraform-sync/terraform-env:<task-name>"
 	if consul.KVPath != nil && *consul.KVPath != "" {
-		kvPath = path.Join(*consul.KVPath, "terraform")
+		// Terraform Consul backend will append "-env:workspace" to the configured
+		// path. This modifies the KV path for CTS to have the same KV path structure for
+		// configured paths: "<configured-path>/terraform-env:<task-name>"
+		if !strings.HasSuffix(*consul.KVPath, "/terraform") {
+			kvPath = path.Join(*consul.KVPath, "terraform")
+		} else {
+			kvPath = *consul.KVPath
+		}
 	}
 
 	backend := map[string]interface{}{


### PR DESCRIPTION
Updates code comments to include more context on end result of the KV path for stored state files