### PR TITLE
Change API error from string to object

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -154,6 +154,10 @@ func jsonResponse(w http.ResponseWriter, code int, response interface{}) error {
 	return json.NewEncoder(w).Encode(response)
 }
 
+func jsonErrorResponse(w http.ResponseWriter, code int, err error) error {
+	return jsonResponse(w, code, NewErrorResponse(err))
+}
+
 // getTaskName retrieves the taskname from the url. Returns empty string if no
 // taskname is specified
 func getTaskName(reqPath, apiPath, version string) (string, error) {

--- a/api/error.go
+++ b/api/error.go
@@ -1,0 +1,29 @@
+package api
+
+// ErrorObject is the object to represent an error object from the API server
+type ErrorObject struct {
+	Message string `json:"message"`
+}
+
+// ErrorResponse is the object to represent an error response from the API server
+type ErrorResponse struct {
+	Error *ErrorObject `json:"error,omitempty"`
+}
+
+// NewErrorResponse creates a new API response for an error
+func NewErrorResponse(err error) ErrorResponse {
+	return ErrorResponse{
+		Error: &ErrorObject{
+			Message: err.Error(),
+		},
+	}
+}
+
+// ErrorMessage returns the error message if there is an error.
+func (resp ErrorResponse) ErrorMessage() (string, bool) {
+	if resp.Error == nil {
+		return "", false
+	}
+
+	return resp.Error.Message, true
+}

--- a/api/task.go
+++ b/api/task.go
@@ -47,9 +47,7 @@ func (h *taskHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err := fmt.Errorf("'%s' in an unsupported method. The task API "+
 			"currently supports the method(s): '%s'", r.Method, http.MethodPatch)
 		log.Printf("[TRACE] (api.task) unsupported method: %s", err)
-		jsonResponse(w, http.StatusMethodNotAllowed, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusMethodNotAllowed, err)
 	}
 }
 
@@ -64,9 +62,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 	taskName, err := getTaskName(r.URL.Path, taskPath, h.version)
 	if err != nil {
 		log.Printf("[TRACE] (api.task) bad request: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 
 		return
 	}
@@ -75,9 +71,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		err := fmt.Errorf("No taskname was included in the api request. " +
 			"Updating a task requires the taskname: '/v1/tasks/:task_name'")
 		log.Printf("[TRACE] (api.task) bad request: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -86,36 +80,28 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		err := fmt.Errorf("A task with the name '%s' does not exist or has not "+
 			"been initialized yet", taskName)
 		log.Printf("[TRACE] (api.task) task not found: %s", err)
-		jsonResponse(w, http.StatusNotFound, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusNotFound, err)
 		return
 	}
 
 	runOp, err := runOption(r)
 	if err != nil {
 		log.Printf("[TRACE] (api.task) unsupported run option: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("[TRACE] (api.task) unable to read request body: %s", err)
-		jsonResponse(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 
 	conf, err := decodeBody(body)
 	if err != nil {
 		log.Printf("[TRACE] (api.task) problem decoding body: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
@@ -133,9 +119,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 	plan, err := d.UpdateTask(ctx, patch)
 	if err != nil {
 		log.Printf("[TRACE] (api.task) error while updating task: %s", err)
-		jsonResponse(w, http.StatusInternalServerError, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -43,27 +43,21 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	taskName, err := getTaskName(r.URL.Path, taskStatusPath, h.version)
 	if err != nil {
 		log.Printf("[TRACE] (api.taskstatus) bad request: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
 	filter, err := statusFilter(r)
 	if err != nil {
 		log.Printf("[TRACE] (api.taskstatus) bad request: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 
 	include, err := include(r)
 	if err != nil {
 		log.Printf("[TRACE] (api.taskstatus) bad request: %s", err)
-		jsonResponse(w, http.StatusBadRequest, map[string]string{
-			"error": err.Error(),
-		})
+		jsonErrorResponse(w, http.StatusBadRequest, err)
 		return
 	}
 


### PR DESCRIPTION
**Breaking change**: This will give room for future details to be added to the API error responses.

Prior to change
```
{
  "error": "unsupported status parameter value. only supporting status values successful, errored, critical, and unknown but got xxx"
}
```

After change
```
{
  "error": {
    "message": "unsupported status parameter value. only supporting status values successful, errored, critical, and unknown but got XXX"
  }
}
```

