### PR TITLE
make api-tooling-core team the default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default PR reviews to the team
+* @hashicorp/api-tooling-core


### PR DESCRIPTION
Documentation on how this works.
https://help.github.com/articles/about-codeowners/