### PR TITLE
Consume `enabled` field in task driver

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -235,6 +235,7 @@ func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProvide
 		tasks[i] = driver.Task{
 			Description:     *t.Description,
 			Name:            *t.Name,
+			Enabled:         *t.Enabled,
 			Providers:       providers,
 			ProviderInfo:    providerInfo,
 			Services:        services,

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -180,7 +180,8 @@ func TestNewDriverTasks(t *testing.T) {
 				},
 			},
 			[]driver.Task{{
-				Name: "name",
+				Name:    "name",
+				Enabled: true,
 				Providers: driver.NewTerraformProviderBlocks(
 					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
 						{"providerA": map[string]interface{}{}},
@@ -238,7 +239,8 @@ func TestNewDriverTasks(t *testing.T) {
 				},
 			},
 			[]driver.Task{{
-				Name: "name",
+				Name:    "name",
+				Enabled: true,
 				Providers: driver.NewTerraformProviderBlocks(
 					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
 						{"providerA": map[string]interface{}{

--- a/driver/task.go
+++ b/driver/task.go
@@ -28,6 +28,7 @@ type BufferPeriod struct {
 type Task struct {
 	Description     string
 	Name            string
+	Enabled         bool
 	Providers       TerraformProviderBlocks // task.providers config info
 	ProviderInfo    map[string]interface{}  // driver.required_provider config info
 	Services        []Service

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -119,6 +119,12 @@ func (tf *Terraform) Version() string {
 // InitTask initializes the task by creating the Terraform root module and related
 // files to execute on.
 func (tf *Terraform) InitTask(force bool) error {
+	if !tf.task.Enabled {
+		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
+			"initializing", tf.task.Name)
+		return nil
+	}
+
 	task := tf.task
 
 	services := make([]tftmpl.Service, len(task.Services))
@@ -179,6 +185,12 @@ func (tf *Terraform) InitTask(force bool) error {
 // SetBufferPeriod sets the buffer period for the task. Do not set this when
 // task needs to immediately render a template and run.
 func (tf *Terraform) SetBufferPeriod(watcher templates.Watcher) {
+	if !tf.task.Enabled {
+		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
+			"setting buffer period", tf.task.Name)
+		return
+	}
+
 	taskName := tf.task.Name
 
 	if tf.template == nil {
@@ -203,6 +215,12 @@ func (tf *Terraform) SetBufferPeriod(watcher templates.Watcher) {
 // cycles to load all the dependencies asynchronously. Returns a boolean whether
 // the template was rendered
 func (tf *Terraform) RenderTemplate(ctx context.Context, watcher templates.Watcher) (bool, error) {
+	if !tf.task.Enabled {
+		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
+			"rendering template", tf.task.Name)
+		return true, nil
+	}
+
 	taskName := tf.task.Name
 	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
 
@@ -238,6 +256,12 @@ func (tf *Terraform) RenderTemplate(ctx context.Context, watcher templates.Watch
 // InspectTask inspects for any differences pertaining to the task between
 // the state of Consul and network infrastructure using the Terraform plan command
 func (tf *Terraform) InspectTask(ctx context.Context) error {
+	if !tf.task.Enabled {
+		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
+			"inspecting", tf.task.Name)
+		return nil
+	}
+
 	taskName := tf.task.Name
 
 	if err := tf.init(ctx); err != nil {
@@ -256,6 +280,12 @@ func (tf *Terraform) InspectTask(ctx context.Context) error {
 
 // ApplyTask applies the task changes.
 func (tf *Terraform) ApplyTask(ctx context.Context) error {
+	if !tf.task.Enabled {
+		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
+			"applying", tf.task.Name)
+		return nil
+	}
+
 	taskName := tf.task.Name
 
 	if err := tf.init(ctx); err != nil {

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -112,6 +112,20 @@ driver "terraform" {
 		terraformBlock + dbTask() + webTask()
 }
 
+// disabledTaskConfig returns a config file with a task that is disabled
+func disabledTaskConfig(consulAddr, tempDir string) string {
+	disabledTask := `
+task {
+	name = "disabled_task"
+	description = "task is configured as disabled"
+	enabled = false
+	services = ["api", "db"]
+	providers = ["local"]
+	source = "../../test_modules/e2e_basic_task"
+}`
+	return baseConfig() + consulBlock(consulAddr) + terraformBlock(tempDir) + disabledTask
+}
+
 func consulBlock(addr string) string {
 	return fmt.Sprintf(`
 consul {


### PR DESCRIPTION
 - Previously added `enabled` field to task configuration
 - Update driver methods to not make changes if task is disabled
 - e2e test for configuring a disabled task