### PR TITLE
Add e2e tests for Update Task API

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -263,7 +263,7 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 	err = makeConfig(configPath, disabledTaskConfig(srv.HTTPAddr, tempDir, port))
 	require.NoError(t, err)
 
-	cmd, err := runSyncLongMode(configPath)
+	cmd, err := runSync(configPath)
 	defer stopCommand(cmd)
 	require.NoError(t, err)
 	time.Sleep(5 * time.Second)
@@ -343,8 +343,7 @@ func runSyncDevMode(configPath string) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
-// runSyncLongMode - placeholder name
-func runSyncLongMode(configPath string) (*exec.Cmd, error) {
+func runSync(configPath string) (*exec.Cmd, error) {
 	cmd := exec.Command("consul-terraform-sync",
 		fmt.Sprintf("--config-file=%s", configPath))
 	cmd.Stdout = os.Stdout

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -8,14 +8,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
@@ -213,8 +216,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	for _, tc := range overallCases {
 		t.Run(tc.name, func(t *testing.T) {
 			u := fmt.Sprintf("http://localhost:%d/%s/%s", port, "v1", tc.path)
-			resp, err := http.Get(u)
-			require.NoError(t, err)
+			resp := apiRequest(t, http.MethodGet, u, "")
 			defer resp.Body.Close()
 
 			require.Equal(t, resp.StatusCode, http.StatusOK)
@@ -242,11 +244,109 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	delete()
 }
 
+func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
+	t.Parallel()
+
+	srv, err := newTestConsulServer(t)
+	require.NoError(t, err, "failed to start consul server")
+	defer srv.Stop()
+
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "disabled_task")
+	delete, err := testutils.MakeTempDir(tempDir)
+	// no defer to delete directory: only delete at end of test if no errors
+	require.NoError(t, err)
+
+	port, err := api.FreePort()
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tempDir, configFile)
+	err = makeConfig(configPath, disabledTaskConfig(srv.HTTPAddr, tempDir, port))
+	require.NoError(t, err)
+
+	cmd, err := runSyncLongMode(configPath)
+	defer stopCommand(cmd)
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+
+	// Confirm that terraform files were not generated for a disabled task
+	fileInfos, err := ioutil.ReadDir(fmt.Sprintf("%s/%s", tempDir, "disabled_task"))
+	require.NoError(t, err)
+	require.Equal(t, len(fileInfos), 0)
+
+	// Confirm that resources were not created
+	resourcesPath := fmt.Sprintf("%s/%s", tempDir, resourcesDir)
+	confirmDirNotFound(t, resourcesPath)
+
+	// Update Task API: enable task with inspect run option
+	baseUrl := fmt.Sprintf("http://localhost:%d/%s/tasks/%s",
+		port, "v1", disabledTaskName)
+	u := fmt.Sprintf("%s?run=inspect", baseUrl)
+	resp := apiRequest(t, http.MethodPatch, u, `{"enabled":true}`)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var inspectPlan driver.InspectPlan
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&inspectPlan)
+	require.NoError(t, err)
+
+	// Confirm inspect plan response: changes present, plan not empty
+	assert.True(t, inspectPlan.ChangesPresent)
+	assert.NotEmpty(t, inspectPlan.Plan)
+
+	// Confirm that resources were not generated during inspect mode
+	confirmDirNotFound(t, resourcesPath)
+
+	// Update Task API: enable task with run now option
+	u = fmt.Sprintf("%s?run=now", baseUrl)
+	resp1 := apiRequest(t, http.MethodPatch, u, `{"enabled":true}`)
+	defer resp1.Body.Close()
+
+	// Confirm that resources are generated
+	_, err = ioutil.ReadDir(resourcesPath)
+	require.NoError(t, err)
+
+	// Update Task API: disable task
+	resp2 := apiRequest(t, http.MethodPatch, baseUrl, `{"enabled":false}`)
+	defer resp2.Body.Close()
+
+	// Delete Resources
+	err = os.RemoveAll(resourcesPath)
+	require.NoError(t, err)
+
+	// Register a new service
+	service := testutil.TestService{
+		ID:      "api-2",
+		Name:    "api",
+		Address: "5.6.7.8",
+		Port:    8080,
+	}
+	registerService(t, srv, service, testutil.HealthPassing)
+	time.Sleep(3 * time.Second)
+
+	// Confirm that resources are not recreated for disabled task
+	confirmDirNotFound(t, resourcesPath)
+
+	delete()
+}
+
 // runSyncDevMode runs the daemon in development which does not run or download
 // Terraform.
 func runSyncDevMode(configPath string) (*exec.Cmd, error) {
 	cmd := exec.Command("consul-terraform-sync",
 		fmt.Sprintf("--config-file=%s", configPath), "--client-type=development")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+// runSyncLongMode - placeholder name
+func runSyncLongMode(configPath string) (*exec.Cmd, error) {
+	cmd := exec.Command("consul-terraform-sync",
+		fmt.Sprintf("--config-file=%s", configPath))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
@@ -323,4 +423,21 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 			}
 		}
 	}
