### PR TITLE
Share controller drivers with API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 )
 
@@ -54,13 +55,14 @@ const (
 // API supports api requests to the cts biniary
 type API struct {
 	store   *event.Store
+	drivers map[string]driver.Driver
 	port    int
 	version string
 	srv     *http.Server
 }
 
 // NewAPI create a new API object
-func NewAPI(store *event.Store, port int) *API {
+func NewAPI(store *event.Store, drivers map[string]driver.Driver, port int) *API {
 	mux := http.NewServeMux()
 
 	// retrieve overall status
@@ -83,6 +85,7 @@ func NewAPI(store *event.Store, port int) *API {
 
 	return &API{
 		port:    port,
+		drivers: drivers,
 		store:   store,
 		version: defaultAPIVersion,
 		srv:     srv,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 )
 
@@ -44,7 +45,7 @@ func TestServe(t *testing.T) {
 
 	port, err := FreePort()
 	require.NoError(t, err)
-	api := NewAPI(event.NewStore(), port)
+	api := NewAPI(event.NewStore(), map[string]driver.Driver{}, port)
 	go api.Serve(ctx)
 
 	for _, tc := range cases {
@@ -80,7 +81,7 @@ func TestServe_context_cancel(t *testing.T) {
 
 	port, err := FreePort()
 	require.NoError(t, err)
-	api := NewAPI(event.NewStore(), port)
+	api := NewAPI(event.NewStore(), map[string]driver.Driver{}, port)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/api"
 	"github.com/stretchr/testify/assert"
@@ -113,7 +114,7 @@ func TestStatus(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	api := NewAPI(store, port)
+	api := NewAPI(store, map[string]driver.Driver{}, port)
 	go api.Serve(ctx)
 	time.Sleep(3 * time.Second) // in case tests run before server is ready
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -124,7 +124,7 @@ func TestBaseControllerInit(t *testing.T) {
 				conf: tc.config,
 			}
 
-			err := baseCtrl.init(ctx)
+			_, err := baseCtrl.init(ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 )
 
 var _ Controller = (*ReadOnly)(nil)
@@ -32,9 +33,10 @@ func NewReadOnly(conf *config.Config) (Controller, error) {
 }
 
 // Init initializes the controller before it can be run
-func (ctrl *ReadOnly) Init(ctx context.Context) error {
-	if err := ctrl.init(ctx); err != nil {
-		return err
+func (ctrl *ReadOnly) Init(ctx context.Context) (map[string]driver.Driver, error) {
+	drivers, err := ctrl.init(ctx)
+	if err != nil {
+		return map[string]driver.Driver{}, err
 	}
 
 	// Sort units for consistent ordering when inspecting tasks
@@ -42,7 +44,7 @@ func (ctrl *ReadOnly) Init(ctx context.Context) error {
 		return ctrl.units[i].taskName < ctrl.units[j].taskName
 	})
 
-	return nil
+	return drivers, nil
 }
 
 // Run runs the controller in read-only mode by checking Consul catalog once for

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 )
@@ -42,7 +43,7 @@ func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 
 // Init initializes the controller before it can be run. Ensures that
 // driver is initializes, works are created for each task.
-func (rw *ReadWrite) Init(ctx context.Context) error {
+func (rw *ReadWrite) Init(ctx context.Context) (map[string]driver.Driver, error) {
 	return rw.init(ctx)
 }
 

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -165,7 +165,7 @@ func TestOnce(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		err := rw.Init(ctx)
+		_, err := rw.Init(ctx)
 		assert.NoError(t, err)
 
 		// testing really starts here...

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -3,6 +3,7 @@ package driver
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/consul-terraform-sync/handler"
@@ -70,6 +71,7 @@ func TestRenderTemplate(t *testing.T) {
 			tmpl.On("Render", mock.Anything).Return(hcat.RenderResult{}, tc.renderErr).Once()
 
 			tf := &Terraform{
+				mu:       &sync.RWMutex{},
 				task:     Task{Name: "RenderTemplateTest", Enabled: true},
 				resolver: r,
 				template: tmpl,
@@ -156,6 +158,7 @@ func TestApplyTask(t *testing.T) {
 			c.On("Apply", ctx).Return(tc.applyReturn).Once()
 
 			tf := &Terraform{
+				mu:        &sync.RWMutex{},
 				task:      Task{Name: "ApplyTaskTest", Enabled: true},
 				client:    c,
 				postApply: tc.postApply,
@@ -284,6 +287,7 @@ func TestDisabledTask(t *testing.T) {
 		// not throw any errors
 
 		tf := &Terraform{
+			mu:   &sync.RWMutex{},
 			task: Task{Name: "disabled_task", Enabled: false},
 		}
 


### PR DESCRIPTION
In order to support an update task API for the disable/enable cli feature, APIs
will need to call the drivers for the associated task.

Changes
 - Update controller.Init() to also return a map of drivers
 - Update API with a `drivers` fields
 - Refactor cli to serve API after controller.Init() is called in order to
 consume drivers
 - Update driver to be concurrent with locks (separate commit)

(I have a subsequent PR that will consume the new drivers field in the API. The changes got sort of big so wanted to make separate PRs)