### PR TITLE
update e2e tests to utilize http2 enhancement

### DIFF
--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -20,21 +20,20 @@ func TestE2E_MetaCOmmandErrors(t *testing.T) {
 	// test cases that cross subcommands that coded in the command meta object
 	t.Parallel()
 
-	srv, err := newTestConsulServer(t)
-	require.NoError(t, err, "failed to start consul server")
+	srv := newTestConsulServer(t)
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "meta_errs")
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	configPath := filepath.Join(tempDir, configFile)
-
 	port, err := api.FreePort()
 	require.NoError(t, err)
 
-	err = makeConfig(configPath, fakeHandlerConfig(srv.HTTPAddr, tempDir, port))
-	require.NoError(t, err)
+	configPath := filepath.Join(tempDir, configFile)
+	config := fakeHandlerConfig().appendPort(port).
+		appendConsulBlock(srv).appendTerraformBlock(tempDir)
+	config.write(t, configPath)
 
 	cmd, err := runSyncDevMode(configPath)
 	defer stopCommand(cmd)
@@ -88,21 +87,20 @@ func TestE2E_MetaCOmmandErrors(t *testing.T) {
 func TestE2E_EnableTaskCommand(t *testing.T) {
 	t.Parallel()
 
-	srv, err := newTestConsulServer(t)
-	require.NoError(t, err, "failed to start consul server")
+	srv := newTestConsulServer(t)
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "enable_cmd")
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	configPath := filepath.Join(tempDir, configFile)
-
 	port, err := api.FreePort()
 	require.NoError(t, err)
 
-	err = makeConfig(configPath, disabledTaskConfig(srv.HTTPAddr, tempDir, port))
-	require.NoError(t, err)
+	configPath := filepath.Join(tempDir, configFile)
+	config := disabledTaskConfig().appendPort(port).
+		appendConsulBlock(srv).appendTerraformBlock(tempDir)
+	config.write(t, configPath)
 
 	cmd, err := runSyncDevMode(configPath)
 	defer stopCommand(cmd)
@@ -152,21 +150,19 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 func TestE2E_DisableTaskCommand(t *testing.T) {
 	t.Parallel()
 
-	srv, err := newTestConsulServer(t)
-	require.NoError(t, err, "failed to start consul server")
+	srv := newTestConsulServer(t)
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "disable_cmd")
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	configPath := filepath.Join(tempDir, configFile)
-
 	port, err := api.FreePort()
 	require.NoError(t, err)
 
-	err = makeConfig(configPath, oneTaskConfig(srv.HTTPAddr, tempDir, port))
-	require.NoError(t, err)
+	configPath := filepath.Join(tempDir, configFile)
+	config := baseConfig().appendPort(port).appendConsulBlock(srv).appendDBTask()
+	config.write(t, configPath)
 
 	cmd, err := runSyncDevMode(configPath)
 	defer stopCommand(cmd)

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -7,11 +7,14 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
 )
 
-func NewTestConsulServerHTTPS(tb testing.TB, path string) *testutil.TestServer {
+func NewTestConsulServerHTTPS(tb testing.TB, relPath string) *testutil.TestServer {
 	log.SetOutput(ioutil.Discard)
 
+	path, err := filepath.Abs(relPath)
+	require.NoError(tb, err, "unable to get absolute path of test certs")
 	certFile := filepath.Join(path, "cert.pem")
 	keyFile := filepath.Join(path, "key.pem")
 
@@ -26,9 +29,7 @@ func NewTestConsulServerHTTPS(tb testing.TB, path string) *testutil.TestServer {
 			c.CertFile = certFile
 			c.KeyFile = keyFile
 		})
-	if err != nil {
-		tb.Fatalf("unable to start Consul test server: %s", err)
-	}
+	require.NoError(tb, err, "unable to start Consul server")
 
 	return srv
 }


### PR DESCRIPTION
Updates the E2E tests to connect with the Consul agent over HTTP/2 by enabling TLS (go limitation).

Since the test setups now require HTTPS endpoint and the cert path from the server to configure CTS, I refactored the config test setup to be more modular. Each test can now compose the pieces together to build the configuration for testing. This was in preference of not passing the test Consul server to all of the config helpers to access the cert path.