### PR TITLE
Fix task_env type validation

### DIFF
--- a/config/provider.go
+++ b/config/provider.go
@@ -146,9 +146,14 @@ func (c *TerraformProviderConfig) Validate() error {
 		// Validate task_env format if exists
 		taskEnv, exists := block["task_env"]
 		if exists {
-			_, ok := taskEnv.(map[string]string)
+			taskEnvMap, ok := taskEnv.(map[string]interface{})
 			if !ok {
-				return fmt.Errorf("unexpected task_env block format")
+				return fmt.Errorf("unexpected task_env block format: task_env should be a map of strings")
+			}
+			for k, v := range taskEnvMap {
+				if _, ok := v.(string); !ok {
+					return fmt.Errorf("unexpected task_env block format: value for %q should be a string", k)
+				}
 			}
 		}
 	}

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -276,7 +276,7 @@ func TestProviderConfigs_Validate(t *testing.T) {
 			"task_env",
 			&TerraformProviderConfigs{{
 				"null": map[string]interface{}{
-					"task_env": map[string]string{
+					"task_env": map[string]interface{}{
 						"NULL_TOKEN": "{{ env \"MY_CTS_NULL_TOKEN\" }}",
 						"NULL_BOOL":  "true",
 						"NULL_NUM":   "10",


### PR DESCRIPTION
HCL config unmarshals `task_env` to interface and type casting nested interfaces requires converting each item and not the collection -- `map[string]interface{}` and so the type validation expecting `map[string]string` would always fail and CTS would error and exit on configuration.

Related #157

Repro steps
1. Config file with `task_env` block for any provider

```hcl
terraform_provider "local" {
  task_env {
    "my_env" = "foo"
  }
}

task {
  name        = "test"
  source      = "<any module>"
  services = ["api", "web"]
}
```

2. Run CTS
```shell
$ consul-terraform-sync -config-file task_env.hcl -inspect
2021/02/04 18:14:47 [ERR] (cli) error validating configuration: unexpected task_env block format
```