### PR TITLE
Default version name

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -125,7 +125,7 @@ func (cli *CLI) Run(args []string) int {
 
 		exitCode, err := subcommands.Run()
 		if err != nil {
-			log.Printf("[ERROR] running the CLI command '%s': %s",
+			fmt.Fprintf(cli.errStream, "Error running the CLI command '%s': %s",
 				strings.Join(args, " "), err)
 		}
 		return exitCode
@@ -135,14 +135,14 @@ func (cli *CLI) Run(args []string) int {
 
 	// Print out binary's help info
 	if help || h {
-		fmt.Printf("Usage of %s:\n", args[0])
+		fmt.Fprintf(cli.outStream, "Usage of %s:\n", args[0])
 		printFlags(f)
 		return ExitCodeOK
 	}
 
 	// Validate required flags
 	if len(configFiles) == 0 {
-		log.Printf("[ERR] config file(s) required, use --config-dir or --config-file flag options")
+		fmt.Fprintf(cli.errStream, "Error: config file(s) required, use --config-dir or --config-file flag options")
 		printFlags(f)
 		return ExitCodeRequiredFlagsError
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	Name string
+	Name = "consul-terraform-sync"
 
 	// GitCommit is the git commit that was compiled. These will be filled in by
 	// the compiler.


### PR DESCRIPTION
CTS versions 0.1.0-techpreview2 and 0.1.0-beta output excluded the CLI name due to the build process not setting it. We likely missed this because the local development build process using the [Makefile set the name](https://github.com/hashicorp/consul-terraform-sync/blob/master/Makefile#L26).

```
$ consul-terraform-sync -version
 0.1.0-techpreview2 (d844653)
Compatible with Terraform >= 0.13.0, < 0.15
```

should be

```
$ consul-terraform-sync -version
consul-terraform-sync 0.1.0-techpreview2 (d844653)
Compatible with Terraform >= 0.13.0, < 0.15
```

not going to back port this, fixing for 0.1.0 GA and beyond