+}
+
+// apiRequest makes an api request. caller is responsible for closing response
+func apiRequest(t *testing.T, method, url, body string) *http.Response {
+	r := strings.NewReader(body)
+	req, err := http.NewRequest(method, url, r)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+func confirmDirNotFound(t *testing.T, dir string) {
+	_, err := ioutil.ReadDir(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such file or directory")
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -246,6 +246,12 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 
 func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 	t.Parallel()
+	// Test enabling and disabling a task
+	// 1. Start with disabled task. Confirm task not initialized, resources not created
+	// 2. API to inspect enabling task. Confirm plan looks good, resources not created
+	// 3. API to actually enable task. Confirm resources are created
+	// 4. API to disable task. Delete resources. Register new service. Confirm
+	// new service registering does not trigger creating resources
 
 	srv, err := newTestConsulServer(t)
 	require.NoError(t, err, "failed to start consul server")

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -123,17 +123,25 @@ driver "terraform" {
 }
 
 // disabledTaskConfig returns a config file with a task that is disabled
-func disabledTaskConfig(consulAddr, tempDir string) string {
-	disabledTask := `
+func disabledTaskConfig(consulAddr, tempDir string, port int) string {
+	disabledTask := fmt.Sprintf(`
+port = %d
+
 task {
-	name = "disabled_task"
+	name = "%s"
 	description = "task is configured as disabled"
 	enabled = false
-	services = ["api", "db"]
+	services = ["api"]
 	providers = ["local"]
 	source = "../../test_modules/e2e_basic_task"
-}`
-	return baseConfig() + consulBlock(consulAddr) + terraformBlock(tempDir) + disabledTask
+}
+
+service {
+	name = "api"
+	description = "backend"
+}
+`, port, disabledTaskName)
+	return consulBlock(consulAddr) + terraformBlock(tempDir) + disabledTask
 }
 
 func consulBlock(addr string) string {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -219,40 +219,6 @@ func TestE2ELocalBackend(t *testing.T) {
 	}
 }
 
-func TestE2EDisabledTask(t *testing.T) {
-	t.Parallel()
-
-	srv, err := newTestConsulServer(t)
-	require.NoError(t, err, "failed to start consul server")
-	defer srv.Stop()
-
-	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "disabled_task")
-	delete, err := testutils.MakeTempDir(tempDir)
-	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
-
-	configPath := filepath.Join(tempDir, configFile)
-	err = makeConfig(configPath, disabledTaskConfig(srv.HTTPAddr, tempDir))
-	require.NoError(t, err)
-
-	// running sync in long-running mode vs. once mode since long-running mode
-	// has additional functions that may execute unexpectedly on disabled tasks
-	err = runSync(configPath, 8*time.Second)
-	require.NoError(t, err)
-
-	// Confirm that terraform files were not generated
-	fileInfos, err := ioutil.ReadDir(fmt.Sprintf("%s/%s", tempDir, "disabled_task"))
-	require.NoError(t, err)
-	require.Equal(t, len(fileInfos), 0)
-
-	// Confirm that resources were not created
-	_, err = ioutil.ReadDir(fmt.Sprintf("%s/%s", tempDir, resourcesDir))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
-
-	delete()
-}
-
 func newTestConsulServer(t *testing.T) (*testutil.TestServer, error) {
 	log.SetOutput(ioutil.Discard)
 	srv, err := testutil.NewTestServerConfig(func(c *testutil.TestServerConfig) {


### PR DESCRIPTION
Commits:
 - Reuse TestE2EDisabledTask for Update Task API e2e test due to overlaps in
 checks. Expand on disabled task to enable then disable and do checks
 - Refactor functions that run CTS
