### PR TITLE
Update Overall Status API to support enabled/disabled tasks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -68,7 +68,7 @@ func NewAPI(store *event.Store, drivers map[string]driver.Driver, port int) *API
 
 	// retrieve overall status
 	mux.Handle(fmt.Sprintf("/%s/%s", defaultAPIVersion, overallStatusPath),
-		newOverallStatusHandler(store, defaultAPIVersion))
+		newOverallStatusHandler(store, drivers, defaultAPIVersion))
 	// retrieve task status for a task-name
 	mux.Handle(fmt.Sprintf("/%s/%s/", defaultAPIVersion, taskStatusPath),
 		newTaskStatusHandler(store, drivers, defaultAPIVersion))

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -240,9 +240,15 @@ func TestJsonResponse(t *testing.T) {
 			http.StatusOK,
 			OverallStatus{
 				TaskSummary: TaskSummary{
-					Successful: 1,
-					Errored:    0,
-					Critical:   1,
+					Status: StatusSummary{
+						Successful: 1,
+						Errored:    0,
+						Critical:   1,
+					},
+					Enabled: EnabledSummary{
+						True:  2,
+						False: 5,
+					},
 				},
 			},
 		},

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -114,9 +114,9 @@ func TestStatus(t *testing.T) {
 
 	// setup drivers
 	drivers := make(map[string]driver.Driver)
-	drivers["task_a"] = createEnabledDriver("task_a")
-	drivers["task_b"] = createEnabledDriver("task_b")
-	drivers["task_c"] = createEnabledDriver("task_c")
+	drivers["task_a"] = createDriver("task_a", true)
+	drivers["task_b"] = createDriver("task_b", true)
+	drivers["task_c"] = createDriver("task_c", true)
 
 	// start up server
 	port, err := FreePort()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -134,9 +134,15 @@ func TestStatus(t *testing.T) {
 		require.NoError(t, err)
 		expect := OverallStatus{
 			TaskSummary: TaskSummary{
-				Successful: 1,
-				Errored:    0,
-				Critical:   2,
+				Status: StatusSummary{
+					Successful: 1,
+					Errored:    0,
+					Critical:   2,
+				},
+				Enabled: EnabledSummary{
+					True:  3,
+					False: 0,
+				},
 			},
 		}
 		assert.Equal(t, expect, actual)

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
-	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -74,16 +73,11 @@ func TestOverallStatus_ServeHTTP(t *testing.T) {
 
 	// set up driver
 	drivers := make(map[string]driver.Driver)
-	enabledD := new(mocks.Driver)
-	enabledD.On("Task").Return(driver.Task{Enabled: true})
-	drivers["success_a"] = enabledD
-	drivers["success_b"] = enabledD
-	drivers["errored_c"] = enabledD
-	drivers["critical_d"] = enabledD
-
-	disabledD := new(mocks.Driver)
-	disabledD.On("Task").Return(driver.Task{Enabled: false})
-	drivers["disabled_e"] = disabledD
+	drivers["success_a"] = createDriver("success_a", true)
+	drivers["success_b"] = createDriver("success_b", true)
+	drivers["errored_c"] = createDriver("errored_c", true)
+	drivers["critical_d"] = createDriver("critical_d", true)
+	drivers["disabled_e"] = createDriver("disabled_e", false)
 
 	handler := newOverallStatusHandler(store, drivers, "v1")
 

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -50,6 +50,7 @@ func TestOverallStatus_ServeHTTP(t *testing.T) {
 						Successful: 2,
 						Errored:    1,
 						Critical:   1,
+						Unknown:    1,
 					},
 					Enabled: EnabledSummary{
 						True:  4,

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -54,9 +54,9 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 	addEvents(store, eventsC)
 
 	drivers := make(map[string]driver.Driver)
-	drivers["task_a"] = createEnabledDriver("task_a")
-	drivers["task_b"] = createEnabledDriver("task_b")
-	drivers["task_c"] = createEnabledDriver("task_c")
+	drivers["task_a"] = createDriver("task_a", true)
+	drivers["task_b"] = createDriver("task_b", true)
+	drivers["task_c"] = createDriver("task_c", true)
 
 	disabledD := new(mocks.Driver)
 	disabledD.On("Task").Return(driver.Task{
@@ -635,12 +635,12 @@ func addEvents(store *event.Store, events []event.Event) {
 	}
 }
 
-func createEnabledDriver(taskName string) driver.Driver {
+func createDriver(taskName string, enabled bool) driver.Driver {
 	d := new(mocks.Driver)
 	d.On("UpdateTask", mock.Anything, mock.Anything).Return("", nil).Once()
 	d.On("Task").Return(driver.Task{
 		Name:    taskName,
-		Enabled: true,
+		Enabled: enabled,
 	})
 	return d
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -226,6 +226,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 
 			// check status values
 			assert.Equal(t, 1, overallStatus.TaskSummary.Status.Successful)
+			assert.Equal(t, 1, overallStatus.TaskSummary.Status.Unknown)
 			// failed task might be errored/critical by now depending on number of events
 			assert.Equal(t, 1, overallStatus.TaskSummary.Status.Errored+
 				overallStatus.TaskSummary.Status.Critical)

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -224,10 +224,15 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 			err = decoder.Decode(&overallStatus)
 			require.NoError(t, err)
 
-			assert.Equal(t, 1, overallStatus.TaskSummary.Successful)
+			// check status values
+			assert.Equal(t, 1, overallStatus.TaskSummary.Status.Successful)
 			// failed task might be errored/critical by now depending on number of events
-			assert.Equal(t, 1, overallStatus.TaskSummary.Errored+
-				overallStatus.TaskSummary.Critical)
+			assert.Equal(t, 1, overallStatus.TaskSummary.Status.Errored+
+				overallStatus.TaskSummary.Status.Critical)
+
+			// check enabled values
+			assert.Equal(t, 2, overallStatus.TaskSummary.Enabled.True)
+			assert.Equal(t, 1, overallStatus.TaskSummary.Enabled.False)
 		})
 	}
 


### PR DESCRIPTION
**Breaking change:** Reorganize the returned status payload to allow for
different breakdowns of task summary information

Example of new payload:
```
{
  "task_summary": {
    "status": { // move status info into this status sub-struct
      "successful": 2,
      "errored": 1,
      "critical": 0,
      "unknown": 0 // new field for disabled tasks with no event data
    },
    "enabled": { // add new enabled information
      "true": 2,
      "false": 1
    }
  }
}
```

Commits:
 - Add driver to overallStatusHandler and use driver to add enabled information
to overall status payload. Refactor task summary to have status and enabled
sub-structures
 - Refactor some testing methods
 - Support 'unknown' status for tasks that are disabled from the start (since
these tasks have never run, there is no event data collected on them)
