### PR TITLE
Add dirty to version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ PROJECT := $(shell go list -m)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
 GIT_DESCRIBE ?= $(shell git describe --tags --always)
+GIT_DIRTY ?= $(shell git diff --stat)
 VERSION := $(shell awk -F\" '/Version/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")
 
 # Tags specific for building
@@ -24,7 +25,8 @@ LD_FLAGS ?= \
 	-w \
 	-X '${PROJECT}/version.Name=${NAME}' \
 	-X '${PROJECT}/version.GitCommit=${GIT_COMMIT}' \
-	-X '${PROJECT}/version.GitDescribe=${GIT_DESCRIBE}'
+	-X '${PROJECT}/version.GitDescribe=${GIT_DESCRIBE}' \
+	-X '${PROJECT}/version.GitDirty=${GIT_DIRTY}'
 
 # dev builds and installs the project locally to $GOPATH/bin.
 dev:

--- a/version/version.go
+++ b/version/version.go
@@ -13,6 +13,10 @@ var (
 	GitCommit   string
 	GitDescribe string
 
+	// GitDirty is dirty if the working tree has local modifications from HEAD.
+	// These will be filled in by the compiler.
+	GitDirty string
+
 	// The main version number that is being run at the moment.
 	//
 	// Version must conform to the format expected by
@@ -41,7 +45,9 @@ func GetHumanVersion() string {
 		version += fmt.Sprintf("-%s", release)
 	}
 
-	if GitCommit != "" {
+	if GitCommit != "" && GitDirty != "" {
+		version += fmt.Sprintf(" (%s dirty)", GitCommit)
+	} else if GitCommit != "" {
 		version += fmt.Sprintf(" (%s)", GitCommit)
 	}
 


### PR DESCRIPTION
Small proposal to include `dirty` in the version output when the working tree has local modifications from HEAD. This is intended primarily for local development use.
 
```
$ consul-terraform-sync -version
consul-terraform-sync 0.1.0-beta (e3aa8cc dirty)
Compatible with Terraform >= 0.13.0, < 0.15
```