### PR TITLE
Separate provider vars from services var

### DIFF
--- a/examples/sync-tasks/my-task/terraform.tfvars
+++ b/examples/sync-tasks/my-task/terraform.tfvars
@@ -7,12 +7,6 @@
 # Task: my-task
 # Description: automate services for website X
 
-myprovider = {
-  address  = "myprovider.example.com"
-  attr     = "foobar"
-  username = "admin"
-}
-
 services = {
   "api.worker-01.dc1" : {
     id              = "api"

--- a/examples/sync-tasks/my-task/variables.module.tf
+++ b/examples/sync-tasks/my-task/variables.module.tf
@@ -7,7 +7,6 @@
 # Task: my-task
 # Description: automate services for website X
 
-
 variable "count" {
   default = null
   type    = number

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	goVersion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
+	goVersion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"
@@ -26,7 +26,7 @@ func TestNewFiles(t *testing.T) {
 
 	testCases := []struct {
 		Name   string
-		Func   func(io.Writer, *RootModuleInputData) error
+		Func   func(io.Writer, string, *RootModuleInputData) error
 		Golden string
 		Input  RootModuleInputData
 	}{
@@ -113,6 +113,21 @@ func TestNewFiles(t *testing.T) {
 				Task: task,
 			},
 		}, {
+			Name:   "providers.tfvars",
+			Func:   newProvidersTFVars,
+			Golden: "testdata/providers.tfvars",
+			Input: RootModuleInputData{
+				Providers: []hcltmpl.NamedBlock{hcltmpl.NewNamedBlock(
+					map[string]interface{}{
+						"testProvider": map[string]interface{}{
+							"alias": "tp",
+							"attr":  "value",
+							"count": 10,
+						},
+					})},
+				Task: task,
+			},
+		}, {
 			Name:   "variables.module.tf",
 			Func:   newModuleVariablesTF,
 			Golden: "testdata/variables.module.tf",
@@ -151,7 +166,7 @@ func TestNewFiles(t *testing.T) {
 			input := tc.Input
 			input.Init()
 			b := new(bytes.Buffer)
-			err := tc.Func(b, &input)
+			err := tc.Func(b, tc.Name, &input)
 			require.NoError(t, err)
 			checkGoldenFile(t, tc.Golden, b.Bytes())
 		})

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/hashicorp/hcat"
 	goVersion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/hcat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zclconf/go-cty/cty"

--- a/templates/tftmpl/module_variables.go
+++ b/templates/tftmpl/module_variables.go
@@ -60,15 +60,14 @@ func ParseModuleVariables(content []byte, filename string) (hcltmpl.Variables, e
 // NewModuleVariablesTF writes content used for variables.module.tf of a
 // Terraform root module. These variable defintions correspond to variables
 // that are passed as arguments within the module block.
-func newModuleVariablesTF(w io.Writer, input *RootModuleInputData) error {
-	err := writePreamble(w, input.Task, ModuleVarsFilename)
+func newModuleVariablesTF(w io.Writer, filename string, input *RootModuleInputData) error {
+	err := writePreamble(w, input.Task, filename)
 	if err != nil {
 		return err
 	}
 
 	hclFile := hclwrite.NewEmptyFile()
 	rootBody := hclFile.Body()
-	rootBody.AppendNewline()
 
 	lastIdx := len(input.Variables) - 1
 	for i, name := range input.Variables.Keys() {

--- a/templates/tftmpl/testdata/only_api_service.tfvars
+++ b/templates/tftmpl/testdata/only_api_service.tfvars
@@ -7,12 +7,6 @@
 # Task: test
 # Description: user description for task named 'test'
 
-testProvider = {
-  alias = "tp"
-  attr  = "value"
-  count = 10
-}
-
 services = {
   "api.worker-01.dc1" : {
     id              = "api"

--- a/templates/tftmpl/testdata/only_web_service.tfvars
+++ b/templates/tftmpl/testdata/only_web_service.tfvars
@@ -7,12 +7,6 @@
 # Task: test
 # Description: user description for task named 'test'
 
-testProvider = {
-  alias = "tp"
-  attr  = "value"
-  count = 10
-}
-
 services = {
   "web.worker-01.dc1" : {
     id              = "web"

--- a/templates/tftmpl/testdata/providers.tfvars
+++ b/templates/tftmpl/testdata/providers.tfvars
@@ -7,5 +7,8 @@
 # Task: test
 # Description: user description for task named 'test'
 
-services = {
+testProvider = {
+  alias = "tp"
+  attr  = "value"
+  count = 10
 }

--- a/templates/tftmpl/testdata/terraform.tfvars
+++ b/templates/tftmpl/testdata/terraform.tfvars
@@ -7,12 +7,6 @@
 # Task: test
 # Description: user description for task named 'test'
 
-testProvider = {
-  alias = "tp"
-  attr  = "value"
-  count = 10
-}
-
 services = {
   "api.worker-01.dc1" : {
     id              = "api"

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -7,12 +7,6 @@
 # Task: test
 # Description: user description for task named 'test'
 
-testProvider = {
-  alias = "tp"
-  attr  = "value"
-  count = 10
-}
-
 services = {
 {{- with $srv := service "api" "dc=dc1" "\"tag\" in Service.Tags" }}
   {{- $last := len $srv | subtract 1}}

--- a/templates/tftmpl/testdata/variables.module.tf
+++ b/templates/tftmpl/testdata/variables.module.tf
@@ -7,7 +7,6 @@
 # Task: test
 # Description: user description for task named 'test'
 
-
 variable "b" {
   default = null
   type    = bool

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -48,10 +48,11 @@ variable "services" {
 }
 `)
 
-// newVariablesTF writes content used for variables.tf of a Terraform root
-// module.
-func newVariablesTF(w io.Writer, input *RootModuleInputData) error {
-	err := writePreamble(w, input.Task, VarsFilename)
+// newVariablesTF writes variable definitions to a file. This includes the
+// required services variable and generated provider variables based on CTS
+// user configuration for the task.
+func newVariablesTF(w io.Writer, filename string, input *RootModuleInputData) error {
+	err := writePreamble(w, input.Task, filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Separating the provider vars allows the `terraform.tfvars` file to be more easily shareable now that potentially sensitive values are not included. This also removes provider info from being unnecessarily included in the `.tfvars.tmpl` template file.

Resolves #172