### PR TITLE
Refactor buffer_period to driver-level

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -242,6 +242,7 @@ func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProvide
 			VarFiles:        t.VarFiles,
 			Version:         *t.Version,
 			UserDefinedMeta: conf.Services.CTSUserDefinedMeta(t.Services),
+			BufferPeriod:    getTemplateBufferPeriod(conf, t),
 		}
 	}
 
@@ -309,4 +310,30 @@ func getProvider(providers driver.TerraformProviderBlocks, id string) driver.Ter
 		Name:      name,
 		Variables: make(hcltmpl.Variables),
 	})
+}
+
+// getTemplateBufferPeriod applies the task buffer period config to its template
+func getTemplateBufferPeriod(conf *config.Config,
+	taskConfig *config.TaskConfig) *driver.BufferPeriod {
+
+	if buffPeriod := taskConfig.BufferPeriod; *buffPeriod.Enabled {
+		return &driver.BufferPeriod{
+			Min: *buffPeriod.Min,
+			Max: *buffPeriod.Max,
+		}
+	}
+
+	if conf == nil {
+		return nil
+	}
+
+	// Set default buffer period
+	if buffPeriod := conf.BufferPeriod; *buffPeriod.Enabled {
+		return &driver.BufferPeriod{
+			Min: *buffPeriod.Min,
+			Max: *buffPeriod.Max,
+		}
+	}
+
+	return nil
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -14,6 +14,9 @@ type Driver interface {
 	// InitTask initializes the task that the driver executes
 	InitTask(force bool) error
 
+	// SetBufferPeriod sets the task's buffer period on the watcher
+	SetBufferPeriod(watcher templates.Watcher)
+
 	// RenderTemplate renders a template. Returns if template rendering
 	// completed or not
 	RenderTemplate(ctx context.Context, watcher templates.Watcher) (bool, error)
@@ -27,7 +30,4 @@ type Driver interface {
 
 	// Version returns the version of the driver.
 	Version() string
-
-	// TemplateID returns the id of the template that the driver uses.
-	TemplateID() string
 }

--- a/driver/task.go
+++ b/driver/task.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"log"
+	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/client"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
@@ -16,6 +17,13 @@ type Service struct {
 	Tag         string
 }
 
+// BufferPeriod contains the task's buffer period configuration information
+// if enabled
+type BufferPeriod struct {
+	Min time.Duration
+	Max time.Duration
+}
+
 // Task contains task configuration information
 type Task struct {
 	Description     string
@@ -27,6 +35,7 @@ type Task struct {
 	VarFiles        []string
 	Version         string
 	UserDefinedMeta map[string]map[string]string
+	BufferPeriod    *BufferPeriod // nil when disabled
 }
 
 // ProviderNames returns the list of providers that the task has configured

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -116,11 +116,6 @@ func (tf *Terraform) Version() string {
 	return TerraformVersion.String()
 }
 
-// TemplateID returns the template ID
-func (tf *Terraform) TemplateID() string {
-	return tf.template.ID()
-}
-
 // InitTask initializes the task by creating the Terraform root module and related
 // files to execute on.
 func (tf *Terraform) InitTask(force bool) error {
@@ -179,6 +174,28 @@ func (tf *Terraform) InitTask(force bool) error {
 	}
 
 	return nil
+}
+
+// SetBufferPeriod sets the buffer period for the task. Do not set this when
+// task needs to immediately render a template and run.
+func (tf *Terraform) SetBufferPeriod(watcher templates.Watcher) {
+	taskName := tf.task.Name
+
+	if tf.template == nil {
+		log.Printf("[WARN] (driver.terraform) attempted to set buffer for "+
+			"'%s' which does not have a template", taskName)
+		return
+	}
+
+	bp := tf.task.BufferPeriod
+	if bp == nil {
+		log.Printf("[TRACE] (driver.terraform) no buffer period for '%s'", taskName)
+		return
+	}
+
+	log.Printf("[TRACE] (driver.terraform) set buffer period for '%s': %v",
+		taskName, bp)
+	watcher.SetBufferPeriod(bp.Min, bp.Max, tf.template.ID())
 }
 
 // RenderTemplate fetches data for the template. If the data is complete fetched,

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -78,18 +78,9 @@ func (_m *Driver) RenderTemplate(ctx context.Context, watcher templates.Watcher)
 	return r0, r1
 }
 
-// TemplateID provides a mock function with given fields:
-func (_m *Driver) TemplateID() string {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
+// SetBufferPeriod provides a mock function with given fields: watcher
+func (_m *Driver) SetBufferPeriod(watcher templates.Watcher) {
+	_m.Called(watcher)
 }
 
 // Version provides a mock function with given fields:


### PR DESCRIPTION
Discovered a bug in earlier refactor https://github.com/hashicorp/consul-terraform-sync/pull/185.
If a task is configured as disabled from the start, a template will not be
generated and template == nil. readwrite.setTemplateBufferPeriods() calls
driver.TemplateID() which throws a nil pointer panic.

Refactor setTemplateBufferPeriods():
 - Add controller.getTemplateBufferPeriods() and then set buffer info on driver.Task
 - Add driver.SetBufferPeriods() which sets buffer info from driver.Task on watcher
 - Update readwrite.Run() to call driver.SetBufferPeriods()
 - Remove the need for driver.TemplateID()