### PR TITLE
Task update API to be consistent JSON payload with snake_case

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -225,8 +225,8 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 
 // InspectPlan stores return the information about what
 type InspectPlan struct {
-	ChangesPresent bool
-	Plan           string
+	ChangesPresent bool   `json:"changes_present"`
+	Plan           string `json:"plan"`
 }
 
 // UpdateTask updates the task on the driver. Makes any calls to re-init


### PR DESCRIPTION
All other API responses are snake case. Instead of creating a dedicated API object that is 1:1 to the internal object, will just added JSON struct tags as a means to have the Update Task API to be consistent with snake case.

```
$ curl localhost:8558/v1/tasks/a -X PATCH -d '{"enabled":true}' | jq .
```

```diff
{
-  "ChangesPresent": false,
-  "Plan": ""
+  "changes_present": false,
+  "plan": ""
}
```