### PR TITLE
User defined metadata for services

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -283,9 +283,11 @@ func TestConfig_Finalize(t *testing.T) {
 	(*expected.Services)[0].Namespace = String("")
 	(*expected.Services)[0].Datacenter = String("")
 	(*expected.Services)[0].Tag = String("")
+	(*expected.Services)[0].CTSUserDefinedMeta = map[string]string{}
 	(*expected.Services)[1].ID = String("serviceB")
 	(*expected.Services)[1].Datacenter = String("")
 	(*expected.Services)[1].Tag = String("")
+	(*expected.Services)[1].CTSUserDefinedMeta = map[string]string{}
 
 	c := longConfig.Copy()
 	c.Finalize()

--- a/config/service.go
+++ b/config/service.go
@@ -276,6 +276,41 @@ func (c *ServiceConfigs) Validate() error {
 	return nil
 }
 
+// CTSUserDefinedMeta generates a map of service name to user defined metadata
+// from a list of service IDs or service names.
+func (c *ServiceConfigs) CTSUserDefinedMeta(serviceList []string) map[string]map[string]string {
+	if c == nil {
+		return nil
+	}
+
+	services := make(map[string]bool)
+	for _, s := range serviceList {
+		services[s] = true
+	}
+
+	m := make(map[string]map[string]string)
+	for _, s := range *c {
+		if len(s.CTSUserDefinedMeta) == 0 {
+			continue
+		}
+
+		serviceName := *s.Name
+		if s.ID != nil && *s.ID != "" {
+			if _, ok := services[*s.ID]; ok {
+				m[serviceName] = s.CTSUserDefinedMeta
+				continue
+			}
+		}
+
+		if _, ok := services[serviceName]; ok {
+			if s.ID == nil || *s.ID == "" {
+				m[serviceName] = s.CTSUserDefinedMeta
+			}
+		}
+	}
+	return m
+}
+
 // GoString defines the printable version of this struct.
 func (c *ServiceConfigs) GoString() string {
 	if c == nil {

--- a/config/service.go
+++ b/config/service.go
@@ -295,7 +295,7 @@ func (c *ServiceConfigs) CTSUserDefinedMeta(serviceList []string) map[string]map
 		}
 
 		serviceName := *s.Name
-		if s.ID != nil && *s.ID != "" {
+		if StringPresent(s.ID) {
 			if _, ok := services[*s.ID]; ok {
 				m[serviceName] = s.CTSUserDefinedMeta
 				continue
@@ -303,7 +303,7 @@ func (c *ServiceConfigs) CTSUserDefinedMeta(serviceList []string) map[string]map
 		}
 
 		if _, ok := services[serviceName]; ok {
-			if s.ID == nil || *s.ID == "" {
+			if !StringPresent(s.ID) {
 				m[serviceName] = s.CTSUserDefinedMeta
 			}
 		}

--- a/config/service.go
+++ b/config/service.go
@@ -29,6 +29,10 @@ type ServiceConfig struct {
 
 	// Tag is used to filter nodes based on the tag for the service.
 	Tag *string `mapstructure:"tag"`
+
+	// CTSUserDefinedMeta is metadata added to a service automated by CTS for
+	// network infrastructure automation.
+	CTSUserDefinedMeta map[string]string `mapstructure:"cts_user_defined_meta"`
 }
 
 // ServiceConfigs is a collection of ServiceConfig
@@ -47,6 +51,14 @@ func (c *ServiceConfig) Copy() *ServiceConfig {
 	o.Name = StringCopy(c.Name)
 	o.Namespace = StringCopy(c.Namespace)
 	o.Tag = StringCopy(c.Tag)
+
+	if c.CTSUserDefinedMeta != nil {
+		o.CTSUserDefinedMeta = make(map[string]string)
+		for k, v := range c.CTSUserDefinedMeta {
+			o.CTSUserDefinedMeta[k] = v
+		}
+	}
+
 	return &o
 }
 
@@ -92,6 +104,15 @@ func (c *ServiceConfig) Merge(o *ServiceConfig) *ServiceConfig {
 		r.Tag = StringCopy(o.Tag)
 	}
 
+	if o.CTSUserDefinedMeta != nil {
+		if r.CTSUserDefinedMeta == nil {
+			r.CTSUserDefinedMeta = make(map[string]string)
+		}
+		for k, v := range o.CTSUserDefinedMeta {
+			r.CTSUserDefinedMeta[k] = v
+		}
+	}
+
 	return r
 }
 
@@ -124,6 +145,10 @@ func (c *ServiceConfig) Finalize() {
 	if c.Tag == nil {
 		c.Tag = String("")
 	}
+
+	if c.CTSUserDefinedMeta == nil {
+		c.CTSUserDefinedMeta = make(map[string]string)
+	}
 }
 
 // Validate validates the values and nested values of the configuration struct
@@ -151,13 +176,15 @@ func (c *ServiceConfig) GoString() string {
 		"Namespace:%s, "+
 		"Datacenter:%s, "+
 		"Tag:%s, "+
-		"Description:%s"+
+		"Description:%s, "+
+		"CTSUserDefinedMeta:%s"+
 		"}",
 		StringVal(c.Name),
 		StringVal(c.Namespace),
 		StringVal(c.Datacenter),
 		StringVal(c.Tag),
 		StringVal(c.Description),
+		c.CTSUserDefinedMeta,
 	)
 }
 

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -28,6 +28,9 @@ func TestServiceConfig_Copy(t *testing.T) {
 				Description: String("description"),
 				Name:        String("name"),
 				Namespace:   String("namespace"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
 			},
 		},
 	}
@@ -145,6 +148,30 @@ func TestServiceConfig_Merge(t *testing.T) {
 			&ServiceConfig{Namespace: String("namespace")},
 			&ServiceConfig{Namespace: String("namespace")},
 		},
+		{
+			"cts_user_defined_meta_overrides",
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "new-value"}},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "new-value"}},
+		},
+		{
+			"cts_user_defined_meta_empty_one",
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServiceConfig{},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"cts_user_defined_meta_empty_two",
+			&ServiceConfig{},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"cts_user_defined_meta_same",
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServiceConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
 	}
 
 	for i, tc := range cases {
@@ -167,12 +194,13 @@ func TestServiceConfig_Finalize(t *testing.T) {
 			"empty",
 			&ServiceConfig{},
 			&ServiceConfig{
-				Datacenter:  String(""),
-				Description: String(""),
-				ID:          String(""),
-				Name:        String(""),
-				Namespace:   String(""),
-				Tag:         String(""),
+				Datacenter:         String(""),
+				Description:        String(""),
+				ID:                 String(""),
+				Name:               String(""),
+				Namespace:          String(""),
+				Tag:                String(""),
+				CTSUserDefinedMeta: map[string]string{},
 			},
 		},
 		{
@@ -181,12 +209,13 @@ func TestServiceConfig_Finalize(t *testing.T) {
 				Name: String("service"),
 			},
 			&ServiceConfig{
-				Datacenter:  String(""),
-				Description: String(""),
-				ID:          String("service"),
-				Name:        String("service"),
-				Namespace:   String(""),
-				Tag:         String(""),
+				Datacenter:         String(""),
+				Description:        String(""),
+				ID:                 String("service"),
+				Name:               String("service"),
+				Namespace:          String(""),
+				Tag:                String(""),
+				CTSUserDefinedMeta: map[string]string{},
 			},
 		},
 	}

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -272,6 +272,60 @@ func TestServiceConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestServiceConfigs_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		i       *ServiceConfigs
+		isValid bool
+	}{
+		{
+			"nil",
+			nil,
+			false,
+		}, {
+			"empty",
+			&ServiceConfigs{},
+			true,
+		}, {
+			"unique services",
+			&ServiceConfigs{
+				{Name: String("a")},
+				{Name: String("b")},
+				{Name: String("c"), ID: String("c1")},
+				{Name: String("c"), ID: String("c2")},
+			},
+			true,
+		}, {
+			"one invalid",
+			&ServiceConfigs{
+				{Name: String("a")},
+				{Description: String("missing name")},
+			},
+			false,
+		}, {
+			"conflicting ID and name",
+			&ServiceConfigs{
+				{Name: String("a")},
+				{Name: String("b"), ID: String("a"), Description: String("this ID conflicts with service named A")},
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			err := tc.i.Validate()
+			if tc.isValid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestServiceConfigs_CTSUserDefinedMeta(t *testing.T) {
 	t.Parallel()
 

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -271,3 +271,124 @@ func TestServiceConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestServiceConfigs_CTSUserDefinedMeta(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		conf        *ServiceConfigs
+		serviceList []string
+		expected    map[string]map[string]string
+	}{
+		{
+			"nil",
+			nil,
+			[]string{"a"},
+			nil,
+		}, {
+			"empty",
+			&ServiceConfigs{},
+			[]string{"a"},
+			make(map[string]map[string]string),
+		}, {
+			"meta",
+			&ServiceConfigs{{
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			}},
+			[]string{"a"},
+			map[string]map[string]string{
+				"a": {"key": "value"},
+			},
+		}, {
+			"no meta",
+			&ServiceConfigs{{
+				Name: String("a"),
+			}},
+			[]string{"a"},
+			map[string]map[string]string{},
+		}, {
+			"meta by id",
+			&ServiceConfigs{{
+				ID:   String("a-with-meta"),
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			}},
+			[]string{"a-with-meta"},
+			map[string]map[string]string{
+				"a": {"key": "value"},
+			},
+		}, {
+			"service id with identical service",
+			&ServiceConfigs{{
+				ID:   String("a-with-meta"),
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			}, {
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "this should not be selected",
+				},
+			}},
+			[]string{"a-with-meta"},
+			map[string]map[string]string{
+				"a": {"key": "value"},
+			},
+		}, {
+			"service name with identical service",
+			&ServiceConfigs{{
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"a": "b",
+				},
+			}, {
+				ID:   String("a-with-meta"),
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			}},
+			[]string{"a"},
+			map[string]map[string]string{
+				"a": {"a": "b"},
+			},
+		}, {
+			"multiple",
+			&ServiceConfigs{{
+				Name: String("a"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value a",
+				},
+			}, {
+				Name: String("b"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value b",
+				},
+			}, {
+				Name: String("c"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value c",
+				},
+			}},
+			[]string{"a", "b"},
+			map[string]map[string]string{
+				"a": {"key": "value a"},
+				"b": {"key": "value b"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.conf.CTSUserDefinedMeta(tc.serviceList)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -219,7 +219,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 			input := hcat.TemplateInput{
 				Contents:      string(contents),
 				ErrMissingKey: true,
-				FuncMapMerge:  HCLTmplFuncMap,
+				FuncMapMerge:  HCLTmplFuncMap(nil),
 			}
 			tmpl := hcat.NewTemplate(input)
 

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -71,13 +71,22 @@ type Task struct {
 }
 
 type Service struct {
+	// Consul service information
 	Datacenter  string
 	Description string
 	Name        string
 	Namespace   string
 	Tag         string
+
+	// CTSUserDefinedMeta is user defined metadata that is configured by
+	// operators for CTS to append to Consul service information to be used for
+	// network infrastructure automation.
+	CTSUserDefinedMeta map[string]string
 }
 
+// TemplateServiceID is the formatted service identifier that satisfies hcat
+// query syntax to make Consul requests to /v1/health/service/:service
+//
 // TODO incorporate namespace
 func (s Service) TemplateServiceID() string {
 	id := s.Name

--- a/templates/tftmpl/template_funcs_test.go
+++ b/templates/tftmpl/template_funcs_test.go
@@ -66,7 +66,8 @@ node_id               = ""
 node_address          = ""
 node_datacenter       = ""
 node_tagged_addresses = {}
-node_meta             = {}`,
+node_meta             = {}
+cts_user_defined_meta = {}`,
 		}, {
 			"basic",
 			&dep.HealthService{
@@ -113,7 +114,8 @@ node_tagged_addresses = {
 }
 node_meta = {
   consul-network-segment = ""
-}`,
+}
+cts_user_defined_meta = {}`,
 		}, {
 			"namespace",
 			&dep.HealthService{
@@ -132,14 +134,53 @@ node_id               = ""
 node_address          = ""
 node_datacenter       = ""
 node_tagged_addresses = {}
-node_meta             = {}`,
+node_meta             = {}
+cts_user_defined_meta = {}`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := hclServiceFunc(tc.content)
+			actual := hclServiceFunc(nil)(tc.content)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestHCLServiceFunc_ctsUserDefinedMeta(t *testing.T) {
+	meta := map[string]map[string]string{
+		"api": {
+			"key":        "value",
+			"foo_bar":    "baz",
+			"spaced key": "spaced value",
+		},
+	}
+	content := &dep.HealthService{
+		ID:      "api",
+		Name:    "api",
+		Address: "1.2.3.4",
+		Port:    8080,
+	}
+	expected := `id                    = "api"
+name                  = "api"
+address               = "1.2.3.4"
+port                  = 8080
+meta                  = {}
+tags                  = []
+namespace             = null
+status                = ""
+node                  = ""
+node_id               = ""
+node_address          = ""
+node_datacenter       = ""
+node_tagged_addresses = {}
+node_meta             = {}
+cts_user_defined_meta = {
+  foo_bar      = "baz"
+  key          = "value"
+  "spaced key" = "spaced value"
+}`
+
+	actual := hclServiceFunc(meta)(content)
+	assert.Equal(t, expected, actual)
 }

--- a/templates/tftmpl/testdata/only_api_service.tfvars
+++ b/templates/tftmpl/testdata/only_api_service.tfvars
@@ -33,6 +33,7 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   },
   "api-2.worker-01.dc1" : {
     id              = "api-2"
@@ -56,6 +57,7 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   },
   "api.worker-02.dc1" : {
     id              = "api"
@@ -79,5 +81,6 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   }
 }

--- a/templates/tftmpl/testdata/only_web_service.tfvars
+++ b/templates/tftmpl/testdata/only_web_service.tfvars
@@ -33,5 +33,6 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   }
 }

--- a/templates/tftmpl/testdata/terraform.tfvars
+++ b/templates/tftmpl/testdata/terraform.tfvars
@@ -33,6 +33,7 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   },
   "api-2.worker-01.dc1" : {
     id              = "api-2"
@@ -56,6 +57,7 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   },
   "web.worker-01.dc1" : {
     id              = "web"
@@ -79,5 +81,6 @@ services = {
     node_meta = {
       consul-network-segment = ""
     }
+    cts_user_defined_meta = {}
   }
 }

--- a/templates/tftmpl/testdata/variables.tf
+++ b/templates/tftmpl/testdata/variables.tf
@@ -24,6 +24,8 @@ variable "services" {
       node_datacenter       = string
       node_tagged_addresses = map(string)
       node_meta             = map(string)
+
+      cts_user_defined_meta = map(string)
     })
   )
 }

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -13,6 +13,7 @@ import (
 )
 
 type healthService struct {
+	// Consul service information
 	ID        string            `hcl:"id"`
 	Name      string            `hcl:"name"`
 	Address   string            `hcl:"address"`
@@ -22,15 +23,19 @@ type healthService struct {
 	Namespace cty.Value         `hcl:"namespace"`
 	Status    string            `hcl:"status"`
 
+	// Consul node information for a service
 	Node                string            `hcl:"node"`
 	NodeID              string            `hcl:"node_id"`
 	NodeAddress         string            `hcl:"node_address"`
 	NodeDatacenter      string            `hcl:"node_datacenter"`
 	NodeTaggedAddresses map[string]string `hcl:"node_tagged_addresses"`
 	NodeMeta            map[string]string `hcl:"node_meta"`
+
+	// Added CTS information for a service
+	CTSUserDefinedMeta map[string]string `hcl:"cts_user_defined_meta"`
 }
 
-func newHealthService(s *dep.HealthService) healthService {
+func newHealthService(s *dep.HealthService, ctsUserDefinedMeta map[string]string) healthService {
 	if s == nil {
 		return healthService{}
 	}
@@ -65,6 +70,8 @@ func newHealthService(s *dep.HealthService) healthService {
 		NodeDatacenter:      s.NodeDatacenter,
 		NodeTaggedAddresses: nonNullMap(s.NodeTaggedAddresses),
 		NodeMeta:            nonNullMap(s.NodeMeta),
+
+		CTSUserDefinedMeta: nonNullMap(ctsUserDefinedMeta),
 	}
 }
 
@@ -108,8 +115,7 @@ func appendNamedBlockValues(body *hclwrite.Body, blocks []hcltmpl.NamedBlock) {
 //
 // services = {
 //   <service>: {
-//	   <attr> = <value>
-//     <attr> = {{ <template syntax> }}
+//	   {{ <template syntax> }}
 //   }
 // }
 func appendRawServiceTemplateValues(body *hclwrite.Body, services []Service) {

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -36,6 +36,8 @@ variable "services" {
       node_datacenter       = string
       node_tagged_addresses = map(string)
       node_meta             = map(string)
+
+      cts_user_defined_meta = map(string)
     })
   )
 }


### PR DESCRIPTION
Adds a new option `cts_user_defined_meta` to the `service` configuration block for Consul Terraform Sync. This attribute is useful to insert metadata for a service to be used for network infrastructure automation and consumed by a Terraform module.

A driving use case for user-defined metadata within CTS is automating load balancers and associating a service with a virtual IP address. The current method is to insert the VIP into Consul service metadata during registration. However, it might not be desirable to insert NIA scoped metadata into Consul, where it may not be useful by applications aside from CTS. It would also require shared context of service to VIP mappings between a network administrator and the application developer. `cts_user_defined_meta` can now be used to keep the scope of context to CTS and controlled by the CTS operator.

```hcl
service {
  name = "app"
  cts_user_defined_meta = {
    some_key = "value"
  }
}
```

## Summary of changes
* Adds config option `service.cts_user_defined_meta`
* Prepares user-defined metadata for the list of services by task during initialization. This list include service names or CTS service IDs. Passes the map of metadata that's scoped by task to the task's corresponding template functions.
* When the `terraform.tfvars.tmpl` is rendered, it inserts the user-defined metadata into the `var.services` to be available for compatible Terraform modules.
  * This new attribute to the `var.services` is a non-breaking change for modules. If modules choose to utilize the `cts_user_defined_meta` field, module authors can update their module `var.services` to include it within their variable definintion.
