### PR TITLE
include service kind in module input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72
+	github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -599,6 +599,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72 h1:U69JSA5apZmu/N9luM/sJtFYWJIzEVavIvBOomeDaIg=
 github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
+github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618 h1:cmwVAs6moHrxz/lwPC1rdr/MXydSpp8R/lF1LWDorE0=
+github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/templates/tftmpl/template_funcs_test.go
+++ b/templates/tftmpl/template_funcs_test.go
@@ -55,6 +55,7 @@ func TestHCLServiceFunc(t *testing.T) {
 			&dep.HealthService{},
 			`id                    = ""
 name                  = ""
+kind                  = ""
 address               = ""
 port                  = 0
 meta                  = {}
@@ -94,6 +95,7 @@ cts_user_defined_meta = {}`,
 			},
 			`id      = "api"
 name    = "api"
+kind    = ""
 address = "1.2.3.4"
 port    = 8080
 meta = {
@@ -117,12 +119,14 @@ node_meta = {
 }
 cts_user_defined_meta = {}`,
 		}, {
-			"namespace",
+			"namespace-n-kind",
 			&dep.HealthService{
 				Namespace: "namespace",
+				Kind:      "mykind",
 			},
 			`id                    = ""
 name                  = ""
+kind                  = "mykind"
 address               = ""
 port                  = 0
 meta                  = {}
@@ -163,6 +167,7 @@ func TestHCLServiceFunc_ctsUserDefinedMeta(t *testing.T) {
 	}
 	expected := `id                    = "api"
 name                  = "api"
+kind                  = ""
 address               = "1.2.3.4"
 port                  = 8080
 meta                  = {}

--- a/templates/tftmpl/testdata/only_api_service.tfvars
+++ b/templates/tftmpl/testdata/only_api_service.tfvars
@@ -17,6 +17,7 @@ services = {
   "api.worker-01.dc1" : {
     id              = "api"
     name            = "api"
+    kind            = ""
     address         = "1.2.3.4"
     port            = 8080
     meta            = {}
@@ -41,6 +42,7 @@ services = {
   "api-2.worker-01.dc1" : {
     id              = "api-2"
     name            = "api"
+    kind            = ""
     address         = "5.6.7.8"
     port            = 8080
     meta            = {}
@@ -65,6 +67,7 @@ services = {
   "api.worker-02.dc1" : {
     id              = "api"
     name            = "api"
+    kind            = ""
     address         = "1.2.3.4"
     port            = 8080
     meta            = {}

--- a/templates/tftmpl/testdata/only_web_service.tfvars
+++ b/templates/tftmpl/testdata/only_web_service.tfvars
@@ -17,6 +17,7 @@ services = {
   "web.worker-01.dc1" : {
     id              = "web"
     name            = "web"
+    kind            = ""
     address         = "1.1.1.1"
     port            = 8000
     meta            = {}

--- a/templates/tftmpl/testdata/terraform.tfvars
+++ b/templates/tftmpl/testdata/terraform.tfvars
@@ -17,6 +17,7 @@ services = {
   "api.worker-01.dc1" : {
     id              = "api"
     name            = "api"
+    kind            = ""
     address         = "1.2.3.4"
     port            = 8080
     meta            = {}
@@ -41,6 +42,7 @@ services = {
   "api-2.worker-01.dc1" : {
     id              = "api-2"
     name            = "api"
+    kind            = ""
     address         = "5.6.7.8"
     port            = 8080
     meta            = {}
@@ -65,6 +67,7 @@ services = {
   "web.worker-01.dc1" : {
     id              = "web"
     name            = "web"
+    kind            = ""
     address         = "1.1.1.1"
     port            = 8000
     meta            = {}

--- a/templates/tftmpl/testdata/variables.tf
+++ b/templates/tftmpl/testdata/variables.tf
@@ -14,6 +14,7 @@ variable "services" {
     object({
       id        = string
       name      = string
+      kind      = string
       address   = string
       port      = number
       meta      = map(string)

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -15,6 +15,7 @@ type healthService struct {
 	// Consul service information
 	ID        string            `hcl:"id"`
 	Name      string            `hcl:"name"`
+	Kind      string            `hcl:"kind"`
 	Address   string            `hcl:"address"`
 	Port      int               `hcl:"port"`
 	Meta      map[string]string `hcl:"meta"`
@@ -56,6 +57,7 @@ func newHealthService(s *dep.HealthService, ctsUserDefinedMeta map[string]string
 	return healthService{
 		ID:        s.ID,
 		Name:      s.Name,
+		Kind:      s.Kind,
 		Address:   s.Address,
 		Port:      s.Port,
 		Meta:      nonNullMap(s.ServiceMeta),

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -22,6 +22,7 @@ variable "services" {
     object({
       id        = string
       name      = string
+      kind      = string
       address   = string
       port      = number
       meta      = map(string)


### PR DESCRIPTION
Takes the newly supported hcat consul health service Kind value and
propagates it through to the module input fields.

Updated to use latest hashicat.
Add it to the services variable fields.
Rendered into templates via mapstructure rendering of data structs.
Tests and testdata updated.

Closes #168