### PR TITLE
Refactor testutils functions

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
 )
 
 func TestServe(t *testing.T) {
@@ -78,12 +78,8 @@ func TestServe(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			u := fmt.Sprintf("http://localhost:%d/%s/%s",
 				port, defaultAPIVersion, tc.path)
-			r := strings.NewReader(tc.body)
-			req, err := http.NewRequest(tc.method, u, r)
-			require.NoError(t, err)
 
-			resp, err := http.DefaultClient.Do(req)
-
+			resp := testutils.RequestHTTP(t, tc.method, u, tc.body)
 			statusCode := 0
 
 			if err == nil {
@@ -95,8 +91,7 @@ func TestServe(t *testing.T) {
 				require.Contains(t, err.Error(), "connect: connection refused")
 				time.Sleep(3 * time.Second)
 
-				resp2, err2 := http.Get(u)
-				require.NoError(t, err2)
+				resp2 := testutils.RequestHTTP(t, http.MethodGet, u, "")
 				defer resp2.Body.Close()
 				statusCode = resp2.StatusCode
 			}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -286,8 +286,7 @@ func Test_Task_Update(t *testing.T) {
 	t.Run("disable-then-enable", func(t *testing.T) {
 		// setup temp dir
 		tempDir := "disable-enable"
-		delete, err := testutils.MakeTempDir(tempDir)
-		require.NoError(t, err)
+		delete := testutils.MakeTempDir(t, tempDir)
 		defer delete()
 
 		// add a driver

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -257,8 +257,7 @@ func TestUpdateTask(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range mockCases {
 		t.Run(tc.name, func(t *testing.T) {
-			delete, err := testutils.MakeTempDir(tc.dirName)
-			require.NoError(t, err)
+			delete := testutils.MakeTempDir(t, tc.dirName)
 			defer delete()
 
 			r := new(mocksTmpl.Resolver)
@@ -292,7 +291,7 @@ func TestUpdateTask(t *testing.T) {
 				tf.fileReader = func(string) ([]byte, error) { return []byte{}, nil }
 			}
 
-			_, err = tf.UpdateTask(ctx, tc.patch)
+			_, err := tf.UpdateTask(ctx, tc.patch)
 			require.NoError(t, err)
 
 			// check that mocks were called as expected
@@ -365,8 +364,7 @@ func TestUpdateTask(t *testing.T) {
 	}
 	for _, tc := range errorCases {
 		t.Run(tc.name, func(t *testing.T) {
-			delete, err := testutils.MakeTempDir(tc.dirName)
-			require.NoError(t, err)
+			delete := testutils.MakeTempDir(t, tc.dirName)
 			defer delete()
 
 			r := new(mocksTmpl.Resolver)
@@ -392,7 +390,7 @@ func TestUpdateTask(t *testing.T) {
 				},
 			}
 
-			_, err = tf.UpdateTask(ctx, tc.patch)
+			_, err := tf.UpdateTask(ctx, tc.patch)
 			require.Error(t, err)
 		})
 	}

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -32,9 +32,8 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "status_endpoints")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 
@@ -257,9 +256,8 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "disabled_task")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	port, err := api.FreePort()
 	require.NoError(t, err)

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -3,11 +3,9 @@
 package e2e
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -54,7 +52,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 		Address: "5.6.7.8",
 		Port:    8080,
 	}
-	registerService(t, srv, service, testutil.HealthPassing)
+	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
 
 	// wait and then retrieve status
 	time.Sleep(7 * time.Second)
@@ -325,7 +323,7 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 		Address: "5.6.7.8",
 		Port:    8080,
 	}
-	registerService(t, srv, service, testutil.HealthPassing)
+	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
 	time.Sleep(3 * time.Second)
 
 	// Confirm that resources are not recreated for disabled task
@@ -365,25 +363,6 @@ func stopCommand(cmd *exec.Cmd) error {
 		return err
 	}
 	return nil
-}
-
-// registerService is a helper function to regsiter a service to the Consul
-// Catalog. The Consul sdk/testutil package currently does not support a method
-// to register multiple service instances, distinguished by their IDs.
-func registerService(t *testing.T, srv *testutil.TestServer, s testutil.TestService, health string) {
-	var body bytes.Buffer
-	enc := json.NewEncoder(&body)
-	require.NoError(t, enc.Encode(&s))
-
-	u := fmt.Sprintf("http://%s/v1/agent/service/register", srv.HTTPAddr)
-	req, err := http.NewRequest("PUT", u, io.Reader(&body))
-	require.NoError(t, err)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	srv.AddCheck(t, s.ID, s.ID, testutil.HealthPassing)
 }
 
 // checkEvents does some basic checks to loosely ensure returned events in

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -25,9 +25,8 @@ func TestE2E_MetaCOmmandErrors(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "meta_errs")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 
@@ -94,9 +93,8 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "enable_cmd")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 
@@ -159,9 +157,8 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "disable_cmd")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -68,12 +68,10 @@ func TestE2EBasic(t *testing.T) {
 	require.Equal(t, "10.10.10.10", string(contents))
 
 	// check statefiles exist
-	status, err := checkStateFile(srv.HTTPAddr, dbTaskName)
-	require.NoError(t, err)
+	status := checkStateFile(t, srv.HTTPAddr, dbTaskName)
 	require.Equal(t, http.StatusOK, status)
 
-	status, err = checkStateFile(srv.HTTPAddr, webTaskName)
-	require.NoError(t, err)
+	status = checkStateFile(t, srv.HTTPAddr, webTaskName)
 	require.Equal(t, http.StatusOK, status)
 
 	delete()
@@ -264,15 +262,11 @@ func runSyncOnce(configPath string) error {
 	return cmd.Run()
 }
 
-func checkStateFile(consulAddr, taskname string) (int, error) {
+func checkStateFile(t *testing.T, consulAddr, taskname string) int {
 	u := fmt.Sprintf("http://%s/v1/kv/%s-env:%s", consulAddr, config.DefaultTFBackendKVPath, taskname)
-
-	resp, err := http.Get(u)
-	if err != nil {
-		return 0, err
-	}
+	resp := testutils.RequestHTTP(t, http.MethodGet, u, "")
 	defer resp.Body.Close()
-	return resp.StatusCode, nil
+	return resp.StatusCode
 }
 
 // checkStateFileLocally returns whether or not a statefile exists

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -41,9 +41,8 @@ func TestE2EBasic(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "basic")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 	err = makeConfig(configPath, twoTaskConfig(srv.HTTPAddr, tempDir))
@@ -88,9 +87,8 @@ func TestE2ERestartSync(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "restart")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 	err = makeConfig(configPath, oneTaskConfig(srv.HTTPAddr, tempDir, 0))
@@ -114,9 +112,8 @@ func TestE2EPanosHandlerError(t *testing.T) {
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "panos_handler")
-	delete, err := testutils.MakeTempDir(tempDir)
+	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
-	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
 	err = makeConfig(configPath, panosConfig(srv.HTTPAddr, tempDir))
@@ -192,9 +189,8 @@ func TestE2ELocalBackend(t *testing.T) {
 			defer srv.Stop()
 
 			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tc.tempDirPrefix)
-			delete, err := testutils.MakeTempDir(tempDir)
+			delete := testutils.MakeTempDir(t, tempDir)
 			// no defer to delete directory: only delete at end of test if no errors
-			require.NoError(t, err)
 
 			configPath := filepath.Join(tempDir, configFile)
 			err = makeConfig(configPath,

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -3,14 +3,9 @@
 package tftmpl
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -183,7 +178,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 					Address: "5.6.7.8",
 					Port:    8080,
 				}
-				registerService(t, srv, service, testutil.HealthPassing)
+				testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
 			}
 
 			// Setup another server with an identical API service
@@ -261,23 +256,4 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 			}
 		})
 	}
