### PR TITLE
add null provider services/instances benchmarks

### DIFF
--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -1,0 +1,279 @@
+// +build e2e
+
+// Runs benchmarks using the Null provider and working with Consul setup with
+// multiple Services or Service Instances.
+
+package benchmarks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/command"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+const configFile = "config.hcl"
+const tempDirPrefix = "tmp_"
+
+// Benchmark N Services Instance (all the same service)
+func Benchmark1Instance(b *testing.B) {
+	benchmarkInstances(b, 1)
+}
+func Benchmark100Instances(b *testing.B) {
+	benchmarkInstances(b, 100)
+}
+func Benchmark1000Instances(b *testing.B) {
+	benchmarkInstances(b, 1000)
+}
+func benchmarkInstances(b *testing.B, N int) {
+	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	defer srv.Stop()
+	path, cleanup := setupServiceInstances(b, srv, N)
+	defer cleanup() // comment out if you want to keep the config files
+	//_ = cleanup
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, runSyncOnce(path))
+	}
+}
+
+// Benchmark N Services
+func Benchmark1Service(b *testing.B) {
+	benchmarkServices(b, 1)
+}
+func Benchmark100Service(b *testing.B) {
+	benchmarkServices(b, 100)
+}
+func Benchmark1000Service(b *testing.B) {
+	benchmarkServices(b, 1000)
+}
+func benchmarkServices(b *testing.B, N int) {
+	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	defer srv.Stop()
+	path, cleanup := setupMultiServices(b, srv, N)
+	defer cleanup() // comment out if you want to keep the config files
+	//_ = cleanup
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, runSyncOnce(path))
+	}
+}
+
+// ----------------------------------------------------------------------------
+
+// Run CTS in once mode from the cli level
+func runSyncOnce(configPath string) error {
+	cli := command.NewCLI(os.Stdout, os.Stderr)
+	args := []string{"cts", "-once", fmt.Sprintf("--config-file=%s", configPath)}
+	exitCode := cli.Run(args)
+	errstr := "Exit Code Error: %s (%d)\n"
+	switch exitCode {
+	case command.ExitCodeOK:
+		return nil
+	case command.ExitCodeError:
+		return fmt.Errorf(errstr, "ExitCodeError", exitCode)
+	case command.ExitCodeInterrupt:
+		return fmt.Errorf(errstr, "ExitCodeInterrupt", exitCode)
+	case command.ExitCodeRequiredFlagsError:
+		return fmt.Errorf(errstr, "ExitCodeRequiredFlagsError", exitCode)
+	case command.ExitCodeParseFlagsError:
+		return fmt.Errorf(errstr, "ExitCodeParseFlagsError", exitCode)
+	case command.ExitCodeConfigError:
+		return fmt.Errorf(errstr, "ExitCodeConfigError", exitCode)
+	case command.ExitCodeDriverError:
+		return fmt.Errorf(errstr, "ExitCodeDriverError", exitCode)
+	default:
+		return fmt.Errorf(errstr, "UNKNOWN", exitCode)
+	}
+}
+
+// Sets up consul and config to test setup with N service instances
+func setupServiceInstances(t testing.TB, srv *testutil.TestServer, N int) (string, func() error) {
+	services := make([]string, 1)
+	for _, s := range generateServices(N, true) {
+		testutils.RegisterConsulService(t, srv, s, testutil.HealthPassing)
+		services[0] = s.Name
+	}
+	return makeConfig(t, services, srv.HTTPAddr, false)
+}
+
+// add generated services as separte services
+func setupMultiServices(t testing.TB, srv *testutil.TestServer, N int) (string, func() error) {
+	services := make([]string, N)
+	for i, s := range generateServices(N, false) {
+		testutils.RegisterConsulService(t, srv, s, testutil.HealthPassing)
+		services[i] = s.Name
+	}
+	return makeConfig(t, services, srv.HTTPSAddr, true)
+}
+
+// generate service instance entries
+func generateServices(n int, instances bool) []testutil.TestService {
+	baseport := 30000
+	services := make([]testutil.TestService, n)
+	for i := 0; i < n; i++ {
+		name, id := "test_service", fmt.Sprintf("svc_%d", i)
+		if !instances {
+			name = id
+		}
+		services[i] = testutil.TestService{
+			Name:    name,
+			ID:      id,
+			Address: "127.0.0.2",
+			Port:    int(baseport + i),
+			Tags:    []string{},
+		}
+	}
+	return services
+}
+
+// writes the config files out to disk, returns path to them and cleanup func
+func makeConfig(t testing.TB, services []string, addr string, tls bool,
+) (string, func() error) {
+	tmpDir := fmt.Sprintf("%s%s", tempDirPrefix, "test_services")
+	cleanup := testutils.MakeTempDir(t, tmpDir)
+	modDir := filepath.Join(tmpDir, "module")
+	testutils.MakeTempDir(t, modDir)
+
+	configPath := filepath.Join(tmpDir, configFile)
+	err := writeConfig(configPath, configContents(addr, tmpDir, tls, services))
+	require.NoError(t, err)
+	modulePath := filepath.Join(modDir, "main.tf")
+	err = writeConfig(modulePath, nullModuleContents())
+	require.NoError(t, err)
+
+	return configPath, cleanup
+}
+
+// write the (config) contents to the path
+func writeConfig(configPath, contents string) error {
+	f, err := os.Create(configPath)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	config := []byte(contents)
+	_, err = f.Write(config)
+	return err
+}
+
+// returns templated contents of config file
+func configContents(address, dir string, tls bool, services []string) string {
+	sservices := `["` + strings.Join(services, `","`) + `"]`
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf(`
+log_level = "WARN"
+
+consul {
+  address = "%s"
+  tls {
+	  enabled = %t
+	  verify = false
+  }
+}
+
+driver "terraform" {
+	path = "%s"
+	backend "local" {}
+}
+
+terraform_provider "local" {}
+
+task {
+  name = "test-services-task"
+  source = "../../%s/module"
+  providers = ["local"]
+  services = %s
+}
+
+`, address, tls, pwd, dir, sservices)
+}
+
+// null resource, services module
+func nullModuleContents() string {
+	return `
+resource "null_resource" "address" {}
+
+variable "services" {
+  description = "Consul services monitored by Consul Terraform Sync"
+  type = map(
+    object({
+      id        = string
+      name      = string
+      kind      = string
+      address   = string
+      port      = number
+      meta      = map(string)
+      tags      = list(string)
+      namespace = string
+      status    = string
+
+      node                  = string
+      node_id               = string
+      node_address          = string
+      node_datacenter       = string
+      node_tagged_addresses = map(string)
+      node_meta             = map(string)
+
+      cts_user_defined_meta = map(string)
+    })
+  )
+}
+`
+}
+
+// ---------------------------------------------------------------------------
+// The below functions are not used but handy to keep around for when you need
+// to check on what data Consul has.
+
+// All registered services
+func showMeServices(t testing.TB, srv *testutil.TestServer) {
+	u := fmt.Sprintf("http://%s/v1/agent/services", srv.HTTPAddr)
+	resp := testutils.RequestHTTP(t, http.MethodGet, u, "")
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+	defer resp.Body.Close()
+}
+
+// Health status for all services
+func showMeHealth(t testing.TB, srv *testutil.TestServer) {
+	// get the node
+	u := fmt.Sprintf("http://%s/v1/health/service/%s", srv.HTTPAddr, "svc_0")
+	resp := testutils.RequestHTTP(t, http.MethodGet, u, "")
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	resp.Body.Close()
+	nodes := []struct{ Node struct{ Node string } }{}
+	json.Unmarshal(b, &nodes)
+	node := nodes[0].Node.Node
+
+	// all services on that node
+	u = fmt.Sprintf("http://%s/v1/health/node/%s", srv.HTTPAddr, node)
+	resp = testutils.RequestHTTP(t, http.MethodGet, u, "")
+	b, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		panic(err)
+	}
+	resp.Body.Close()
+
+	fmt.Println(string(b))
+}

