### PR TITLE
add auto-commit setting support to providers

### DIFF
--- a/config/task_test.go
+++ b/config/task_test.go
@@ -411,6 +411,15 @@ func TestTasksConfig_Validate(t *testing.T) {
 				},
 			},
 			false,
+		}, {
+			"duplicate provider instances",
+			[]*TaskConfig{
+				{
+					Name:      String("task"),
+					Providers: []string{"provider.A", "provider.B"},
+				},
+			},
+			false,
 		},
 	}
 

--- a/handler/panos_test.go
+++ b/handler/panos_test.go
@@ -127,6 +127,20 @@ func TestPanosDo(t *testing.T) {
 			assert.NoError(t, h.Do(nil))
 		})
 	}
+
+	t.Run("autoCommit setting", func(t *testing.T) {
+		m := new(mocks.PanosClient)
+		m.On("InitializeUsing", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Once()
+		m.On("Commit", mock.Anything, mock.Anything, mock.Anything).
+			Return(uint(1), []byte("message"), nil).Once()
+		m.On("WaitForJob", mock.Anything, mock.Anything).Return(nil).Once()
+		m.On("String").Return("client string").Once()
+		h := &Panos{client: m, autoCommit: true}
+		assert.NoError(t, h.Do(nil))
+		h.autoCommit = false
+		assert.NoError(t, h.Do(nil))
+	})
 }
 
 func TestPanosCommit(t *testing.T) {

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -262,6 +262,10 @@ func appendRootProviderBlocks(body *hclwrite.Body, providers []hcltmpl.NamedBloc
 			if attr == "alias" {
 				continue
 			}
+			// auto_commit is an internal setting
+			if attr == "auto_commit" {
+				continue
+			}
 
 			providerBody.SetAttributeTraversal(attr, hcl.Traversal{
 				hcl.TraverseRoot{Name: "var"},


### PR DESCRIPTION
Adds logic to support setting an 'auto-commit' boolean setting on providers that will control the out-of-band automatic commit on task run for providers than need it (eg. Panos).


Note there is no documentation. Seems like any relevant docs would live elsewhere.