### PR TITLE
Support disable CLI

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	mcli "github.com/mitchellh/cli"
-
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/command"
 	"github.com/hashicorp/consul-terraform-sync/config"
@@ -22,6 +20,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul-terraform-sync/version"
+	mcli "github.com/mitchellh/cli"
 )
 
 // Exit codes are int values that represent an exit code for a particular error.

--- a/cli.go
+++ b/cli.go
@@ -8,11 +8,15 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	mcli "github.com/mitchellh/cli"
+
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/command"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
 	"github.com/hashicorp/consul-terraform-sync/event"
@@ -105,15 +109,36 @@ func (cli *CLI) Run(args []string) int {
 		return ExitCodeParseFlagsError
 	}
 
-	if help || h {
-		fmt.Printf("Usage of %s:\n", os.Args[0])
-		printFlags(f)
-		return ExitCodeOK
-	}
-
 	if isVersion {
 		fmt.Fprintf(cli.errStream, "%s %s\n", version.Name, version.GetHumanVersion())
 		fmt.Fprintf(cli.errStream, "Compatible with Terraform %s\n", version.CompatibleTerraformVersionConstraint)
+		return ExitCodeOK
+	}
+
+	// Are we running the binary or a CLI command?
+	// If the first unused argument isn't a flag, then assume subcommand
+	unused := f.Args()
+	if len(unused) > 0 && !strings.HasPrefix(unused[0], "-") {
+		subcommands := &mcli.CLI{
+			Name:     "consul-terraform-sync",
+			Args:     args[1:],
+			Commands: command.Commands(),
+		}
+
+		exitCode, err := subcommands.Run()
+		if err != nil {
+			log.Printf("[ERROR] running the CLI command '%s': %s",
+				strings.Join(args, " "), err)
+		}
+		return exitCode
+	}
+
+	// running the binary!
+
+	// Print out binary's help info
+	if help || h {
+		fmt.Printf("Usage of %s:\n", os.Args[0])
+		printFlags(f)
 		return ExitCodeOK
 	}
 
@@ -123,6 +148,11 @@ func (cli *CLI) Run(args []string) int {
 		printFlags(f)
 		return ExitCodeRequiredFlagsError
 	}