--- a/go.mod
+++ b/go.mod
@@ -20,14 +20,14 @@ require (
 	github.com/hashicorp/consul/sdk v0.7.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0
-	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.15.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.8 // indirect
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20210311164221-2d0b18ae5095
+	github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,6 @@ github.com/hashicorp/go-bexpr v0.1.2 h1:ijMXI4qERbzxbCnkxmfUtwMyjrrk3y+Vt0MxojNC
 github.com/hashicorp/go-bexpr v0.1.2/go.mod h1:ANbpTX1oAql27TZkKVeW8p1w8NTdnyzPe/0qqPCKohU=
 github.com/hashicorp/go-bexpr v0.1.4 h1:vyQpuKqqc+Ywb8tf6vZSlkf5qhYkgrNSWURtQggCfLE=
 github.com/hashicorp/go-bexpr v0.1.4/go.mod h1:ey7VZGNrY1PnLlYp6Nf3RLEizPo0B9W4yw2MnDkcK3M=
-github.com/hashicorp/go-bexpr v0.1.7 h1:z48qzCgJkvdnMO/LDy3XHNyCyxnHiFGx9uTKLv0jW2Y=
-github.com/hashicorp/go-bexpr v0.1.7/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-bindata v3.0.8-0.20180209072458-bf7910af8997+incompatible/go.mod h1:+IrDq36jUYG0q6TsDY9uO2p77C8f8S5y+RbYHr2UI+U=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
@@ -703,10 +701,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210218010241-b58d6b50b196 h1:mKV1rKXc3AkMUZJ4t/Iv8urG/rjOM8j14Szu8gsm+KY=
-github.com/hashicorp/hcat v0.0.0-20210218010241-b58d6b50b196/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
-github.com/hashicorp/hcat v0.0.0-20210311164221-2d0b18ae5095 h1:9U7RR1G48H/OLuHZnppwbqzxE4Vc3dDGsV69AkDEar8=
-github.com/hashicorp/hcat v0.0.0-20210311164221-2d0b18ae5095/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4 h1:c0+e33iz6wzftqP7V87A9cBeCj7RbMXq9CauD8+sCcY=
+github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -1015,8 +1011,6 @@ github.com/mitchellh/pointerstructure v1.0.0 h1:ATSdz4NWrmWPOF1CeCBU4sMCno2hgqdb
 github.com/mitchellh/pointerstructure v1.0.0/go.mod h1:k4XwG94++jLVsSiTxo7qdIfXA9pj9EAeo0QsNNJOLZ8=
 github.com/mitchellh/pointerstructure v1.1.0 h1:6RI+cKHSIOOuMhKALJyMIpGOHsmBGGwS0ZSMCPFn/jM=
 github.com/mitchellh/pointerstructure v1.1.0/go.mod h1:zoQzmW5t87ncZZuJWXEyhr0///POW/WQEeFG4RRVKEs=
-github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
-github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1 h1:FVzMWA5RllMAKIdUSC8mdWo3XtwoecrH79BY70sEEpE=


### PR DESCRIPTION
Runs benchmarks using the Null provider and working with Consul setup
with multiple Services or Service Instances.

Currently uses HTTP connections as they are faster and we aren't using a
lot of connections.