### PR TITLE
Fix bug in Task Status API response when requesting task with no events

### DIFF
--- a/api/task_status.go
+++ b/api/task_status.go
@@ -70,7 +70,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for taskName, events := range data {
 		d, ok := h.drivers.Get(taskName)
 		if !ok {
-			err := fmt.Errorf("task '%s' does not exist", taskName)
+			err := fmt.Errorf("task '%s' does not have a driver", taskName)
 			log.Printf("[TRACE] (api.updatetask) %s", err)
 			jsonErrorResponse(w, http.StatusNotFound, err)
 			return
@@ -92,6 +92,10 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if _, ok := data[taskName]; !ok {
 			if d, ok := h.drivers.Get(taskName); ok {
 				statuses[taskName] = makeTaskStatusUnknown(d.Task())
+			} else {
+				err := fmt.Errorf("task '%s' does not exist", taskName)
+				log.Printf("[TRACE] (api.updatetask) %s", err)
+				jsonErrorResponse(w, http.StatusNotFound, err)
 			}
 		}
 	}

--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -224,6 +224,21 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 			},
 		},
 		{
+			"single task that has no event data",
+			"/v1/status/tasks/task_d",
+			http.StatusOK,
+			map[string]TaskStatus{
+				"task_d": TaskStatus{
+					TaskName:  "task_d",
+					Status:    StatusUnknown,
+					Enabled:   false,
+					Providers: []string{"null"},
+					Services:  []string{"web"},
+					EventsURL: "",
+				},
+			},
+		},
+		{
 			"non-existent task",
 			"/v1/status/tasks/task_nonexistent",
 			http.StatusNotFound,

--- a/event/store.go
+++ b/event/store.go
@@ -51,7 +51,9 @@ func (s *Store) Read(taskName string) map[string][]Event {
 
 	data := make(map[string][]*Event)
 	if taskName != "" {
-		data[taskName] = s.events[taskName]
+		if e, ok := s.events[taskName]; ok {
+			data[taskName] = e
+		}
 	} else {
 		data = s.events
 	}

--- a/event/store_test.go
+++ b/event/store_test.go
@@ -114,7 +114,6 @@ func TestStore_Read(t *testing.T) {
 				Event{TaskName: "5"},
 			},
 			map[string][]Event{
-
 				"4": []Event{
 					Event{TaskName: "4"},
 					Event{TaskName: "4"},
@@ -127,9 +126,7 @@ func TestStore_Read(t *testing.T) {
 			"read task - no event",
 			"4",
 			[]Event{},
-			map[string][]Event{
-				"4": []Event{},
-			},
+			map[string][]Event{},
 		},
 	}
 


### PR DESCRIPTION
Previously when requesting task status for a task with a driver and no events (e.g. a task configured as disabled), the API would return:

```
TaskStatus{
	TaskName:  "task_d",
	Status:    StatusUnknown,
	Enabled:   false,
	Providers: []string{}, // this data is missing
	Services:  []string{}, // this data is missing
	EventsURL: "",
},
```

It should return:
```
TaskStatus{
	TaskName:  "task_d",
	Status:    StatusUnknown,
	Enabled:   false,
	Providers: []string{"null"},
	Services:  []string{"local"},
	EventsURL: "",
},
```
See test for more details.

Commits:
 - Fix how store.Read() returns events for tasks without events. This was causing tasks without events to be handled similarly as tasks with events. Therefore code handling tasks without events was unreachable
 - After fixing store.Read, update code handling tasks without events (now that it is reachable) to handle when a task has no events and no driver