### PR TITLE
Add Update Task API with initial support to disable/enable a task

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -148,3 +148,22 @@ func jsonResponse(w http.ResponseWriter, code int, response interface{}) error {
 	w.WriteHeader(code)
 	return json.NewEncoder(w).Encode(response)
 }
+
+// getTaskName retrieves the taskname from the url. Returns empty string if no
+// taskname is specified
+func getTaskName(reqPath, apiPath, version string) (string, error) {
+	taskPathNoID := fmt.Sprintf("/%s/%s", version, apiPath)
+	if reqPath == taskPathNoID {
+		return "", nil
+	}
+
+	taskPathWithID := taskPathNoID + "/"
+	taskName := strings.TrimPrefix(reqPath, taskPathWithID)
+	if invalid := strings.ContainsRune(taskName, '/'); invalid {
+		return "", fmt.Errorf("unsupported path '%s'. request must be format "+
+			"'path/{task-name}'. task name cannot have '/ ' and api "+
+			"does not support further resources", reqPath)
+	}
+
+	return taskName, nil
+}

--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 

--- a/api/api.go
+++ b/api/api.go
@@ -76,6 +76,10 @@ func NewAPI(store *event.Store, drivers map[string]driver.Driver, port int) *API
 	mux.Handle(fmt.Sprintf("/%s/%s", defaultAPIVersion, taskStatusPath),
 		newTaskStatusHandler(store, defaultAPIVersion))
 
