### PR TITLE
Set provider intermediate variable as sensitive

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -103,7 +103,7 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 
 // Version returns the Terraform CLI version for the Terraform driver.
 func (tf *Terraform) Version() string {
-	return TerraformVersion
+	return TerraformVersion.String()
 }
 
 // InitTask initializes the task by creating the Terraform root module and related
@@ -140,10 +140,11 @@ func (tf *Terraform) InitTask(force bool) error {
 	}
 
 	input := tftmpl.RootModuleInputData{
-		Backend:      tf.backend,
-		Providers:    task.Providers.ProviderBlocks(),
-		ProviderInfo: task.ProviderInfo,
-		Services:     services,
+		TerraformVersion: TerraformVersion,
+		Backend:          tf.backend,
+		Providers:        task.Providers.ProviderBlocks(),
+		ProviderInfo:     task.ProviderInfo,
+		Services:         services,
 		Task: tftmpl.Task{
 			Description: task.Description,
 			Name:        task.Name,

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -20,7 +20,7 @@ import (
 const fallbackTFVersion = "0.13.5"
 
 // TerraformVersion is the version of Terraform CLI for the Terraform driver.
-var TerraformVersion string
+var TerraformVersion *goVersion.Version
 
 // InstallTerraform installs the Terraform binary to the configured path.
 // If an existing Terraform exists in the path, it is checked for compatibility.
@@ -45,14 +45,13 @@ func InstallTerraform(ctx context.Context, conf *config.TerraformConfig) error {
 		}
 
 		// Set the global variable to the installed version
-		version := tfVersion.String()
-		TerraformVersion = version
+		TerraformVersion = tfVersion
 		if !compatible {
 			return errUnsupportedTerraformVersion
 		}
 
 		log.Printf("[INFO] (driver.terraform) skipping install, terraform %s "+
-			"already exists at path %s/terraform", version, path)
+			"already exists at path %s/terraform", tfVersion.String(), path)
 		return nil
 	}
 
@@ -65,7 +64,7 @@ func InstallTerraform(ctx context.Context, conf *config.TerraformConfig) error {
 	log.Printf("[INFO] (driver.terraform) successfully installed terraform")
 
 	// Set the global variable to the installed version
-	TerraformVersion = tfVersion.String()
+	TerraformVersion = tfVersion
 	return nil
 }
 

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	goVersion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,6 +70,7 @@ func TestNewFiles(t *testing.T) {
 			Func:   newVariablesTF,
 			Golden: "testdata/variables.tf",
 			Input: RootModuleInputData{
+				TerraformVersion: goVersion.Must(goVersion.NewSemver("0.14.2")),
 				Providers: []hcltmpl.NamedBlock{hcltmpl.NewNamedBlock(
 					map[string]interface{}{
 						"testProvider": map[string]interface{}{

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -70,7 +70,7 @@ func TestNewFiles(t *testing.T) {
 			Func:   newVariablesTF,
 			Golden: "testdata/variables.tf",
 			Input: RootModuleInputData{
-				TerraformVersion: goVersion.Must(goVersion.NewSemver("0.14.2")),
+				TerraformVersion: goVersion.Must(goVersion.NewSemver("0.99.9")),
 				Providers: []hcltmpl.NamedBlock{hcltmpl.NewNamedBlock(
 					map[string]interface{}{
 						"testProvider": map[string]interface{}{

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/hcat"
+	goVersion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -33,6 +34,7 @@ func TestInitRootModule(t *testing.T) {
 	expectedPerm := os.FileMode(0660)
 
 	input := RootModuleInputData{
+		TerraformVersion: goVersion.Must(goVersion.NewSemver("0.14.2")),
 		Backend: map[string]interface{}{
 			"consul": map[string]interface{}{
 				"scheme": "https",

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -34,7 +34,7 @@ func TestInitRootModule(t *testing.T) {
 	expectedPerm := os.FileMode(0660)
 
 	input := RootModuleInputData{
-		TerraformVersion: goVersion.Must(goVersion.NewSemver("0.14.2")),
+		TerraformVersion: goVersion.Must(goVersion.NewSemver("0.99.9")),
 		Backend: map[string]interface{}{
 			"consul": map[string]interface{}{
 				"scheme": "https",

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/consul-terraform-sync/version"
+	goVersion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -118,12 +119,13 @@ func (s Service) hcatQuery() string {
 
 // RootModuleInputData is the input data used to generate the root module
 type RootModuleInputData struct {
-	Backend      map[string]interface{}
-	Providers    []hcltmpl.NamedBlock
-	ProviderInfo map[string]interface{}
-	Services     []Service
-	Task         Task
-	Variables    hcltmpl.Variables
+	TerraformVersion *goVersion.Version
+	Backend          map[string]interface{}
+	Providers        []hcltmpl.NamedBlock
+	ProviderInfo     map[string]interface{}
+	Services         []Service
+	Task             Task
+	Variables        hcltmpl.Variables
 
 	backend *hcltmpl.NamedBlock
 }

--- a/templates/tftmpl/testdata/variables.tf
+++ b/templates/tftmpl/testdata/variables.tf
@@ -37,6 +37,7 @@ variable "services" {
 variable "testProvider" {
   default     = null
   description = "Configuration object for testProvider"
+  sensitive   = true
   type = object({
     alias = string
     attr  = string


### PR DESCRIPTION
Sensitive argument won't prevent provider args from being stored in the state files, but will omit them from Terraform output and logs.

Conditionally adds the `sensitive = true` to the generated `variables.tf` when the discovered/installed Terraform version is 0.14+

Resolves #85