### PR TITLE
Fix multiple tasks not triggered on same service

### DIFF
--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -1,0 +1,146 @@
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/testutils"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTasksUpdate(t *testing.T) {
+	// Tests multiple tasks are triggered on service registration and de-registration
+	// by verifying the content of terraform.tfvars
+	t.Parallel()
+
+	srv := newTestConsulServer(t)
+	defer srv.Stop()
+
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "multiple_tasks")
+	delete := testutils.MakeTempDir(t, tempDir)
+	testutils.MakeTempDir(t, tempDir)
+
+	apiTaskName := "e2e_task_api"
+	apiTask := fmt.Sprintf(`
+task {
+	name = "%s"
+	description = "basic read-write e2e task api only"
+	services = ["api"]
+	providers = ["local"]
+	source = "../../test_modules/e2e_basic_task"
+}
+`, apiTaskName)
+	configPath := filepath.Join(tempDir, configFile)
+	var config hclConfig
+	config = config.appendConsulBlock(srv).appendTerraformBlock(tempDir).
+		appendDBTask().appendWebTask().appendString(apiTask)
+	config.write(t, configPath)
+
+	cmd, err := runSync(configPath)
+	require.NoError(t, err)
+
+	// Stop CTS then stop the Consul agent
+	defer stopCommand(cmd)
+
+	t.Run("once mode", func(t *testing.T) {
+		// Wait for tasks to execute once
+		time.Sleep(15 * time.Second)
+
+		// Verify Catalog information is reflected in terraform.tfvars
+		expectedTaskServices := map[string][]string{
+			apiTaskName: []string{"api"},
+			dbTaskName:  []string{"api", "db"},
+			webTaskName: []string{"api", "web"},
+		}
+		for taskName, expected := range expectedTaskServices {
+			tfvarsFile := filepath.Join(tempDir, taskName, "terraform.tfvars")
+			serviceIDs := loadTFVarsServiceIDs(t, tfvarsFile)
+			if !assert.Equal(t, expected, serviceIDs) {
+				t.Fail()
+			}
+		}
+	})
+
+	t.Run("register services", func(t *testing.T) {
+		// Register api and web instances
+		apiInstance := testutil.TestService{
+			ID:      "api_new",
+			Name:    "api",
+			Address: "5.6.7.8",
+			Port:    8080,
+		}
+		webInstance := testutil.TestService{
+			ID:      "web_new",
+			Name:    "web",
+			Address: "5.6.7.8",
+			Port:    8080,
+		}
+		testutils.RegisterConsulService(t, srv, apiInstance, testutil.HealthPassing)
+		testutils.RegisterConsulService(t, srv, webInstance, testutil.HealthPassing)
+
+		// Wait for CTS to detect changes and run tasks
+		time.Sleep(15 * time.Second)
+
+		// Verify updated Catalog information is reflected in terraform.tfvars
+		expectedTaskServices := map[string][]string{
+			apiTaskName: []string{"api", "api_new"},
+			dbTaskName:  []string{"api", "api_new", "db"},
+			webTaskName: []string{"api", "api_new", "web", "web_new"},
+		}
+		for taskName, expected := range expectedTaskServices {
+			tfvarsFile := filepath.Join(tempDir, taskName, "terraform.tfvars")
+			serviceIDs := loadTFVarsServiceIDs(t, tfvarsFile)
+			if !assert.Equal(t, expected, serviceIDs) {
+				t.Fail()
+			}
+		}
+	})
+
+	t.Run("deregister service", func(t *testing.T) {
+		// Deregister service
+		testutils.DeregisterConsulService(t, srv, "api_new")
+		time.Sleep(15 * time.Second)
+
+		// Verify updated Catalog information is reflected in terraform.tfvars
+		expectedTaskServices := map[string][]string{
+			apiTaskName: []string{"api"},
+			dbTaskName:  []string{"api", "db"},
+			webTaskName: []string{"api", "web", "web_new"},
+		}
+		for taskName, expected := range expectedTaskServices {
+			tfvarsFile := filepath.Join(tempDir, taskName, "terraform.tfvars")
+			serviceIDs := loadTFVarsServiceIDs(t, tfvarsFile)
+			if !assert.Equal(t, expected, serviceIDs) {
+				t.Fail()
+			}
+		}
+	})
+
+	delete()
+}
+
+func loadTFVarsServiceIDs(t *testing.T, file string) []string {
+	// This is a bit hacky using regex but simpler than re-implementing syntax
+	// parsing for Terraform variables
+	content, err := ioutil.ReadFile(file)
+	require.NoError(t, err)
+
+	var ids []string
+	re := regexp.MustCompile(`\s+id\s+\= \"([^"]+)`)
+	matches := re.FindAllSubmatch(content, -1)
+	for _, match := range matches {
+		ids = append(ids, string(match[1]))
+	}
+
+	sort.Strings(ids)
+	return ids
+}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4
+	github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4 h1:c0+e33iz6wzftqP7V87A9cBeCj7RbMXq9CauD8+sCcY=
-github.com/hashicorp/hcat v0.0.0-20210326153635-0d29726683e4/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb h1:ydggGsxttv0FXQb4+OFsOZlD7ad13P4YVEi5rbbFmpo=
+github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -55,6 +55,12 @@ func RegisterConsulService(tb testing.TB, srv *testutil.TestServer,
 	sdk.AddCheck(srv, tb, s.ID, s.ID, testutil.HealthPassing)
 }
 
+func DeregisterConsulService(tb testing.TB, srv *testutil.TestServer, id string) {
+	u := fmt.Sprintf("http://%s/v1/agent/service/deregister/%s", srv.HTTPAddr, id)
+	resp := RequestHTTP(tb, http.MethodPut, u, "")
+	defer resp.Body.Close()
+}
+
 // RequestHTTP makes an http request. The caller is responsible for closing
 // the response.
 func RequestHTTP(t testing.TB, method, url, body string) *http.Response {


### PR DESCRIPTION
Resolves #234

Pulls in update from https://github.com/hashicorp/hcat/pull/40 which fixes multiple templates getting removed after second render. That had caused some tasks to go stale and not update as catalog changes were detected by CTS.

Added e2e test that verifies content of `terraform.tfvars` after Catalog changes are detected and task execution is triggered. The new test fails w/o the hashicat changes.

```
 --- FAIL: TestTasksUpdate/deregister_service (10.06s)
        tasks_test.go:120: 
            	Error Trace:	tasks_test.go:120
            	Error:      	Not equal: 
            	            	expected: []string{"api", "web", "web_new"}
            	            	actual  : []string{"api", "api_new", "web", "web_new"}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,3 +1,4 @@
            	            	-([]string) (len=3) {
            	            	+([]string) (len=4) {
            	            	  (string) (len=3) "api",
            	            	+ (string) (len=7) "api_new",
            	            	  (string) (len=3) "web",
            	Test:       	TestMultipleTasksUpdate/deregister_service
```