### PR TITLE
Modify the Update Task API response when returning inspect

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -252,6 +252,16 @@ func TestJsonResponse(t *testing.T) {
 				},
 			},
 		},
+		{
+			"update task inspect",
+			http.StatusOK,
+			UpdateTaskResponse{
+				Inspect: &driver.InspectPlan{
+					ChangesPresent: true,
+					Plan:           "plan!",
+				},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -325,11 +325,11 @@ func Test_Task_Update(t *testing.T) {
 			Return(expectedPlan, nil).Once()
 		drivers["task_a"] = d
 
-		actualPlan, err := c.Task().Update("task_a", UpdateTaskConfig{
+		actual, err := c.Task().Update("task_a", UpdateTaskConfig{
 			Enabled: config.Bool(false),
 		}, &QueryParam{Run: driver.RunOptionInspect})
 
 		require.NoError(t, err)
-		assert.Equal(t, expectedPlan, actualPlan)
+		assert.Equal(t, expectedPlan, *actual.Inspect)
 	})
 }

--- a/api/task.go
+++ b/api/task.go
@@ -57,6 +57,10 @@ type UpdateTaskConfig struct {
 	Enabled *bool `mapstructure:"enabled"`
 }
 
+type UpdateTaskResponse struct {
+	Inspect *driver.InspectPlan `json:"inspect,omitempty"`
+}
+
 // updateTask does a patch update to an existing task
 func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 	taskName, err := getTaskName(r.URL.Path, taskPath, h.version)
@@ -126,7 +130,12 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jsonResponse(w, http.StatusOK, plan)
+	if runOp != driver.RunOptionInspect {
+		jsonResponse(w, http.StatusOK, UpdateTaskResponse{})
+		return
+	}
+
+	jsonResponse(w, http.StatusOK, UpdateTaskResponse{&plan})
 }
 
 func decodeBody(body []byte) (UpdateTaskConfig, error) {

--- a/api/task_test.go
+++ b/api/task_test.go
@@ -181,11 +181,16 @@ func TestTask_updateTask(t *testing.T) {
 			require.Equal(t, tc.statusCode, resp.Code)
 
 			decoder := json.NewDecoder(resp.Body)
-			var actual driver.InspectPlan
+			var actual UpdateTaskResponse
 			err = decoder.Decode(&actual)
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.updateTaskRet, actual)
+			emptyPlan := driver.InspectPlan{}
+			if tc.updateTaskRet == emptyPlan {
+				assert.Nil(t, actual.Inspect)
+			} else {
+				assert.Equal(t, tc.updateTaskRet, *actual.Inspect)
+			}
 		})
 	}
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
-	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
@@ -291,14 +290,15 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var inspectPlan driver.InspectPlan
+	var r api.UpdateTaskResponse
 	decoder := json.NewDecoder(resp.Body)
-	err = decoder.Decode(&inspectPlan)
+	err = decoder.Decode(&r)
 	require.NoError(t, err)
 
 	// Confirm inspect plan response: changes present, plan not empty
-	assert.True(t, inspectPlan.ChangesPresent)
-	assert.NotEmpty(t, inspectPlan.Plan)
+	assert.NotNil(t, r.Inspect)
+	assert.True(t, r.Inspect.ChangesPresent)
+	assert.NotEmpty(t, r.Inspect.Plan)
 
 	// Confirm that resources were not generated during inspect mode
 	confirmDirNotFound(t, resourcesPath)


### PR DESCRIPTION
While writing the API docs for Update Task, I found that the returned response didn't make sense to me for all cases

PR changes the response so that the returned driver.InspectPlan is wrapped in an 'inspect' object, and it is only returned when `?run=inspect` is requested.

For other/no run options, return an empty 'inspect' object. Previously, an empty driver.InspectPlan was returned when `?run=inspected` was _not_ requested. The empty values are confusing. In particular, `changes_present` would be false for `?run=now` even though changes might have actually been present.

Example payload when `?run=inspect`
```
{
  "inspect": {
    "changes_present": true,
    "plan": "<Terraform plan output>"
  }
}
```

Payload when no run option or `?run=now`
```
{}
```

Prior to the change, payload when payload when no run option or `?run=now`:
```
{
   "changes_present": false,
   "plan": ""
}
```