-}
-
-// registerService is a helper function to regsiter a service to the Consul
-// Catalog. The Consul sdk/testutil package currently does not support a method
-// to register multiple service instances, distinguished by their IDs.
-func registerService(t *testing.T, srv *testutil.TestServer, s testutil.TestService, health string) {
-	var body bytes.Buffer
-	enc := json.NewEncoder(&body)
-	require.NoError(t, enc.Encode(&s))
-
-	u := fmt.Sprintf("http://%s/v1/agent/service/register", srv.HTTPAddr)
-	req, err := http.NewRequest("PUT", u, io.Reader(&body))
-	require.NoError(t, err)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	srv.AddCheck(t, s.ID, s.ID, testutil.HealthPassing)
 }

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -71,20 +71,29 @@ func RequestHTTP(t *testing.T, method, url, body string) *http.Response {
 // one of these as an argument.
 var _ testutil.TestingTB = (*TestingTB)(nil)
 
+// TestingTB implements Consul's testutil.TestingTB
 type TestingTB struct {
 	cleanup func()
 	sync.Mutex
 }
 
+// DoCleanup implements Consul's testutil.TestingTB's DoCleanup()
 func (t *TestingTB) DoCleanup() {
 	t.Lock()
 	defer t.Unlock()
 	t.cleanup()
 }
 
-func (*TestingTB) Failed() bool                { return false }
+// Failed implements Consul's testutil.TestingTB's Failed()
+func (*TestingTB) Failed() bool { return false }
+
+// Logf implements Consul's testutil.TestingTB's Logf()
 func (*TestingTB) Logf(string, ...interface{}) {}
-func (*TestingTB) Name() string                { return "TestingTB" }
+
+// Name implements Consul's testutil.TestingTB's Name()
+func (*TestingTB) Name() string { return "TestingTB" }
+
+// Cleanup implements Consul's testutil.TestingTB's Cleanup()
 func (t *TestingTB) Cleanup(f func()) {
 	t.Lock()
 	defer t.Unlock()

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -7,28 +7,29 @@ import (
 	"log"
 	"os"
 	"sync"
+	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 // MakeTempDir creates a directory in the current path for a test. Caller is
 // responsible for managing the uniqueness of the directory name. Returns a
 // function for the caller to delete the temporary directory.
-func MakeTempDir(tempDir string) (func() error, error) {
+func MakeTempDir(t *testing.T, tempDir string) func() error {
 	_, err := os.Stat(tempDir)
 	if !os.IsNotExist(err) {
 		log.Printf("[WARN] temp dir %s was not cleared out after last test. "+
 			"Deleting.", tempDir)
-		if err = os.RemoveAll(tempDir); err != nil {
-			return nil, err
-		}
+		err = os.RemoveAll(tempDir)
+		require.NoError(t, err)
 	}
 	os.Mkdir(tempDir, os.ModePerm)
 
 	return func() error {
 		return os.RemoveAll(tempDir)
 
-	}, nil
+	}
 }
 
 // Meets consul/sdk/testutil/TestingTB interface

--- a/testutils/utils_test.go
+++ b/testutils/utils_test.go
@@ -10,10 +10,9 @@ import (
 func TestMakeTempDir(t *testing.T) {
 	t.Run("happy-path", func(t *testing.T) {
 		tempDir := "test-temp"
-		delete, err := MakeTempDir(tempDir)
-		require.NoError(t, err)
+		delete := MakeTempDir(t, tempDir)
 
-		_, err = ioutil.ReadDir(tempDir)
+		_, err := ioutil.ReadDir(tempDir)
 		require.NoError(t, err)
 
 		delete()


### PR DESCRIPTION
Commits:
 - Update MakeTempDir() to have testing.T parameter and check for errors within
 function rather than have the caller check errors
 - Move registerService() to testutils.RegisterConsulService()
 - Move apiRequest() to testutils.RequestHTTP(). Update other http requests in
 tests to use testutils function
 - Add some comments to some public structs/methods