### PR TITLE
Fix "missing config flag option" when running docker container in daemon-mode

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -16,7 +16,7 @@ fi
 
 # If user is trying to run consul-terraform-sync with no arguments (daemon-mode),
 # then $1 will default to '/bin/sh'. In this case, do not pass along default arguments.
-if [ "$1" = '/bin/sh' ]
+if [ "$*" = '/bin/sh -c /bin/${NAME}' ]
 then
     set -- /bin/consul-terraform-sync
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -14,6 +14,13 @@ then
     set -- /bin/consul-terraform-sync "$@"
 fi
 
+# If user is trying to run consul-terraform-sync with no arguments (daemon-mode),
+# then $1 will default to '/bin/sh'. In this case, do not pass along default arguments.
+if [ "$1" = '/bin/sh' ]
+then
+    set -- /bin/consul-terraform-sync
+fi
+
 # Matches VOLUME in the Dockerfile, for importing config files into image
 CTS_CONFIG_DIR=/consul-terraform-sync/config
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -15,7 +15,8 @@ then
 fi
 
 # If user is trying to run consul-terraform-sync with no arguments (daemon-mode),
-# then $1 will default to '/bin/sh'. In this case, do not pass along default arguments.
+# docker will run '/bin/sh -c /bin/${NAME}'. Check for the full command since
+# running 'bin/sh' is a common pattern
 if [ "$*" = '/bin/sh -c /bin/${NAME}' ]
 then
     set -- /bin/consul-terraform-sync


### PR DESCRIPTION
Currently when running CTS docker container in once-mode or inspect-mode,
everything runs great. When running the container in daemon-mode (without any
flags), the configuration files are not passed in. In other modes (with flags), the
configuration file is successfully passed in.

The following error is seen when running`$ docker run -ti -v /my/path/to/config/file:/consul-terraform-sync/config hashicorp/consul-terraform-sync:0.1.0-beta`
> [ERR] config file(s) required, use --config-dir or --config-file flag options...

Change: update docker entrypoint to also pass config-directory when no CTS flags
are passed. With this change, I was able to build the docker image locally and test
daemon-mode, version, once-mode successfully