### PR TITLE
Change version output to stdout

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -109,8 +109,8 @@ func (cli *CLI) Run(args []string) int {
 	}
 
 	if isVersion {
-		fmt.Fprintf(cli.errStream, "%s %s\n", version.Name, version.GetHumanVersion())
-		fmt.Fprintf(cli.errStream, "Compatible with Terraform %s\n", version.CompatibleTerraformVersionConstraint)
+		fmt.Fprintf(cli.outStream, "%s %s\n", version.Name, version.GetHumanVersion())
+		fmt.Fprintf(cli.outStream, "Compatible with Terraform %s\n", version.CompatibleTerraformVersionConstraint)
 		return ExitCodeOK
 	}
 


### PR DESCRIPTION
**Breaking change:** The output of the version flag was going to `stderr`. This changes the output to `stdout` to align with how other hashicorp tools are set.

```shell
$ consul-terraform-sync -version 1> stdout.txt
$ cat stdout.txt 
consul-terraform-sync 0.1.0-techpreview2 (7fbd5e1)
Compatible with Terraform >= 0.13.0, < 0.15
```