### PR TITLE
Support querying service by namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/consul v1.8.0
 	github.com/hashicorp/consul/sdk v0.5.0
 	github.com/hashicorp/go-checkpoint v0.5.0
+	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
@@ -24,7 +25,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	github.com/tidwall/pretty v1.0.2 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
@@ -35,6 +36,8 @@ require (
 )
 
 replace (
+	github.com/hashicorp/hcat => ../hcat
+
 	// Terraform imports a pre-go-mod version of Vault. These replace directives
 	// resolves the ambiguous import between the package `vault/api` and
 	// `vault/api` nested go module.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618
+	github.com/hashicorp/hcat v0.0.0-20210126174106-fbb1851663ad
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.6.0
 	github.com/hashicorp/logutils v1.0.0
@@ -36,8 +36,6 @@ require (
 )
 
 replace (
-	github.com/hashicorp/hcat => ../hcat
-
 	// Terraform imports a pre-go-mod version of Vault. These replace directives
 	// resolves the ambiguous import between the package `vault/api` and
 	// `vault/api` nested go module.

--- a/go.sum
+++ b/go.sum
@@ -599,10 +599,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72 h1:U69JSA5apZmu/N9luM/sJtFYWJIzEVavIvBOomeDaIg=
-github.com/hashicorp/hcat v0.0.0-20201211001333-cc9b9b904d72/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
-github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618 h1:cmwVAs6moHrxz/lwPC1rdr/MXydSpp8R/lF1LWDorE0=
-github.com/hashicorp/hcat v0.0.0-20210122002113-a06a4c3ec618/go.mod h1:EdfFuaZdeoDhNpqom+ZqaDhw6dX/gtK2JEFgUPyCcZc=
+github.com/hashicorp/hcat v0.0.0-20210126174106-fbb1851663ad h1:l9AaW/7elp+JPXdMGj9ZE5V8bCfw0W/jhZGahq0i7tQ=
+github.com/hashicorp/hcat v0.0.0-20210126174106-fbb1851663ad/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.10.0/go.mod h1:YuAtHxm2v74s+IjQwUG88dHBJPd5jL+cXr5BGVzSKhE=
 github.com/hashicorp/go-bexpr v0.1.2/go.mod h1:ANbpTX1oAql27TZkKVeW8p1w8NTdnyzPe/0qqPCKohU=
+github.com/hashicorp/go-bexpr v0.1.4 h1:vyQpuKqqc+Ywb8tf6vZSlkf5qhYkgrNSWURtQggCfLE=
+github.com/hashicorp/go-bexpr v0.1.4/go.mod h1:ey7VZGNrY1PnLlYp6Nf3RLEizPo0B9W4yw2MnDkcK3M=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-checkpoint v0.0.0-20171009173528-1545e56e46de/go.mod h1:xIwEieBHERyEvaeKF/TcHh1Hu+lxPM+n2vT1+g9I4m4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
@@ -874,6 +876,8 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/panicwrap v1.0.0/go.mod h1:pKvZHwWrZowLUzftuFq7coarnxbBXU4aQh3N0BJOeeA=
 github.com/mitchellh/pointerstructure v1.0.0 h1:ATSdz4NWrmWPOF1CeCBU4sMCno2hgqdbSrRPFWQSVZI=
 github.com/mitchellh/pointerstructure v1.0.0/go.mod h1:k4XwG94++jLVsSiTxo7qdIfXA9pj9EAeo0QsNNJOLZ8=
+github.com/mitchellh/pointerstructure v1.1.0 h1:6RI+cKHSIOOuMhKALJyMIpGOHsmBGGwS0ZSMCPFn/jM=
+github.com/mitchellh/pointerstructure v1.1.0/go.mod h1:zoQzmW5t87ncZZuJWXEyhr0///POW/WQEeFG4RRVKEs=
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=
@@ -1076,6 +1080,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.83+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
@@ -1537,6 +1543,8 @@ gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -99,8 +99,6 @@ func TestNewFiles(t *testing.T) {
 				Services: []Service{
 					{
 						Name:        "web",
-						Namespace:   "ns",
-						Datacenter:  "dc1",
 						Description: "web service",
 					}, {
 						Name:        "api",

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -239,7 +239,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 				}
 
 				err = <-w.WaitCh(ctx)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -98,11 +98,11 @@ func (s Service) hcatQuery() string {
 	var opts []string
 
 	if s.Datacenter != "" {
-		opts = append(opts, fmt.Sprintf(`dc=\"%s\"`, s.Datacenter))
+		opts = append(opts, fmt.Sprintf("dc=%s", s.Datacenter))
 	}
 
 	if s.Namespace != "" {
-		opts = append(opts, fmt.Sprintf(`ns=\"%s\"`, s.Namespace))
+		opts = append(opts, fmt.Sprintf("ns=%s", s.Namespace))
 	}
 
 	if s.Tag != "" {

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -190,14 +190,14 @@ func TestService_hcatQuery(t *testing.T) {
 				Name:       "app",
 				Datacenter: "dc1",
 			},
-			`"app" "dc=\"dc1\""`,
+			`"app" "dc=dc1"`,
 		}, {
 			"namespace",
 			Service{
 				Name:      "app",
 				Namespace: "namespace",
 			},
-			`"app" "ns=\"namespace\""`,
+			`"app" "ns=namespace"`,
 		}, {
 			"tag",
 			Service{
@@ -213,7 +213,7 @@ func TestService_hcatQuery(t *testing.T) {
 				Namespace:  "namespace",
 				Tag:        "my-tag",
 			},
-			`"app" "dc=\"dc1\"" "ns=\"namespace\"" "\"my-tag\" in Service.Tags"`,
+			`"app" "dc=dc1" "ns=namespace" "\"my-tag\" in Service.Tags"`,
 		},
 	}
 	for _, tc := range testCases {

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -169,3 +169,55 @@ func TestAppendRootProviderBlocks(t *testing.T) {
 		})
 	}
 }
+
+func TestService_hcatQuery(t *testing.T) {
+	testCases := []struct {
+		name     string
+		service  Service
+		expected string
+	}{
+		{
+			"empty",
+			Service{},
+			`""`,
+		}, {
+			"base",
+			Service{Name: "app"},
+			`"app"`,
+		}, {
+			"datacenter",
+			Service{
+				Name:       "app",
+				Datacenter: "dc1",
+			},
+			`"app" "dc=\"dc1\""`,
+		}, {
+			"namespace",
+			Service{
+				Name:      "app",
+				Namespace: "namespace",
+			},
+			`"app" "ns=\"namespace\""`,
+		}, {
+			"tag",
+			Service{
+				Name: "app",
+				Tag:  "my-tag",
+			},
+			`"app" "\"my-tag\" in Service.Tags"`,
+		}, {
+			"all",
+			Service{
+				Name:       "app",
+				Datacenter: "dc1",
+				Namespace:  "namespace",
+				Tag:        "my-tag",
+			},
+			`"app" "dc=\"dc1\"" "ns=\"namespace\"" "\"my-tag\" in Service.Tags"`,
+		},
+	}
+	for _, tc := range testCases {
+		actual := tc.service.hcatQuery()
+		assert.Equal(t, tc.expected, actual)
+	}
+}

--- a/templates/tftmpl/template_funcs.go
+++ b/templates/tftmpl/template_funcs.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/hashicorp/hcat"
 	"github.com/hashicorp/hcat/dep"
 	"github.com/hashicorp/hcat/tfunc"
 	"github.com/hashicorp/hcl/v2/gohcl"
@@ -13,13 +14,12 @@ import (
 // HCLTmplFuncMap is the map of template functions for rendering HCL
 // to their respective implementations
 func HCLTmplFuncMap(meta map[string]map[string]string) template.FuncMap {
-	return template.FuncMap{
-		"indent":   tfunc.Helpers()["indent"],
-		"subtract": tfunc.Math()["subtract"],
-
-		"joinStrings": joinStringsFunc,
-		"HCLService":  hclServiceFunc(meta),
-	}
+	tmplFuncs := hcat.FuncMapConsulV1()
+	tmplFuncs["indent"] = tfunc.Helpers()["indent"]
+	tmplFuncs["subtract"] = tfunc.Math()["subtract"]
+	tmplFuncs["joinStrings"] = joinStringsFunc
+	tmplFuncs["HCLService"] = hclServiceFunc(meta)
+	return tmplFuncs
 }
 
 // JoinStrings joins an optional number of strings with the separator while

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -14,17 +14,17 @@ testProvider = {
 }
 
 services = {
-{{- with $srv := service "api" "dc=\"dc1\"" "\"tag\" in Service.Tags" }}
+{{- with $srv := service "api" "dc=dc1" "\"tag\" in Service.Tags" }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
 {{ HCLService $s | indent 4 }}
   } {{- if (ne $i $last)}},{{end}}
   {{- end}}
-{{- end}}{{- with $beforeSrv := service "api" "dc=\"dc1\"" "\"tag\" in Service.Tags" }}
-  {{- with $afterSrv := service "web" "dc=\"dc1\"" "ns=\"ns\"" }},{{end}}
+{{- end}}{{- with $beforeSrv := service "api" "dc=dc1" "\"tag\" in Service.Tags" }}
+  {{- with $afterSrv := service "web" "dc=dc1" "ns=ns" }},{{end}}
 {{- end}}
-{{- with $srv := service "web" "dc=\"dc1\"" "ns=\"ns\"" }}
+{{- with $srv := service "web" "dc=dc1" "ns=ns" }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -22,9 +22,9 @@ services = {
   } {{- if (ne $i $last)}},{{end}}
   {{- end}}
 {{- end}}{{- with $beforeSrv := service "api" "dc=dc1" "\"tag\" in Service.Tags" }}
-  {{- with $afterSrv := service "web" "dc=dc1" "ns=ns" }},{{end}}
+  {{- with $afterSrv := service "web" }},{{end}}
 {{- end}}
-{{- with $srv := service "web" "dc=dc1" "ns=ns" }}
+{{- with $srv := service "web" }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -14,17 +14,17 @@ testProvider = {
 }
 
 services = {
-{{- with $srv := service "tag.api@dc1"}}
+{{- with $srv := service "api" "dc=\"dc1\"" "\"tag\" in Service.Tags" }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
 {{ HCLService $s | indent 4 }}
   } {{- if (ne $i $last)}},{{end}}
   {{- end}}
-{{- end}}{{- with $beforeSrv := service "tag.api@dc1"}}
-  {{- with $afterSrv := service "web@dc1"}},{{end}}
+{{- end}}{{- with $beforeSrv := service "api" "dc=\"dc1\"" "\"tag\" in Service.Tags" }}
+  {{- with $afterSrv := service "web" "dc=\"dc1\"" "ns=\"ns\"" }},{{end}}
 {{- end}}
-{{- with $srv := service "web@dc1"}}
+{{- with $srv := service "web" "dc=\"dc1\"" "ns=\"ns\"" }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -128,14 +128,13 @@ func appendRawServiceTemplateValues(body *hclwrite.Body, services []Service) {
 	})
 	lastIdx := len(services) - 1
 	for i, s := range services {
-		rawService := fmt.Sprintf(baseAddressStr, s.TemplateServiceID())
+		rawService := fmt.Sprintf(baseAddressStr, s.hcatQuery())
 
 		if i == lastIdx {
 			rawService += "\n}"
 		} else {
 			nextS := services[i+1]
-			rawComma := fmt.Sprintf(baseCommaStr, s.TemplateServiceID(),
-				nextS.TemplateServiceID())
+			rawComma := fmt.Sprintf(baseCommaStr, s.hcatQuery(), nextS.hcatQuery())
 			rawService += rawComma
 		}
 
@@ -159,7 +158,7 @@ func nonNullMap(m map[string]string) map[string]string {
 // baseAddressStr is the raw template following hcat syntax for addresses of
 // Consul services.
 const baseAddressStr = `
-{{- with $srv := service "%s"}}
+{{- with $srv := service %s }}
   {{- $last := len $srv | subtract 1}}
   {{- range $i, $s := $srv}}
   "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
@@ -171,6 +170,6 @@ const baseAddressStr = `
 // baseCommaStr is the raw template following hcat syntax for the comma between
 // different Consul services. Rendering a comma requires there to be an instance
 // of the service before and after the comma.
-const baseCommaStr = `{{- with $beforeSrv := service "%s"}}
-  {{- with $afterSrv := service "%s"}},{{end}}
+const baseCommaStr = `{{- with $beforeSrv := service %s }}
+  {{- with $afterSrv := service %s }},{{end}}
 {{- end}}`


### PR DESCRIPTION
Service config blocks with namespaces defined can now query services based on namespace when deployed with Consul enterprise.

```hcl
service {
  name = "app"
  namespace = "app-team"
}
```

Configuring the service namespace without Consul enterprise will result in an exiting error:
```
2021/01/25 18:14:43.253097 [ERR] (cli) error running controller in Once mode: health.service(app?ns=app-team&filter="Checks.Status == passing"): Unexpected response code: 400 (Bad request: Invalid query parameter: "ns" - Namespaces are a Consul Enterprise feature)
```

Pulls in changes from  https://github.com/hashicorp/hcat/pull/35
Marking this with a bug label since the namespace option was available before it was fully supported.