### PR TITLE
command: add port flag option

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -33,9 +33,7 @@ func Commands() map[string]cli.CommandFactory {
 
 	all := map[string]cli.CommandFactory{
 		"task disable": func() (cli.Command, error) {
-			return &taskDisableCommand{
-				meta: m,
-			}, nil
+			return newTaskDisableCommand(m), nil
 		},
 	}
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/mitchellh/cli"
 	"github.com/mitchellh/go-wordwrap"
 )
@@ -17,42 +18,53 @@ const width = uint(78)
 // meta contains the meta-options and functionality for all CTS commands
 type meta struct {
 	UI cli.Ui
+
+	helpOptions []string
+	port        int
 }
 
-// nameHelpCommand is a interface to retrieve a command's name and help text
-type nameHelpCommand interface {
-	Name() string
-	Help() string
-}
-
-func (m *meta) defaultFlagSet(c nameHelpCommand, args []string) *flag.FlagSet {
-	flags := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.IntVar(&m.port, "port", config.DefaultPort, "The port to use for the Consul Terraform Sync API server")
 	flags.SetOutput(ioutil.Discard)
-	flags.Usage = func() {
-		m.UI.Error(fmt.Sprintf("Error: unsupported arguments in flags '%s'",
-			strings.Join(args, ", ")))
-		m.UI.Output(fmt.Sprintf("Please see --help information below for "+
-			"supported options:\n\n%s", c.Help()))
+
+	flags.VisitAll(func(f *flag.Flag) {
+		option := fmt.Sprintf("  %s %s\n    %s\n", f.Name, f.Value, f.Usage)
+		m.helpOptions = append(m.helpOptions, option)
+	})
+	if len(m.helpOptions) == 0 {
+		m.helpOptions = append(m.helpOptions, "No options are currently available")
 	}
 
 	return flags
 }
 
-func (m *meta) oneArgCheck(c nameHelpCommand, args []string) bool {
-	if len(args) == 1 {
+func (m *meta) setFlagsUsage(flags *flag.FlagSet, args []string, help string) {
+	flags.Usage = func() {
+		m.UI.Error(fmt.Sprintf("Error: unsupported arguments in flags '%s'",
+			strings.Join(args, ", ")))
+		m.UI.Output(fmt.Sprintf("Please see --help information below for "+
+			"supported options:\n\n%s", help))
+	}
+}
+
+func (m *meta) oneArgCheck(name string, args []string) bool {
+	numArgs := len(args)
+	if numArgs == 1 {
 		return true
 	}
 
-	m.UI.Error("Error: this command requires one argument: <task name>")
-	if len(args) == 0 {
+	m.UI.Error("Error: this command requires one argument: [options] <task name>")
+	if numArgs == 0 {
 		m.UI.Output("No arguments were passed to the command")
 	} else {
 		m.UI.Output(fmt.Sprintf("%d arguments were passed to the command: '%s'",
-			len(args), strings.Join(args, ", ")))
+			numArgs, strings.Join(args, ", ")))
+		m.UI.Output("All flags are required to appear before positional arguments if set\n")
 	}
 
 	help := fmt.Sprintf("For additional help try 'consul-terraform-sync %s --help'",
-		c.Name())
+		name)
 	help = wordwrap.WrapString(help, width)
 
 	m.UI.Output(help)
@@ -61,7 +73,6 @@ func (m *meta) oneArgCheck(c nameHelpCommand, args []string) bool {
 
 func (m *meta) client() *api.Client {
 	return api.NewClient(&api.ClientConfig{
-		// TODO: add support for configuring port when doing general options
-		Port: 8558,
+		Port: m.port,
 	}, nil)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -20,12 +20,12 @@ type meta struct {
 	UI cli.Ui
 
 	helpOptions []string
-	port        int
+	port        *int
 }
 
 func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
-	flags.IntVar(&m.port, "port", config.DefaultPort, "The port to use for the Consul Terraform Sync API server")
+	m.port = flags.Int("port", config.DefaultPort, "The port to use for the Consul Terraform Sync API server")
 	flags.SetOutput(ioutil.Discard)
 
 	flags.VisitAll(func(f *flag.Flag) {
@@ -73,6 +73,6 @@ func (m *meta) oneArgCheck(name string, args []string) bool {
 
 func (m *meta) client() *api.Client {
 	return api.NewClient(&api.ClientConfig{
-		Port: m.port,
+		Port: *m.port,
 	}, nil)
 }

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
@@ -9,26 +10,38 @@ import (
 	"github.com/mitchellh/go-wordwrap"
 )
 
+const cmdTaskDisableName = "task disable"
+
 // TaskDisableCommand handles the `task disable` command
 type taskDisableCommand struct {
 	meta
+
+	flags *flag.FlagSet
+}
+
+func newTaskDisableCommand(m meta) *taskDisableCommand {
+	flags := m.defaultFlagSet(cmdTaskDisableName)
+	return &taskDisableCommand{
+		meta:  m,
+		flags: flags,
+	}
 }
 
 // Name returns the subcommand
-func (c *taskDisableCommand) Name() string {
-	return "task disable"
+func (c taskDisableCommand) Name() string {
+	return cmdTaskDisableName
 }
 
 // Help returns the command's usage, list of flags, and examples
 func (c *taskDisableCommand) Help() string {
-	helpText := `
+	helpText := fmt.Sprintf(`
 Usage: consul-terraform-sync task disable [options] <task name>
 
   Task Disable is used to disable existing tasks. Once disabled, a task will no
   longer run and make changes to your network infrastructure resources.
 
 Options:
-  No options are currently available
+%s
 
 Example:
 
@@ -36,7 +49,7 @@ Example:
     ==> Waiting to disable 'Test_2'...
 
     ==> 'Test_2' disable complete!
-`
+`, strings.Join(c.meta.helpOptions, "\n"))
 	return strings.TrimSpace(helpText)
 }
 
@@ -47,14 +60,14 @@ func (c *taskDisableCommand) Synopsis() string {
 
 // Run runs the command
 func (c *taskDisableCommand) Run(args []string) int {
-	flags := c.meta.defaultFlagSet(c, args)
+	c.meta.setFlagsUsage(c.flags, args, c.Help())
 
-	if err := flags.Parse(args); err != nil {
+	if err := c.flags.Parse(args); err != nil {
 		return ExitCodeParseFlagsError
 	}
 
-	args = flags.Args()
-	if ok := c.meta.oneArgCheck(c, args); !ok {
+	args = c.flags.Args()
+	if ok := c.meta.oneArgCheck(c.Name(), args); !ok {
 		return ExitCodeRequiredFlagsError
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,8 @@ const (
 	// DefaultLogLevel is the default logging level.
 	DefaultLogLevel = "WARN"
 
-	// defaultPort is the default port to use for api server.
-	defaultPort = 8558
+	// DefaultPort is the default port to use for api server.
+	DefaultPort = 8558
 )
 
 // Config is used to configure Sync
@@ -71,7 +71,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		LogLevel:           String(DefaultLogLevel),
 		Syslog:             DefaultSyslogConfig(),
-		Port:               Int(defaultPort),
+		Port:               Int(DefaultPort),
 		Consul:             consul,
 		Driver:             DefaultDriverConfig(),
 		Tasks:              DefaultTaskConfigs(),
@@ -170,7 +170,7 @@ func (c *Config) Finalize() {
 	}
 
 	if c.Port == nil {
-		c.Port = Int(defaultPort)
+		c.Port = Int(DefaultPort)
 	}
 
 	if c.ClientType == nil {


### PR DESCRIPTION
Add `-port` as a default flag option for CLI commands. The default port remains as `8558`.

```
$ consul-terraform-sync task disable -port 2000 my_task
==> Waiting to disable 'my_task'...

==> Error: unable to disable 'my_task'
    Patch "http://localhost:2000/v1/tasks/my_task": dial tcp 127.0.0.1:2000:
connect: connection refused
```

Changes overview
* Dynamically add flag options to Help output
    ```
    $ consul-terraform-sync task disable -h
    Usage: consul-terraform-sync task disable [options] <task name>

      Task Disable is used to disable existing tasks. Once disabled, a task will no
      longer run and make changes to your network infrastructure resources.

    Options:
      port 8558
        The port to use for the Consul Terraform Sync API server
    ```
* Added additional help msg when flags and arguments are set out of Golang's expected order
    ```
    $ consul-terraform-sync task disable my_task -port 2000
    ==> Error: this command requires one argument: [options] <task name>
        3 arguments were passed to the command: 'my_task, -port, 2000'
        All flags are required to appear before positional arguments

        For additional help try 'consul-terraform-sync task disable --help'
    ```