### PR TITLE
Update Task Status API to support enabled/disabled tasks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -71,10 +71,10 @@ func NewAPI(store *event.Store, drivers map[string]driver.Driver, port int) *API
 		newOverallStatusHandler(store, defaultAPIVersion))
 	// retrieve task status for a task-name
 	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskStatusPath),
-		newTaskStatusHandler(store, defaultAPIVersion))
+		newTaskStatusHandler(store, drivers, defaultAPIVersion))
 	// retrieve all task statuses
 	mux.Handle(fmt.Sprintf("/%s/%s", defaultAPIVersion, taskStatusPath),
-		newTaskStatusHandler(store, defaultAPIVersion))
+		newTaskStatusHandler(store, drivers, defaultAPIVersion))
 
 	// crud task
 	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskPath),

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -68,6 +68,7 @@ func TestServe(t *testing.T) {
 	d := new(mocks.Driver)
 	d.On("UpdateTask", mock.Anything, mock.Anything).
 		Return(driver.InspectPlan{}, nil).Once()
+	d.On("Task").Return(driver.Task{Enabled: true})
 	drivers["task_b"] = d
 
 	api := NewAPI(event.NewStore(), drivers, port)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -114,12 +114,9 @@ func TestStatus(t *testing.T) {
 
 	// setup drivers
 	drivers := make(map[string]driver.Driver)
-	d := new(mocksD.Driver)
-	d.On("UpdateTask", mock.Anything, mock.Anything).Return("", nil).Once()
-	d.On("Task").Return(driver.Task{Enabled: true})
-	drivers["task_a"] = d
-	drivers["task_b"] = d
-	drivers["task_c"] = d
+	drivers["task_a"] = createEnabledDriver("task_a")
+	drivers["task_b"] = createEnabledDriver("task_b")
+	drivers["task_c"] = createEnabledDriver("task_c")
 
 	// start up server
 	port, err := FreePort()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -112,12 +112,21 @@ func TestStatus(t *testing.T) {
 	eventsC := createTaskEvents("task_c", []bool{false, false, true})
 	addEvents(store, eventsC)
 
+	// setup drivers
+	drivers := make(map[string]driver.Driver)
+	d := new(mocksD.Driver)
+	d.On("UpdateTask", mock.Anything, mock.Anything).Return("", nil).Once()
+	d.On("Task").Return(driver.Task{Enabled: true})
+	drivers["task_a"] = d
+	drivers["task_b"] = d
+	drivers["task_c"] = d
+
 	// start up server
 	port, err := FreePort()
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	api := NewAPI(store, map[string]driver.Driver{}, port)
+	api := NewAPI(store, drivers, port)
 	go api.Serve(ctx)
 	time.Sleep(3 * time.Second) // in case tests run before server is ready
 
@@ -152,6 +161,7 @@ func TestStatus(t *testing.T) {
 				map[string]TaskStatus{
 					"task_a": TaskStatus{
 						TaskName:  "task_a",
+						Enabled:   true,
 						Status:    StatusSuccessful,
 						Providers: []string{},
 						Services:  []string{},
@@ -159,6 +169,7 @@ func TestStatus(t *testing.T) {
 					},
 					"task_b": TaskStatus{
 						TaskName:  "task_b",
+						Enabled:   true,
 						Status:    StatusCritical,
 						Providers: []string{},
 						Services:  []string{},
@@ -166,6 +177,7 @@ func TestStatus(t *testing.T) {
 					},
 					"task_c": TaskStatus{
 						TaskName:  "task_c",
+						Enabled:   true,
 						Status:    StatusCritical,
 						Providers: []string{},
 						Services:  []string{},
@@ -181,6 +193,7 @@ func TestStatus(t *testing.T) {
 				map[string]TaskStatus{
 					"task_a": TaskStatus{
 						TaskName:  "task_a",
+						Enabled:   true,
 						Status:    StatusSuccessful,
 						Providers: []string{},
 						Services:  []string{},
@@ -197,6 +210,7 @@ func TestStatus(t *testing.T) {
 					"task_b": TaskStatus{
 						TaskName:  "task_b",
 						Status:    StatusCritical,
+						Enabled:   true,
 						Providers: []string{},
 						Services:  []string{},
 						EventsURL: "/v1/status/tasks/task_b?include=events",
@@ -212,6 +226,7 @@ func TestStatus(t *testing.T) {
 				map[string]TaskStatus{
 					"task_b": TaskStatus{
 						TaskName:  "task_b",
+						Enabled:   true,
 						Status:    StatusCritical,
 						Providers: []string{},
 						Services:  []string{},
@@ -219,6 +234,7 @@ func TestStatus(t *testing.T) {
 					},
 					"task_c": TaskStatus{
 						TaskName:  "task_c",
+						Enabled:   true,
 						Status:    StatusCritical,
 						Providers: []string{},
 						Services:  []string{},

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -75,7 +75,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			jsonErrorResponse(w, http.StatusNotFound, err)
 			return
 		}
-		status := makeTaskStatus(taskName, events, d.Task(), h.version)
+		status := makeTaskStatus(events, d.Task(), h.version)
 
 		if filter != "" && status.Status != filter {
 			continue
@@ -110,7 +110,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // makeTaskStatus takes event data for a task and returns a task status
-func makeTaskStatus(taskName string, events []event.Event, task driver.Task,
+func makeTaskStatus(events []event.Event, task driver.Task,
 	version string) TaskStatus {
 
 	successes := make([]bool, len(events))
@@ -131,12 +131,12 @@ func makeTaskStatus(taskName string, events []event.Event, task driver.Task,
 	}
 
 	return TaskStatus{
-		TaskName:  taskName,
+		TaskName:  task.Name,
 		Status:    successToStatus(successes),
 		Enabled:   task.Enabled,
 		Providers: mapKeyToArray(uniqProviders),
 		Services:  mapKeyToArray(uniqServices),
-		EventsURL: makeEventsURL(events, version, taskName),
+		EventsURL: makeEventsURL(events, version, task.Name),
 	}
 }
 

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -72,9 +72,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			err := fmt.Errorf("task '%s' does not exist", taskName)
 			log.Printf("[TRACE] (api.updatetask) %s", err)
-			jsonResponse(w, http.StatusNotFound, map[string]string{
-				"error": err.Error(),
-			})
+			jsonErrorResponse(w, http.StatusNotFound, err)
 			return
 		}
 		status := makeTaskStatus(taskName, events, d.Task(), h.version)

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -227,7 +227,6 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"non-existent task",
 			"/v1/status/tasks/task_nonexistent",
-			// http.StatusOK,
 			http.StatusNotFound,
 			map[string]TaskStatus{},
 		},

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -155,6 +155,11 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 // returns false, no event is stored.
 func (rw *ReadWrite) checkApply(ctx context.Context, u unit, retry bool) (bool, error) {
 	taskName := u.taskName
+	d := u.driver
+	if !d.Task().Enabled {
+		log.Printf("[TRACE] (ctrl) skipping disabled task '%s'", taskName)
+		return true, nil
+	}
 
 	// setup to store event information
 	ev, err := event.NewEvent(taskName, &event.Config{
@@ -176,7 +181,6 @@ func (rw *ReadWrite) checkApply(ctx context.Context, u unit, retry bool) (bool, 
 	}
 	ev.Start()
 
-	d := u.driver
 	var rendered bool
 	rendered, storedErr = d.RenderTemplate(ctx)
 	if storedErr != nil {

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -125,7 +125,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
-			require.Equal(t, tc.statusCode, resp.StatusCode)
+			assert.Equal(t, tc.statusCode, resp.StatusCode)
 
 			if tc.statusCode != http.StatusOK {
 				return
@@ -192,10 +192,10 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 
 			task, ok := taskStatuses[disabledTaskName]
 			if tc.expectDisabledTask {
-				require.True(t, ok)
+				assert.True(t, ok)
 				assert.Nil(t, task.Events)
 			} else {
-				require.False(t, ok)
+				assert.False(t, ok)
 			}
 		})
 	}

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -11,6 +11,7 @@ const (
 
 	fakeSuccessTaskName = "fake_handler_success_task"
 	fakeFailureTaskName = "fake_handler_failure_task"
+	disabledTaskName    = "disabled_task"
 )
 
 // oneTaskConfig returns a basic config file with a single task
@@ -82,7 +83,16 @@ task {
 	providers = ["fake-sync.success"]
 	source = "../../test_modules/e2e_basic_task"
 }
-`, port, fakeFailureTaskName, fakeSuccessTaskName)
+
+task {
+	name = "%s"
+	description = "disabled task"
+	enabled = false
+	services = ["api"]
+	providers = ["fake-sync.success"]
+	source = "../../test_modules/e2e_basic_task"
+}
+`, port, fakeFailureTaskName, fakeSuccessTaskName, disabledTaskName)
 
 	return fakeHandlerConfig + consulBlock(consulAddr) + terraformBlock(tempDir)
 }


### PR DESCRIPTION
Example of updated return payload:
```
  "task_a": {
    "task_name": "task_a",
    "status": "successful",
    "enabled": false, // new field
	...
  }
```

Commits:
 - Add driver to taskStatusHandler and use driver to add `enabled` information
 to task status payload
 - Support 'unknown' status for tasks that are disabled from the start (since
 these tasks have never run, there is no event data  collected on them)
 - Fix issue in controller where events were being stored even though tasks were
 disabled
