### PR TITLE
move cli.go into commands package

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -1,4 +1,4 @@
-package main
+package command
 
 import (
 	"context"
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
-	"github.com/hashicorp/consul-terraform-sync/command"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
 	"github.com/hashicorp/consul-terraform-sync/event"
@@ -121,7 +120,7 @@ func (cli *CLI) Run(args []string) int {
 		subcommands := &mcli.CLI{
 			Name:     "consul-terraform-sync",
 			Args:     args[1:],
-			Commands: command.Commands(),
+			Commands: Commands(),
 		}
 
 		exitCode, err := subcommands.Run()

--- a/command/commands.go
+++ b/command/commands.go
@@ -6,16 +6,6 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-// Exit codes match the main cli's exit code
-const (
-	ExitCodeOK int = 0
-
-	ExitCodeError = 10 + iota
-	ExitCodeInterrupt
-	ExitCodeRequiredFlagsError
-	ExitCodeParseFlagsError
-)
-
 // Commands returns the mapping of CLI commands for CTS. The meta
 // parameter lets you set meta options for all commands.
 func Commands() map[string]cli.CommandFactory {

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"os"
+
+	"github.com/hashicorp/consul-terraform-sync/command"
 )
 
 func main() {
-	cli := NewCLI(os.Stdout, os.Stderr)
+	cli := command.NewCLI(os.Stdout, os.Stderr)
 	os.Exit(cli.Run(os.Args))
 }


### PR DESCRIPTION
This lets us import the cli and use it to run cts similar to the e2e
tests, runs the full app, but keeping it in process. This is
particularly useful for benchmarking, so we can profile the benchmarks.