### PR TITLE
propagate context through handlers

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -198,7 +198,7 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	if tf.postApply != nil {
 		log.Printf("[TRACE] (driver.terraform) post-apply out-of-band actions "+
 			"for '%s'", taskName)
-		if err := tf.postApply.Do(nil); err != nil {
+		if err := tf.postApply.Do(ctx, nil); err != nil {
 			return err
 		}
 	}

--- a/handler/fake.go
+++ b/handler/fake.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -59,7 +60,7 @@ func NewFake(config map[string]interface{}) (*Fake, error) {
 // Do executes fake handler, which fmt.Print-s the fake handler's name which
 // is the output inspected by handler example. It returns an error if configured
 // to do so.
-func (h *Fake) Do(prevErr error) error {
+func (h *Fake) Do(ctx context.Context, prevErr error) error {
 	fmt.Printf("FakeHandler: '%s'\n", h.name)
 
 	var err error = nil
@@ -74,7 +75,7 @@ func (h *Fake) Do(prevErr error) error {
 		}
 	}
 
-	return callNext(h.next, prevErr, err)
+	return callNext(ctx, h.next, prevErr, err)
 }
 
 // SetNext sets the next handler that should be called

--- a/handler/fake_test.go
+++ b/handler/fake_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,7 +89,7 @@ func TestFakeDo(t *testing.T) {
 				h.err = true
 			}
 
-			err := h.Do(nil)
+			err := h.Do(context.Background(), nil)
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
@@ -106,13 +107,13 @@ func TestFakeDo(t *testing.T) {
 			first:        true,
 		}
 		// success
-		err := h.Do(nil)
+		err := h.Do(context.Background(), nil)
 		assert.NoError(t, err)
 
 		// failures
-		err = h.Do(nil)
+		err = h.Do(context.Background(), nil)
 		assert.Error(t, err)
-		err = h.Do(nil)
+		err = h.Do(context.Background(), nil)
 		assert.Error(t, err)
 	})
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -117,7 +118,7 @@ func ExampleTerraformProviderHandler() {
 			}
 		}
 	}
-	fmt.Println("Handler Errors:", next.Do(nil))
+	fmt.Println("Handler Errors:", next.Do(context.Background(), nil))
 	// Output:
 	// FakeHandler: '1'
 	// FakeHandler: '2'
@@ -152,7 +153,7 @@ func TestCallNext(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fmt.Println("fake: ", tc.nextH, " equal? ", tc.nextH == nil)
-			err := callNext(tc.nextH, nil, nil)
+			err := callNext(context.Background(), tc.nextH, nil, nil)
 			if tc.nextErr {
 				assert.Error(t, err)
 			} else {

--- a/handler/panos.go
+++ b/handler/panos.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"log"
 	"os"
@@ -111,7 +112,7 @@ func NewPanos(c map[string]interface{}) (*Panos, error) {
 
 // Do executes panos' out-of-band Commit API and calls next handler while passing
 // on relevant errors
-func (h *Panos) Do(prevErr error) error {
+func (h *Panos) Do(ctx context.Context, prevErr error) error {
 	committing := "disabled"
 	if h.autoCommit {
 		committing = "enabled"
@@ -122,7 +123,7 @@ func (h *Panos) Do(prevErr error) error {
 	if h.autoCommit {
 		err = h.commit()
 	}
-	return callNext(h.next, prevErr, err)
+	return callNext(ctx, h.next, prevErr, err)
 }
 
 // commit calls panos' InitializeUsing & Commit SDK

--- a/handler/panos_test.go
+++ b/handler/panos_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -124,7 +125,7 @@ func TestPanosDo(t *testing.T) {
 				h.SetNext(next)
 			}
 
-			assert.NoError(t, h.Do(nil))
+			assert.NoError(t, h.Do(context.Background(), nil))
 		})
 	}
 
@@ -137,9 +138,9 @@ func TestPanosDo(t *testing.T) {
 		m.On("WaitForJob", mock.Anything, mock.Anything).Return(nil).Once()
 		m.On("String").Return("client string").Once()
 		h := &Panos{client: m, autoCommit: true}
-		assert.NoError(t, h.Do(nil))
+		assert.NoError(t, h.Do(context.Background(), nil))
 		h.autoCommit = false
-		assert.NoError(t, h.Do(nil))
+		assert.NoError(t, h.Do(context.Background(), nil))
 	})
 }
 


### PR DESCRIPTION
Handler's Do() methods need to be cancellable via context and having the context helps. This makes sure the context is passed along.

Split this out from panos-retry work.