### PR TITLE
fix docker permissions with a 'home' directory

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,9 +63,11 @@ RUN set -eux && \
     rm -rf /root/.gnupg
 
 ### Added for CTS
-RUN mkdir -p /consul-terraform-sync/config
+RUN mkdir -p /consul-terraform-sync/config \
+        && chown -R ${NAME}:${NAME} /consul-terraform-sync
 VOLUME /consul-terraform-sync/config
 COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+WORKDIR /consul-terraform-sync
 ENTRYPOINT ["/bin/docker-entrypoint.sh"]
 ###
 


### PR DESCRIPTION
Changed /consul-terraform-syn directory to be owned by the added user of
the same name and made it the working directory. This allows writing to
the current/working directory which is needed for the sync-tasks
directory to be created and for terraform to be downloaded locally (both
the defaults).

Note that setting the terraform config variables 'path' or 'working_dir'
to something other than "" will not work.