+	return cli.runBinary(configFiles, inspectTasks, isInspect, isOnce, clientType)
+}
+
+func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
+	isInspect, isOnce bool, clientType string) int {
 
 	// Build the config.
 	conf, err := config.BuildConfig([]string(configFiles))

--- a/command/commands.go
+++ b/command/commands.go
@@ -6,7 +6,17 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// Commands returns the mapping of CLI commands for Nomad. The meta
+// Exit codes match the main cli's exit code
+const (
+	ExitCodeOK int = 0
+
+	ExitCodeError = 10 + iota
+	ExitCodeInterrupt
+	ExitCodeRequiredFlagsError
+	ExitCodeParseFlagsError
+)
+
+// Commands returns the mapping of CLI commands for CTS. The meta
 // parameter lets you set meta options for all commands.
 func Commands() map[string]cli.CommandFactory {
 	m := meta{

--- a/command/commands.go
+++ b/command/commands.go
@@ -1,0 +1,33 @@
+package command
+
+import (
+	"os"
+
+	"github.com/mitchellh/cli"
+)
+
+// Commands returns the mapping of CLI commands for Nomad. The meta
+// parameter lets you set meta options for all commands.
+func Commands() map[string]cli.CommandFactory {
+	m := meta{
+		UI: &cli.PrefixedUi{
+			InfoPrefix:   "==> ",
+			OutputPrefix: "    ",
+			ErrorPrefix:  "==> ",
+			Ui: &cli.BasicUi{
+				Writer: os.Stdout,
+				Reader: os.Stdin,
+			},
+		},
+	}
+
+	all := map[string]cli.CommandFactory{
+		"task disable": func() (cli.Command, error) {
+			return &taskDisableCommand{
+				meta: m,
+			}, nil
+		},
+	}
+
+	return all
+}

--- a/command/meta.go
+++ b/command/meta.go
@@ -1,8 +1,67 @@
 package command
 
-import "github.com/mitchellh/cli"
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-wordwrap"
+)
+
+// terminal width. use for word-wrapping
+const width = uint(78)
 
 // meta contains the meta-options and functionality for all CTS commands
 type meta struct {
 	UI cli.Ui
+}
+
+// nameHelpCommand is a interface to retrieve a command's name and help text
+type nameHelpCommand interface {
+	Name() string
+	Help() string
+}
+
+func (m *meta) defaultFlagSet(c nameHelpCommand, args []string) *flag.FlagSet {
+	flags := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	flags.SetOutput(ioutil.Discard)
+	flags.Usage = func() {
+		m.UI.Error(fmt.Sprintf("Error: unsupported arguments in flags '%s'",
+			strings.Join(args, ", ")))
+		m.UI.Output(fmt.Sprintf("Please see --help information below for "+
+			"supported options:\n\n%s", c.Help()))
+	}
+
+	return flags
+}
+
+func (m *meta) oneArgCheck(c nameHelpCommand, args []string) bool {
+	if len(args) == 1 {
+		return true
+	}
+
+	m.UI.Error("Error: this command requires one argument: <task name>")
+	if len(args) == 0 {
+		m.UI.Output("No arguments were passed to the command")
+	} else {
+		m.UI.Output(fmt.Sprintf("%d arguments were passed to the command: '%s'",
+			len(args), strings.Join(args, ", ")))
+	}
+
+	help := fmt.Sprintf("For additional help try 'consul-terraform-sync %s --help'",
+		c.Name())
+	help = wordwrap.WrapString(help, width)
+
+	m.UI.Output(help)
+	return false
+}
+
+func (m *meta) client() *api.Client {
+	return api.NewClient(&api.ClientConfig{
+		// TODO: add support for configuring port when doing general options
+		Port: 8558,
+	}, nil)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -1,0 +1,8 @@
+package command
+
+import "github.com/mitchellh/cli"
+
+// meta contains the meta-options and functionality for all CTS commands
+type meta struct {
+	UI cli.Ui
+}

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -1,0 +1,22 @@
+package command
+
+// TaskDisableCommand handles the `task disable` command
+type taskDisableCommand struct {
+	meta
+}
+
+// Help returns the command's usage, list of flags, and examples
+func (c *taskDisableCommand) Help() string {
+	return "TODO"
+}
+
+// Synopsis is a short one-line synopsis of the command
+func (c *taskDisableCommand) Synopsis() string {
+	return "Disables existing tasks from running."
+}
+
+// Run runs the command
+func (c *taskDisableCommand) Run(args []string) int {
+	c.UI.Info("Running...TODO")
+	return 0
+}

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -1,13 +1,43 @@
 package command
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/mitchellh/go-wordwrap"
+)
+
 // TaskDisableCommand handles the `task disable` command
 type taskDisableCommand struct {
 	meta
 }
 
+// Name returns the subcommand
+func (c *taskDisableCommand) Name() string {
+	return "task disable"
+}
+
 // Help returns the command's usage, list of flags, and examples
 func (c *taskDisableCommand) Help() string {
-	return "TODO"
+	helpText := `
+Usage: consul-terraform-sync task disable [options] <task name>
+
+  Task Disable is used to disable existing tasks. Once disabled, a task will no
+  longer run and make changes to your network infrastructure resources.
+
+Options:
+  No options are currently available
+
+Example:
+
+  $ consul-terraform-sync task disable my_task
+    ==> Waiting to disable 'Test_2'...
+
+    ==> 'Test_2' disable complete!
+`
+	return strings.TrimSpace(helpText)
 }
 
 // Synopsis is a short one-line synopsis of the command
@@ -17,6 +47,36 @@ func (c *taskDisableCommand) Synopsis() string {
 
 // Run runs the command
 func (c *taskDisableCommand) Run(args []string) int {
-	c.UI.Info("Running...TODO")
-	return 0
+	flags := c.meta.defaultFlagSet(c, args)
+
+	if err := flags.Parse(args); err != nil {
+		return ExitCodeParseFlagsError
+	}
+
+	args = flags.Args()
+	if ok := c.meta.oneArgCheck(c, args); !ok {
+		return ExitCodeRequiredFlagsError
+	}
+
+	taskName := args[0]
+
+	c.UI.Info(fmt.Sprintf("Waiting to disable '%s'...", taskName))
+	c.UI.Output("")
+
+	client := c.meta.client()
+	err := client.Task().Update(taskName, api.UpdateTaskConfig{
+		Enabled: config.Bool(false),
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to disable '%s'", taskName))
+
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	c.UI.Info(fmt.Sprintf("'%s' disable complete!", taskName))
+
+	return ExitCodeOK
 }

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/hashicorp/consul v1.8.0
 	github.com/hashicorp/consul/sdk v0.5.0
 	github.com/hashicorp/go-checkpoint v0.5.0
-	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
@@ -22,7 +21,9 @@ require (
 	github.com/hashicorp/terraform-exec v0.9.0
 	github.com/hashicorp/vault v1.4.2
 	github.com/hashicorp/vault/api v1.0.5-0.20200630205458-1a16f3c699c6
+	github.com/mitchellh/cli v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
`consul-terraform-sync task disable <task_name>`

Changes (each correspond with a commit. See individual commit messages for
more details):
 - Some initial minimal CLI command support. Taken from Nomad and Terraform
 - Support disable CLI (fixes some typos in previous change too)

Note: planning to write an E2E test once I also update Status API with enabled/disabled. In the test, then I will be able to run the disable CLI and use the status API to confirm changes in disabled/enabled.