### PR TITLE
Make a testutils package to hold helper functions shared across packages

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
-	"log"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -16,6 +14,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/api"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -267,8 +266,9 @@ func Test_Task_Update(t *testing.T) {
 	t.Run("disable-then-enable", func(t *testing.T) {
 		// setup temp dir
 		tempDir := "disable-enable"
-		makeTempDir(tempDir)
-		defer removeDir(tempDir)
+		delete, err := testutils.MakeTempDir(tempDir)
+		require.NoError(t, err)
+		defer delete()
 
 		// add a driver
 		d, err := driver.NewTerraform(&driver.TerraformConfig{
@@ -290,21 +290,4 @@ func Test_Task_Update(t *testing.T) {
 		)
 		require.Error(t, err)
 	})
-}
-
-// makeTempDir creates a directory for a test
-func makeTempDir(tempDir string) error {
-	_, err := os.Stat(tempDir)
-	if !os.IsNotExist(err) {
-		log.Printf("[WARN] temp dir %s was not cleared out after last test. Deleting.", tempDir)
-		if err = removeDir(tempDir); err != nil {
-			return err
-		}
-	}
-	return os.Mkdir(tempDir, os.ModePerm)
-}
-
-// removeDir removes temporary directory created for a test
-func removeDir(tempDir string) error {
-	return os.RemoveAll(tempDir)
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "status_endpoints")
-	err = makeTempDir(tempDir)
+	delete, err := testutils.MakeTempDir(tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 	require.NoError(t, err)
 
@@ -210,7 +211,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 
 	err = stopCommand(cmd)
 	require.NoError(t, err)
-	removeDir(tempDir)
+	delete()
 }
 
 // runSyncDevMode runs the daemon in development which does not run or download

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -1,0 +1,29 @@
+// testutils package contains some helper methods that are used in tests across
+// multiple packages
+
+package testutils
+
+import (
+	"log"
+	"os"
+)
+
+// MakeTempDir creates a directory in the current path for a test. Caller is
+// responsible for managing the uniqueness of the directory name. Returns a
+// function for the caller to delete the temporary directory.
+func MakeTempDir(tempDir string) (func() error, error) {
+	_, err := os.Stat(tempDir)
+	if !os.IsNotExist(err) {
+		log.Printf("[WARN] temp dir %s was not cleared out after last test. "+
+			"Deleting.", tempDir)
+		if err = os.RemoveAll(tempDir); err != nil {
+			return nil, err
+		}
+	}
+	os.Mkdir(tempDir, os.ModePerm)
+
+	return func() error {
+		return os.RemoveAll(tempDir)
+
+	}, nil
+}

--- a/testutils/utils_test.go
+++ b/testutils/utils_test.go
@@ -1,0 +1,23 @@
+package testutils
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeTempDir(t *testing.T) {
+	t.Run("happy-path", func(t *testing.T) {
+		tempDir := "test-temp"
+		delete, err := MakeTempDir(tempDir)
+		require.NoError(t, err)
+
+		_, err = ioutil.ReadDir(tempDir)
+		require.NoError(t, err)
+
+		delete()
+		_, err = ioutil.ReadDir(tempDir)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Changes:
 - Refactor out makeTempDir to testutils

It was copied in two packages and we have at least one other test-helper-type method that would benefit from consolidating in a testing package