### PR TITLE
Fix exponential backoff calculation for retry methods

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"math/rand"
 	"time"
 
@@ -79,8 +80,8 @@ func (r Retry) waitTime(attempt uint) int {
 		return 1
 	}
 	a := float64(attempt)
-	baseTimeSeconds := a * a
-	nextTimeSeconds := (a + 1) * (a + 1)
+	baseTimeSeconds := math.Exp2(a)
+	nextTimeSeconds := math.Exp2(a + 1)
 	delayRange := (nextTimeSeconds - baseTimeSeconds) / 2
 	delay := r.random.Float64() * delayRange
 	total := (baseTimeSeconds + delay) * float64(time.Second)

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -146,20 +146,20 @@ func TestWaitTime(t *testing.T) {
 		{
 			"first attempt",
 			0,
-			0,
-			0.5,
+			1,
+			1.5,
 		},
 		{
 			"second attempt",
 			1,
-			1,
-			2.5,
+			2,
+			3,
 		},
 		{
 			"third attempt",
 			2,
 			4,
-			6.5,
+			6,
 		},
 	}
 


### PR DESCRIPTION
Previous "exponential" backoff algorithm was `x**2`, which is incorrect. Adjusted
to be actually exponential:`2**x`