### PR TITLE
Use consul configuration for the default consul backend for Terraform

### DIFF
--- a/config/consul.go
+++ b/config/consul.go
@@ -200,6 +200,10 @@ func (c *ConsulConfig) GoString() string {
 
 // Env returns an environment map of supported Consul configuration
 func (c *ConsulConfig) Env() map[string]string {
+	if c == nil {
+		return nil
+	}
+
 	env := make(map[string]string)
 	if val := StringVal(c.Address); val != "" {
 		env["CONSUL_HTTP_ADDR"] = val

--- a/config/consul.go
+++ b/config/consul.go
@@ -197,3 +197,21 @@ func (c *ConsulConfig) GoString() string {
 		c.Transport.GoString(),
 	)
 }
+
+// Env returns an environment map of supported Consul configuration
+func (c *ConsulConfig) Env() map[string]string {
+	env := make(map[string]string)
+	if val := StringVal(c.Address); val != "" {
+		env["CONSUL_HTTP_ADDR"] = val
+	}
+	if val := StringVal(c.Token); val != "" {
+		env["CONSUL_HTTP_TOKEN"] = val
+	}
+	if c.TLS != nil {
+		for k, v := range c.TLS.ConsulEnv() {
+			env[k] = v
+		}
+	}
+
+	return env
+}

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -326,6 +326,17 @@ func (c *TerraformConfig) GoString() string {
 	)
 }
 
+// IsConsulBackend returns if the Terraform backend is using Consul KV for
+// remote state store.
+func (c *TerraformConfig) IsConsulBackend() bool {
+	if c.Backend == nil {
+		return false
+	}
+
+	_, ok := c.Backend["consul"]
+	return ok
+}
+
 func mergeMaps(c, o map[string]interface{}) map[string]interface{} {
 	r := make(map[string]interface{})
 	for k, v := range c {

--- a/config/tls.go
+++ b/config/tls.go
@@ -161,3 +161,34 @@ func (c *TLSConfig) GoString() string {
 		BoolVal(c.Verify),
 	)
 }
+
+// ConsulEnv returns an environment map of the TLS configuration for Consul
+func (c *TLSConfig) ConsulEnv() map[string]string {
+	env := make(map[string]string)
+
+	if !BoolVal(c.Enabled) {
+		return env
+	}
+
+	if val := StringVal(c.Cert); val != "" {
+		env["CONSUL_CLIENT_CERT"] = val
+	}
+
+	if val := StringVal(c.CACert); val != "" {
+		env["CONSUL_CACERT"] = val
+	}
+
+	if val := StringVal(c.CAPath); val != "" {
+		env["CONSUL_CAPATH"] = val
+	}
+
+	if val := StringVal(c.Key); val != "" {
+		env["CONSUL_CLIENT_KEY"] = val
+	}
+
+	if val := StringVal(c.ServerName); val != "" {
+		env["CONSUL_TLS_SERVER_NAME"] = val
+	}
+
+	return env
+}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -183,6 +183,9 @@ func TestNewDriverTasks(t *testing.T) {
 			[]driver.Task{{
 				Name:    "name",
 				Enabled: true,
+				Env: map[string]string{
+					"CONSUL_HTTP_ADDR": "localhost:8500",
+				},
 				Providers: driver.NewTerraformProviderBlocks(
 					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
 						{"providerA": map[string]interface{}{}},
@@ -242,6 +245,9 @@ func TestNewDriverTasks(t *testing.T) {
 			[]driver.Task{{
 				Name:    "name",
 				Enabled: true,
+				Env: map[string]string{
+					"CONSUL_HTTP_ADDR": "localhost:8500",
+				},
 				Providers: driver.NewTerraformProviderBlocks(
 					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
 						{"providerA": map[string]interface{}{

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -272,6 +272,56 @@ func TestNewDriverTasks(t *testing.T) {
 					Max: 20 * time.Second,
 				},
 			}},
+		}, {
+			// Task env is fetched from providers and Consul config when using
+			// default backend
+			"task env",
+			&config.Config{
+				Consul: &config.ConsulConfig{
+					Address: config.String("my.consul.address"),
+					Token:   config.String("TEST_CONSUL_TOKEN"),
+				},
+				Tasks: &config.TaskConfigs{
+					{
+						Name:      config.String("name"),
+						Providers: []string{"providerA"},
+						Source:    config.String("source"),
+					},
+				},
+				TerraformProviders: &config.TerraformProviderConfigs{
+					{"providerA": map[string]interface{}{
+						"task_env": map[string]interface{}{
+							"PROVIDER_TOKEN": "TEST_PROVIDER_TOKEN",
+						},
+					}},
+				},
+			},
+			[]driver.Task{{
+				Name:    "name",
+				Enabled: true,
+				Env: map[string]string{
+					"CONSUL_HTTP_ADDR":  "my.consul.address",
+					"CONSUL_HTTP_TOKEN": "TEST_CONSUL_TOKEN",
+					"PROVIDER_TOKEN":    "TEST_PROVIDER_TOKEN",
+				},
+				Providers: driver.NewTerraformProviderBlocks(
+					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
+						{"providerA": map[string]interface{}{
+							"task_env": map[string]interface{}{
+								"PROVIDER_TOKEN": "TEST_PROVIDER_TOKEN",
+							},
+						}},
+					})),
+				ProviderInfo:    map[string]interface{}{},
+				Services:        []driver.Service{},
+				Source:          "source",
+				VarFiles:        []string{},
+				UserDefinedMeta: map[string]map[string]string{},
+				BufferPeriod: &driver.BufferPeriod{
+					Min: 5 * time.Second,
+					Max: 20 * time.Second,
+				},
+			}},
 		},
 	}
 

--- a/driver/task.go
+++ b/driver/task.go
@@ -46,6 +46,7 @@ type Task struct {
 	Description     string
 	Name            string
 	Enabled         bool
+	Env             map[string]string
 	Providers       TerraformProviderBlocks // task.providers config info
 	ProviderInfo    map[string]interface{}  // driver.required_provider config info
 	Services        []Service

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -96,7 +96,7 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 		log.Printf("[ERR] (driver.terraform) init client type '%s' error: %s", config.ClientType, err)
 		return nil, err
 	}
-	if env := config.Task.Providers.Env(); len(env) > 0 {
+	if env := config.Task.Env; len(env) > 0 {
 		tfClient.SetEnv(env)
 	}
 
@@ -171,7 +171,7 @@ func (tf *Terraform) SetBufferPeriod() {
 		return
 	}
 
-	log.Printf("[TRACE] (driver.terraform) set buffer period for '%s': %v",
+	log.Printf("[TRACE] (driver.terraform) set buffer period for '%s': %+v",
 		taskName, bp)
 	tf.watcher.SetBufferPeriod(bp.Min, bp.Max, tf.template.ID())
 }


### PR DESCRIPTION
The default Terraform backend when ran by CTS is the Consul KV. Users would configure the Consul block in CTS configuration and assume the same configuration would be used for the Terraform Consul backend. However there were two edge cases not handled for configuring the default Consul backend.
1. Configuration values in Consul block for CTS configuration file were not passed to the Consul client used by Terraform backend (i.e. the `backend "consul" {}` block in Terraform `main.tf`).
2. Configuration values for Consul through ENV were not passed to the Consul client used by Terraform backend if a provider `task_env` was set because it no longer consumed from the os environment ([tfexec docs](https://pkg.go.dev/github.com/hashicorp/terraform-exec@v0.13.0/tfexec#Terraform.SetEnv)).

The proposed changes convert Consul configuration to the supported ENV to set for the task's Terraform workspace. These changes do not write Consul configuration values to any Terraform files unless explicitly configured within the Terraform [backend block](https://www.consul.io/docs/nia/configuration#backend).