+	// crud task
+	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskPath),
+		newTaskHandler(store, drivers, defaultAPIVersion))
+
 	srv := &http.Server{
 		Addr:         fmt.Sprintf(":%d", port),
 		WriteTimeout: time.Second * 15,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -225,3 +225,57 @@ func TestJsonResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestGetTaskName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		path      string
+		expectErr bool
+		expected  string
+	}{
+		{
+			"all task statuses",
+			"/v1/status/tasks",
+			false,
+			"",
+		},
+		{
+			"task status for a specific task",
+			"/v1/status/tasks/my_specific_task",
+			false,
+			"my_specific_task",
+		},
+		{
+			"empty task name",
+			"/v1/status/tasks/",
+			false,
+			"",
+		},
+		{
+			"tasks task name",
+			"/v1/status/tasks/tasks",
+			false,
+			"tasks",
+		},
+		{
+			"invalid name",
+			"/v1/status/tasks/mytask/stuff",
+			true,
+			"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getTaskName(tc.path, taskStatusPath, "v1")
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,10 +5,14 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul-terraform-sync/driver"
@@ -21,21 +25,36 @@ func TestServe(t *testing.T) {
 	cases := []struct {
 		name       string
 		path       string
+		method     string
+		body       string
 		statusCode int
 	}{
 		{
 			"overall status",
 			"status",
+			http.MethodGet,
+			"",
 			http.StatusOK,
 		},
 		{
 			"task status: all",
 			"status/tasks",
+			http.MethodGet,
+			"",
 			http.StatusOK,
 		},
 		{
 			"task status: single",
 			"status/tasks/task_b",
+			http.MethodGet,
+			"",
+			http.StatusOK,
+		},
+		{
+			"update task (patch)",
+			"tasks/task_b",
+			http.MethodPatch,
+			`{"enabled": true}`,
 			http.StatusOK,
 		},
 	}
@@ -45,14 +64,24 @@ func TestServe(t *testing.T) {
 
 	port, err := FreePort()
 	require.NoError(t, err)
-	api := NewAPI(event.NewStore(), map[string]driver.Driver{}, port)
+
+	drivers := make(map[string]driver.Driver)
+	d := new(mocks.Driver)
+	d.On("UpdateTask", mock.Anything).Return(nil).Once()
+	drivers["task_b"] = d
+
+	api := NewAPI(event.NewStore(), drivers, port)
 	go api.Serve(ctx)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			u := fmt.Sprintf("http://localhost:%d/%s/%s",
 				port, defaultAPIVersion, tc.path)
-			resp, err := http.Get(u)
+			r := strings.NewReader(tc.body)
+			req, err := http.NewRequest(tc.method, u, r)
+			require.NoError(t, err)
+
+			resp, err := http.DefaultClient.Do(req)
 
 			statusCode := 0
 

--- a/api/task.go
+++ b/api/task.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/event"
+	"github.com/mitchellh/mapstructure"
+)
+
+const taskPath = "tasks"
+
+// taskHandler handles the tasks endpoint
+type taskHandler struct {
+	store   *event.Store
+	drivers map[string]driver.Driver
+	version string
+}
+
+// newTaskHandler returns a new taskHandler
+func newTaskHandler(store *event.Store, drivers map[string]driver.Driver,
+	version string) *taskHandler {
+
+	return &taskHandler{
+		store:   store,
+		drivers: drivers,
+		version: version,
+	}
+}
+
+// ServeHTTP serves the tasks endpoint
+func (h *taskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Printf("[TRACE] (api.task) requesting tasks '%s'", r.URL.Path)
+
+	switch r.Method {
+	case http.MethodPatch:
+		h.updateTask(w, r)
+	default:
+		err := fmt.Errorf("'%s' in an unsupported method. The task API "+
+			"currently supports the method(s): '%s'", r.Method, http.MethodPatch)
+		log.Printf("[TRACE] (api.task) unsupported method: %s", err)
+		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{
+			"error": err.Error(),
+		})
+	}
+}
+
+// UpdateTaskConfig contains the fields available for patch updating a task.
+// Not all task configuration is available for update
+type UpdateTaskConfig struct {
+	Enabled *bool `mapstructure:"enabled"`
+}
+
+// updateTask does a patch update to an existing task
+func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
+	taskName, err := getTaskName(r.URL.Path, taskPath, h.version)
+	if err != nil {
+		log.Printf("[TRACE] (api.task) bad request: %s", err)
+		jsonResponse(w, http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		})
+
+		return
+	}
+
+	if taskName == "" {
+		err := fmt.Errorf("No taskname was included in the api request. " +
+			"Updating a task requires the taskname: '/v1/tasks/:task_name'")
+		log.Printf("[TRACE] (api.task) bad request: %s", err)
+		jsonResponse(w, http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	d, ok := h.drivers[taskName]
+	if !ok {
+		err := fmt.Errorf("A task with the name '%s' does not exist or has not "+
+			"been initialized yet", taskName)
+		log.Printf("[TRACE] (api.task) task not found: %s", err)
+		jsonResponse(w, http.StatusNotFound, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("[TRACE] (api.task) unable to read request body: %s", err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	conf, err := decodeBody(body)
+	if err != nil {
+		log.Printf("[TRACE] (api.task) problem decoding body: %s", err)
+		jsonResponse(w, http.StatusBadRequest, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	patch := driver.PatchTask{}
+	if conf.Enabled != nil {
+		log.Printf("[INFO] (api.task) Updating task to be enabled=%t",
+			config.BoolVal(conf.Enabled))
+		patch.Enabled = config.BoolVal(conf.Enabled)
+	}
+
+	err = d.UpdateTask(patch)
+	if err != nil {
+		log.Printf("[TRACE] (api.task) error while updating task: %s", err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, "")
+}
+
+func decodeBody(body []byte) (UpdateTaskConfig, error) {
+	var raw map[string]interface{}
+
+	err := json.Unmarshal(body, &raw)
+	if err != nil {
+		return UpdateTaskConfig{}, err
+	}
+
+	var config UpdateTaskConfig
+	var md mapstructure.Metadata
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Metadata:         &md,
+		Result:           &config,
+	})
+	if err != nil {
+		return UpdateTaskConfig{}, err
+	}
+
+	if err = decoder.Decode(raw); err != nil {
+		return UpdateTaskConfig{}, err
+	}
+
+	if len(md.Unused) > 0 {
+		sort.Strings(md.Unused)
+		err := fmt.Errorf("request body's JSON contains unsupported keys: %s",
+			strings.Join(md.Unused, ", "))
+		return UpdateTaskConfig{}, err
+	}
+
+	return config, nil
+}

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -40,7 +40,7 @@ func newTaskStatusHandler(store *event.Store, version string) *taskStatusHandler
 func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[TRACE] (api.taskstatus) requesting task status '%s'", r.URL.Path)
 
-	taskName, err := getTaskName(r.URL.Path, h.version)
+	taskName, err := getTaskName(r.URL.Path, taskStatusPath, h.version)
 	if err != nil {
 		log.Printf("[TRACE] (api.taskstatus) bad request: %s", err)
 		jsonResponse(w, http.StatusBadRequest, map[string]string{
@@ -81,25 +81,6 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, http.StatusOK, statuses)
-}
-
-// getTaskName retrieves the taskname from the url. Returns empty string if no
-// taskname is specified
-func getTaskName(path, version string) (string, error) {
-	taskPathNoID := fmt.Sprintf("/%s/%s", version, taskStatusPath)
-	if path == taskPathNoID {
-		return "", nil
-	}
-
-	taskPathWithID := taskPathNoID + "/"
-	taskName := strings.TrimPrefix(path, taskPathWithID)
-	if invalid := strings.ContainsRune(taskName, '/'); invalid {
-		return "", fmt.Errorf("unsupported path '%s'. request must be format "+
-			"'/status/tasks/{task-name}'. task name cannot have '/ ' and api "+
-			"does not support further resources", path)
-	}
-
-	return taskName, nil
 }
 
 // makeTaskStatus takes event data for a task and returns an overall task status

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -237,58 +237,6 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 
 }
 
-func TestTaskStatus_GetTaskName(t *testing.T) {
-	cases := []struct {
-		name      string
-		path      string
-		expectErr bool
-		expected  string
-	}{
-		{
-			"all task statuses",
-			"/v1/status/tasks",
-			false,
-			"",
-		},
-		{
-			"task status for a specific task",
-			"/v1/status/tasks/my_specific_task",
-			false,
-			"my_specific_task",
-		},
-		{
-			"empty task name",
-			"/v1/status/tasks/",
-			false,
-			"",
-		},
-		{
-			"tasks task name",
-			"/v1/status/tasks/tasks",
-			false,
-			"tasks",
-		},
-		{
-			"invalid name",
-			"/v1/status/tasks/mytask/stuff",
-			true,
-			"",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := getTaskName(tc.path, "v1")
-			if tc.expectErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
 func TestTaskStatus_MakeStatus(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/api/task_test.go
+++ b/api/task_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/event"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTask_New(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+	}{
+		{
+			"happy path",
+			"v1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTaskHandler(event.NewStore(), map[string]driver.Driver{}, tc.version)
+			assert.Equal(t, tc.version, h.version)
+		})
+	}
+}
+
+func TestTask_ServeHTTP(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		path       string
+		method     string
+		body       string
+		statusCode int
+	}{
+		{
+			"patch update task",
+			"/v1/tasks/task_patch_update",
+			http.MethodPatch,
+			`{"enabled": true}`,
+			http.StatusOK,
+		},
+		{
+			"put update task",
+			"/v1/tasks/xyz",
+			http.MethodPut,
+			``,
+			http.StatusMethodNotAllowed,
+		},
+	}
+
+	drivers := make(map[string]driver.Driver)
+	patchUpdateD := new(mocks.Driver)
+	patchUpdateD.On("UpdateTask", mock.Anything).Return(nil).Once()
+	drivers["task_patch_update"] = patchUpdateD
+
+	handler := newTaskHandler(event.NewStore(), drivers, "v1")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := strings.NewReader(tc.body)
+			req, err := http.NewRequest(tc.method, tc.path, r)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			handler.ServeHTTP(resp, req)
+
+			require.Equal(t, tc.statusCode, resp.Code)
+		})
+	}
+}
+
+func TestTask_updateTask(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name          string
+		path          string
+		body          string
+		statusCode    int
+		updateTaskRet error
+	}{
+		{
+			"happy path",
+			"/v1/tasks/task_a",
+			`{"enabled": true}`,
+			http.StatusOK,
+			nil,
+		},
+		{
+			"bad path/taskname",
+			"/v1/tasks/task/a",
+			`{"enabled": true}`,
+			http.StatusBadRequest,
+			nil,
+		},
+		{
+			"no task specified",
+			"/v1/tasks",
+			`{"enabled": true}`,
+			http.StatusBadRequest,
+			nil,
+		},
+		{
+			"task not found",
+			"/v1/tasks/task_b",
+			`{"enabled": true}`,
+			http.StatusNotFound,
+			nil,
+		},
+		{
+			"ill formed request body",
+			"/v1/tasks/task_a",
+			`...???`,
+			http.StatusBadRequest,
+			nil,
+		},
+		{
+			"error when updating task",
+			"/v1/tasks/task_a",
+			`{"enabled": true}`,
+			http.StatusInternalServerError,
+			errors.New("error updating task"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			drivers := make(map[string]driver.Driver)
+			d := new(mocks.Driver)
+			d.On("UpdateTask", mock.Anything).Return(tc.updateTaskRet).Once()
+			drivers["task_a"] = d
+
+			handler := newTaskHandler(event.NewStore(), drivers, "v1")
+
+			r := strings.NewReader(tc.body)
+			req, err := http.NewRequest(http.MethodPatch, tc.path, r)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			handler.updateTask(resp, req)
+			require.Equal(t, tc.statusCode, resp.Code)
+		})
+	}
+}
+
+func TestTask_decodeJSON(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		body      string
+		expected  UpdateTaskConfig
+		expectErr bool
+	}{
+		{
+			"no enabled field",
+			`{"unsupported": true}`,
+			UpdateTaskConfig{Enabled: nil},
+			true,
+		},
+		{
+			"enabled true",
+			`{"enabled": true}`,
+			UpdateTaskConfig{Enabled: config.Bool(true)},
+			false,
+		},
+		{
+			"enable false",
+			`{"enabled": false}`,
+			UpdateTaskConfig{Enabled: config.Bool(false)},
+			false,
+		},
+		{
+			"unmarshal error",
+			`sdfsdf`,
+			UpdateTaskConfig{Enabled: nil},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := decodeBody([]byte(tc.body))
+			assert.Equal(t, tc.expected, actual)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -28,6 +28,9 @@ type Driver interface {
 	// ApplyTask applies change for the task managed by the driver
 	ApplyTask(ctx context.Context) error
 
+	// UpdateTask supports updating certain fields of a task
+	UpdateTask(task PatchTask) error
+
 	// Version returns the version of the driver.
 	Version() string
 }

--- a/driver/task.go
+++ b/driver/task.go
@@ -8,6 +8,12 @@ import (
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
 )
 
+// PatchTask holds the information to patch update a task. It will only include
+// fields that we support updating at this time
+type PatchTask struct {
+	Enabled bool
+}
+
 // Service contains service configuration information
 type Service struct {
 	Datacenter  string

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -5,6 +5,7 @@ package mocks
 import (
 	context "context"
 
+	driver "github.com/hashicorp/consul-terraform-sync/driver"
 	mock "github.com/stretchr/testify/mock"
 
 	templates "github.com/hashicorp/consul-terraform-sync/templates"
@@ -81,6 +82,20 @@ func (_m *Driver) RenderTemplate(ctx context.Context, watcher templates.Watcher)
 // SetBufferPeriod provides a mock function with given fields: watcher
 func (_m *Driver) SetBufferPeriod(watcher templates.Watcher) {
 	_m.Called(watcher)
+}
+
+// UpdateTask provides a mock function with given fields: task
+func (_m *Driver) UpdateTask(task driver.PatchTask) error {
+	ret := _m.Called(task)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(driver.PatchTask) error); ok {
+		r0 = rf(task)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Version provides a mock function with given fields:


### PR DESCRIPTION
Add support for `PATCH /v1/tasks/<task_name> -data '{"enabled:"true}'`. This will
be used for the upcoming disable task CLI. Additional functionality will be
added in subsequent PRs for enable task CLI.

Changes (each correspond with a commit. See individual commit messages for
more details):
 - Refactor api's getTaskName() to be shared across handlers
 - Add driver.UpdateTask() to allow patch updating a task
 - Add Update Task API

Note: ^ I tried to split out changes into commits. Not perfect. There's a couple lines
(particularly imports) that aren't in the right commit.