### PR TITLE
Add support for provider configuration containing object-type attributes

### DIFF
--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -44,6 +44,10 @@ func TestNewFiles(t *testing.T) {
 					map[string]interface{}{
 						"testProvider": map[string]interface{}{
 							"alias": "tp",
+							"obj": map[string]interface{}{
+								"username": "name",
+								"id":       "123",
+							},
 							"attr":  "value",
 							"count": 10,
 						},
@@ -69,6 +73,10 @@ func TestNewFiles(t *testing.T) {
 					map[string]interface{}{
 						"testProvider": map[string]interface{}{
 							"alias": "tp",
+							"obj": map[string]interface{}{
+								"username": "name",
+								"id":       "123",
+							},
 							"attr":  "value",
 							"count": 10,
 						},

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -43,6 +43,10 @@ func TestInitRootModule(t *testing.T) {
 			map[string]interface{}{
 				"testProvider": map[string]interface{}{
 					"alias": "tp",
+					"obj": map[string]interface{}{
+						"username": "name",
+						"id":       "123",
+					},
 					"attr":  "value",
 					"count": 10,
 				},

--- a/templates/tftmpl/testdata/main.tf
+++ b/templates/tftmpl/testdata/main.tf
@@ -24,6 +24,10 @@ terraform {
 provider "testProvider" {
   attr  = var.testProvider.attr
   count = var.testProvider.count
+  obj {
+    id       = var.testProvider.obj.id
+    username = var.testProvider.obj.username
+  }
 }
 
 # user description for task named 'test'

--- a/templates/tftmpl/testdata/variables.tf
+++ b/templates/tftmpl/testdata/variables.tf
@@ -40,5 +40,9 @@ variable "testProvider" {
     alias = string
     attr  = string
     count = number
+    obj = object({
+      id       = string
+      username = string
+    })
   })
 }


### PR DESCRIPTION
When converting user-defined provider configuration into provider definition
blocks with variables, object-type attributes were formatted like
`obj = var.provider_name.obj`. This led to "Error: Unsupported argument".

This PR formats object-type attributes into a block like:
```
obj {
  attr = var.provider_name.obj.attr
  ...
}
```

Fixes https://github.com/hashicorp/consul-terraform-sync/issues/171