### PR TITLE
Refactor map of drivers to a Drivers object

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -56,14 +56,14 @@ const (
 // API supports api requests to the cts binary
 type API struct {
 	store   *event.Store
-	drivers map[string]driver.Driver
+	drivers *driver.Drivers
 	port    int
 	version string
 	srv     *http.Server
 }
 
 // NewAPI create a new API object
-func NewAPI(store *event.Store, drivers map[string]driver.Driver, port int) *API {
+func NewAPI(store *event.Store, drivers *driver.Drivers, port int) *API {
 	mux := http.NewServeMux()
 
 	// retrieve overall status

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -64,12 +64,12 @@ func TestServe(t *testing.T) {
 	port, err := FreePort()
 	require.NoError(t, err)
 
-	drivers := make(map[string]driver.Driver)
+	drivers := driver.NewDrivers()
 	d := new(mocks.Driver)
 	d.On("UpdateTask", mock.Anything, mock.Anything).
 		Return(driver.InspectPlan{}, nil).Once()
 	d.On("Task").Return(driver.Task{Enabled: true})
-	drivers["task_b"] = d
+	drivers.Add("task_b", d)
 
 	api := NewAPI(event.NewStore(), drivers, port)
 	go api.Serve(ctx)
@@ -106,7 +106,7 @@ func TestServe_context_cancel(t *testing.T) {
 
 	port, err := FreePort()
 	require.NoError(t, err)
-	api := NewAPI(event.NewStore(), map[string]driver.Driver{}, port)
+	api := NewAPI(event.NewStore(), driver.NewDrivers(), port)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -113,10 +113,10 @@ func TestStatus(t *testing.T) {
 	addEvents(store, eventsC)
 
 	// setup drivers
-	drivers := make(map[string]driver.Driver)
-	drivers["task_a"] = createDriver("task_a", true)
-	drivers["task_b"] = createDriver("task_b", true)
-	drivers["task_c"] = createDriver("task_c", true)
+	drivers := driver.NewDrivers()
+	drivers.Add("task_a", createDriver("task_a", true))
+	drivers.Add("task_b", createDriver("task_b", true))
+	drivers.Add("task_c", createDriver("task_c", true))
 
 	// start up server
 	port, err := FreePort()
@@ -276,7 +276,7 @@ func Test_Task_Update(t *testing.T) {
 	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	drivers := make(map[string]driver.Driver)
+	drivers := driver.NewDrivers()
 	api := NewAPI(event.NewStore(), drivers, port)
 	go api.Serve(ctx)
 	time.Sleep(3 * time.Second) // in case tests run before server is ready
@@ -296,7 +296,7 @@ func Test_Task_Update(t *testing.T) {
 			ClientType: "test",
 		})
 		require.NoError(t, err)
-		drivers["task_a"] = d
+		drivers.Add("task_a", d)
 
 		assert.True(t, d.Task().Enabled)
 		plan, err := c.Task().Update("task_a", UpdateTaskConfig{
@@ -322,9 +322,9 @@ func Test_Task_Update(t *testing.T) {
 		d := new(mocksD.Driver)
 		d.On("UpdateTask", mock.Anything, mock.Anything).
 			Return(expectedPlan, nil).Once()
-		drivers["task_a"] = d
+		drivers.Add("task_b", d)
 
-		actual, err := c.Task().Update("task_a", UpdateTaskConfig{
+		actual, err := c.Task().Update("task_b", UpdateTaskConfig{
 			Enabled: config.Bool(false),
 		}, &QueryParam{Run: driver.RunOptionInspect})
 

--- a/api/overall_status.go
+++ b/api/overall_status.go
@@ -38,12 +38,12 @@ type EnabledSummary struct {
 // overallStatusHandler handles the overall status endpoint
 type overallStatusHandler struct {
 	store   *event.Store
-	drivers map[string]driver.Driver
+	drivers *driver.Drivers
 	version string
 }
 
 // newOverallStatusHandler returns a new overall status handler
-func newOverallStatusHandler(store *event.Store, drivers map[string]driver.Driver, version string) *overallStatusHandler {
+func newOverallStatusHandler(store *event.Store, drivers *driver.Drivers, version string) *overallStatusHandler {
 	return &overallStatusHandler{
 		store:   store,
 		drivers: drivers,
@@ -74,7 +74,7 @@ func (h *overallStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	for taskName, d := range h.drivers {
+	for taskName, d := range h.drivers.Map() {
 		// look for any tasks that have a driver but no events
 		if _, ok := data[taskName]; !ok {
 			taskSummary.Status.Unknown++

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -73,12 +73,12 @@ func TestOverallStatus_ServeHTTP(t *testing.T) {
 	addEvents(store, eventsD)
 
 	// set up driver
-	drivers := make(map[string]driver.Driver)
-	drivers["success_a"] = createDriver("success_a", true)
-	drivers["success_b"] = createDriver("success_b", true)
-	drivers["errored_c"] = createDriver("errored_c", true)
-	drivers["critical_d"] = createDriver("critical_d", true)
-	drivers["disabled_e"] = createDriver("disabled_e", false)
+	drivers := driver.NewDrivers()
+	drivers.Add("success_a", createDriver("success_a", true))
+	drivers.Add("success_b", createDriver("success_b", true))
+	drivers.Add("errored_c", createDriver("errored_c", true))
+	drivers.Add("critical_d", createDriver("critical_d", true))
+	drivers.Add("disabled_e", createDriver("disabled_e", false))
 
 	handler := newOverallStatusHandler(store, drivers, "v1")
 

--- a/api/task.go
+++ b/api/task.go
@@ -21,12 +21,12 @@ const taskPath = "tasks"
 // taskHandler handles the tasks endpoint
 type taskHandler struct {
 	store   *event.Store
-	drivers map[string]driver.Driver
+	drivers *driver.Drivers
 	version string
 }
 
 // newTaskHandler returns a new taskHandler
-func newTaskHandler(store *event.Store, drivers map[string]driver.Driver,
+func newTaskHandler(store *event.Store, drivers *driver.Drivers,
 	version string) *taskHandler {
 
 	return &taskHandler{
@@ -79,7 +79,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, ok := h.drivers[taskName]
+	d, ok := h.drivers.Get(taskName)
 	if !ok {
 		err := fmt.Errorf("A task with the name '%s' does not exist or has not "+
 			"been initialized yet", taskName)

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -53,10 +53,10 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 	eventsC := createTaskEvents("task_c", []bool{false, true, true})
 	addEvents(store, eventsC)
 
-	drivers := make(map[string]driver.Driver)
-	drivers["task_a"] = createDriver("task_a", true)
-	drivers["task_b"] = createDriver("task_b", true)
-	drivers["task_c"] = createDriver("task_c", true)
+	drivers := driver.NewDrivers()
+	drivers.Add("task_a", createDriver("task_a", true))
+	drivers.Add("task_b", createDriver("task_b", true))
+	drivers.Add("task_c", createDriver("task_c", true))
 
 	disabledD := new(mocks.Driver)
 	disabledD.On("Task").Return(driver.Task{
@@ -70,7 +70,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			driver.Service{Name: "web"},
 		},
 	})
-	drivers["task_d"] = disabledD
+	drivers.Add("task_d", disabledD)
 
 	handler := newTaskStatusHandler(store, drivers, "v1")
 

--- a/api/task_test.go
+++ b/api/task_test.go
@@ -30,7 +30,7 @@ func TestTask_New(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := newTaskHandler(event.NewStore(), map[string]driver.Driver{}, tc.version)
+			h := newTaskHandler(event.NewStore(), driver.NewDrivers(), tc.version)
 			assert.Equal(t, tc.version, h.version)
 		})
 	}
@@ -61,11 +61,11 @@ func TestTask_ServeHTTP(t *testing.T) {
 		},
 	}
 
-	drivers := make(map[string]driver.Driver)
+	drivers := driver.NewDrivers()
 	patchUpdateD := new(mocks.Driver)
 	patchUpdateD.On("UpdateTask", mock.Anything, mock.Anything).
 		Return(driver.InspectPlan{}, nil).Once()
-	drivers["task_patch_update"] = patchUpdateD
+	drivers.Add("task_patch_update", patchUpdateD)
 
 	handler := newTaskHandler(event.NewStore(), drivers, "v1")
 
@@ -164,11 +164,11 @@ func TestTask_updateTask(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			drivers := make(map[string]driver.Driver)
+			drivers := driver.NewDrivers()
 			d := new(mocks.Driver)
 			d.On("UpdateTask", mock.Anything, mock.Anything).
 				Return(tc.updateTaskRet, tc.updateTaskErr).Once()
-			drivers["task_a"] = d
+			drivers.Add("task_a", d)
 
 			handler := newTaskHandler(event.NewStore(), drivers, "v1")
 

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -33,10 +33,10 @@ func NewReadOnly(conf *config.Config) (Controller, error) {
 }
 
 // Init initializes the controller before it can be run
-func (ctrl *ReadOnly) Init(ctx context.Context) (map[string]driver.Driver, error) {
+func (ctrl *ReadOnly) Init(ctx context.Context) (*driver.Drivers, error) {
 	drivers, err := ctrl.init(ctx)
 	if err != nil {
-		return map[string]driver.Driver{}, err
+		return nil, err
 	}
 
 	// Sort units for consistent ordering when inspecting tasks

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -43,7 +43,7 @@ func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 
 // Init initializes the controller before it can be run. Ensures that
 // driver is initializes, works are created for each task.
-func (rw *ReadWrite) Init(ctx context.Context) (map[string]driver.Driver, error) {
+func (rw *ReadWrite) Init(ctx context.Context) (*driver.Drivers, error) {
 	return rw.init(ctx)
 }
 

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -61,7 +61,7 @@ func (d *Drivers) Map() map[string]Driver {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	copy := make(map[string]Driver)
+	copy := make(map[string]Driver, len(d.drivers))
 	for k, v := range d.drivers {
 		copy[k] = v
 	}

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -1,0 +1,69 @@
+package driver
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Drivers wraps the map of task-name to associated driver so that the map
+// can be accessed concurrently
+type Drivers struct {
+	mu *sync.RWMutex
+
+	drivers map[string]Driver
+}
+
+// NewDrivers returns a new drivers object
+func NewDrivers() *Drivers {
+	return &Drivers{
+		mu:      &sync.RWMutex{},
+		drivers: make(map[string]Driver),
+	}
+}
+
+// Add adds a new driver
+func (d *Drivers) Add(taskName string, driver Driver) error {
+	if taskName == "" {
+		return errors.New("error adding driver: task name cannot be empty")
+	}
+	if driver == nil {
+		return fmt.Errorf("error adding driver: '%s' driver cannot be nil", taskName)
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.drivers[taskName]; ok {
+		return fmt.Errorf("error adding driver: a driver already exists for '%s'",
+			taskName)
+	}
+
+	d.drivers[taskName] = driver
+	return nil
+}
+
+// Get retrieves the driver for a task
+func (d *Drivers) Get(taskName string) (Driver, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	driver, ok := d.drivers[taskName]
+	if !ok {
+		return nil, false
+	}
+
+	return driver, true
+}
+
+// Map returns a copy of the map containing the drivers
+func (d *Drivers) Map() map[string]Driver {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	copy := make(map[string]Driver)
+	for k, v := range d.drivers {
+		copy[k] = v
+	}
+	return copy
+}

--- a/driver/drivers_test.go
+++ b/driver/drivers_test.go
@@ -1,0 +1,115 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrivers_Add(t *testing.T) {
+	cases := []struct {
+		name      string
+		taskName  string
+		driver    Driver
+		expectErr bool
+	}{
+		{
+			"happy path",
+			"happy_task",
+			&Terraform{},
+			false,
+		},
+		{
+			"error: empty task name",
+			"",
+			&Terraform{},
+			true,
+		},
+		{
+			"error: nil driver",
+			"nil_driver",
+			nil,
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			drivers := NewDrivers()
+			err := drivers.Add(tc.taskName, tc.driver)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				actual, ok := drivers.drivers[tc.taskName]
+				require.True(t, ok)
+				assert.Equal(t, tc.driver, actual)
+			}
+		})
+	}
+
+	t.Run("driver already exists", func(t *testing.T) {
+		taskName := "already_exists"
+		drivers := NewDrivers()
+		err := drivers.Add(taskName, &Terraform{})
+		require.NoError(t, err)
+
+		err = drivers.Add(taskName, &Terraform{})
+		require.Error(t, err)
+	})
+}
+
+func TestDrivers_Get(t *testing.T) {
+	cases := []struct {
+		name     string
+		taskName string
+		ok       bool
+	}{
+		{
+			"driver exists",
+			"task_a",
+			true,
+		},
+		{
+			"driver doesn't exist",
+			"non_existent_task",
+			false,
+		},
+	}
+
+	drivers := NewDrivers()
+	drivers.Add("task_a", &Terraform{})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := drivers.Get(tc.taskName)
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				assert.NotNil(t, d)
+			} else {
+				assert.Nil(t, d)
+			}
+		})
+	}
+}
+
+func TestDrivers_Map(t *testing.T) {
+	t.Run("drivers map", func(t *testing.T) {
+		drivers := NewDrivers()
+		drivers.Add("task_a", &Terraform{})
+		drivers.Add("task_b", &Terraform{})
+
+		m := drivers.Map()
+
+		// check that expected tasks are in returned map
+		_, ok := m["task_a"]
+		require.True(t, ok)
+		_, ok = m["task_b"]
+		require.True(t, ok)
+
+		// check that adding a driver does not modify returned map
+		drivers.Add("task_c", &Terraform{})
+		_, ok = m["task_c"]
+		require.False(t, ok)
+	})
+}


### PR DESCRIPTION
A map of drivers is shared across the API handlers and read-write controller
to manage task lifecycle. This map of drivers is currently used with read-access
only. However, we will want to support write-access in order to support a
create task cli and delete task cli.

Drivers structure will wrap the map of drivers in order to manage concurrent
read/write access to the map.

Changes:
 - Add driver.Drivers{} to replace map[string]driver.Driver
 - New methods to support currently required functionality NewDrivers(),
 drivers.Add(), drivers.Get(), drivers.Map()