### PR TITLE
Add retry when hcat connection with Consul has an issue

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -26,7 +26,7 @@ type ReadWrite struct {
 	store *event.Store
 	retry retry.Retry
 
-	testMode bool
+	testMode   bool
 	taskNotify chan string
 }
 
@@ -41,7 +41,7 @@ func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 		baseController: baseCtrl,
 		store:          store,
 		retry:          retry.NewRetry(defaultRetry, time.Now().UnixNano()),
-		taskNotify: make(chan string, len(*conf.Tasks)),
+		taskNotify:     make(chan string, len(*conf.Tasks)),
 	}, nil
 }
 
@@ -71,6 +71,7 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 		case err := <-rw.watcher.WaitCh(ctx):
 			if err != nil {
 				log.Printf("[ERR] (ctrl) error watching template dependencies: %s", err)
+				return err
 			}
 
 		case <-ctx.Done():

--- a/controller/watcher.go
+++ b/controller/watcher.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"log"
+	"math/rand"
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
@@ -69,8 +70,8 @@ func retryConsul(retryCount int) (bool, time.Duration) {
 		return false, 0 * time.Second
 	}
 
-	r := retry.NewRetry(0, time.Now().UnixNano()) // 0 is not used
-	wait := r.WaitTime(uint(retryCount))
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
+	wait := retry.WaitTime(uint(retryCount), random)
 	dur := time.Duration(wait)
 	log.Printf("[WARN] (hcat) error connecting with Consul. Waiting %v to retry"+
 		" attempt #%d", dur, retryCount+1)

--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -35,7 +35,9 @@ func Benchmark1000Instances(b *testing.B) {
 	benchmarkInstances(b, 1000)
 }
 func benchmarkInstances(b *testing.B, N int) {
-	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	srv := testutils.NewTestConsulServer(b, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../../testutils",
+	})
 	defer srv.Stop()
 	path, cleanup := setupServiceInstances(b, srv, N)
 	defer cleanup() // comment out if you want to keep the config files
@@ -58,7 +60,9 @@ func Benchmark1000Service(b *testing.B) {
 	benchmarkServices(b, 1000)
 }
 func benchmarkServices(b *testing.B, N int) {
-	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	srv := testutils.NewTestConsulServer(b, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../../testutils",
+	})
 	defer srv.Stop()
 	path, cleanup := setupMultiServices(b, srv, N)
 	defer cleanup() // comment out if you want to keep the config files

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -22,7 +22,9 @@ func BenchmarkTaskTrigger(b *testing.B) {
 	// Benchmarks the time for a Consul catalog change to trigger and re-render
 	// templates used for tasks. This does not benchmark task execution time.
 
-	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	srv := testutils.NewTestConsulServer(b, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../../testutils",
+	})
 	defer srv.Stop()
 
 	tempDir := b.Name()

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -37,7 +37,10 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 	// Benchmarks Run for the ReadWrite controller
 	//
 	// ReadWriteController.Run involves executing Terraform apply concurrently
-	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	srv := testutils.NewTestConsulServer(b, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../../testutils",
+	})
+
 	defer srv.Stop()
 
 	tempDir := b.Name()

--- a/e2e/benchmarks/tasks_test.go
+++ b/e2e/benchmarks/tasks_test.go
@@ -48,7 +48,9 @@ func benchmarkTasks(b *testing.B, numTasks int, numServices int) {
 	// ReadOnlyController.Run involves rendering the template file and executing
 	// Terraform init and Terraform plan serially across all tasks.
 
-	srv := testutils.NewTestConsulServerHTTPS(b, "../../testutils")
+	srv := testutils.NewTestConsulServer(b, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../../testutils",
+	})
 	defer srv.Stop()
 
 	tempDir := b.Name()

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -218,7 +218,9 @@ func TestE2ELocalBackend(t *testing.T) {
 }
 
 func newTestConsulServer(t *testing.T) *testutil.TestServer {
-	srv := testutils.NewTestConsulServerHTTPS(t, "../testutils")
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
 
 	// Register services
 	srv.AddAddressableService(t, "api", testutil.HealthPassing,

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -132,7 +130,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	// restart Consul
 	consul = testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
 		HTTPSRelPath: "../testutils",
-		PortHTTPS:    parsePort(t, consul.HTTPSAddr),
+		PortHTTPS:    consul.Config.Ports.HTTPS,
 	})
 	defer consul.Stop()
 	time.Sleep(5 * time.Second)
@@ -174,18 +172,6 @@ func TestE2EPanosHandlerError(t *testing.T) {
 	require.Error(t, err)
 
 	delete()
-}
-
-// parsePort parses the port as an integer from an address string
-// e.g. "127.0.0.1:8500"
-func parsePort(t *testing.T, addr string) int {
-	parts := strings.Split(addr, ":")
-	require.Equal(t, 2, len(parts))
-
-	port := parts[1]
-	portInt, err := strconv.Atoi(port)
-	require.NoError(t, err)
-	return portInt
 }
 
 func TestE2ELocalBackend(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -176,10 +176,12 @@ func TestE2EPanosHandlerError(t *testing.T) {
 	delete()
 }
 
-// parsePort returns port as an integer from a address like "127.0.0.1:8500"
+// parsePort parses the port as an integer from an address string
+// e.g. "127.0.0.1:8500"
 func parsePort(t *testing.T, addr string) int {
 	parts := strings.Split(addr, ":")
 	require.Equal(t, 2, len(parts))
+
 	port := parts[1]
 	portInt, err := strconv.Atoi(port)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.2.1
-	github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb
+	github.com/hashicorp/hcat v0.0.0-20210401143330-8f813cb572a8
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+l
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb h1:ydggGsxttv0FXQb4+OFsOZlD7ad13P4YVEi5rbbFmpo=
 github.com/hashicorp/hcat v0.0.0-20210326221335-6a6523ecb3bb/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210401143330-8f813cb572a8 h1:SwBA3khclXN44OIeggzo2WZnP6ggoO3LUBR+735Sk4s=
+github.com/hashicorp/hcat v0.0.0-20210401143330-8f813cb572a8/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v0.0.0-20170504190234-a4b07c25de5f/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -37,7 +37,7 @@ func (r Retry) Do(ctx context.Context, f func(context.Context) error, desc strin
 	}
 
 	var attempt uint
-	wait := r.waitTime(attempt)
+	wait := r.WaitTime(attempt)
 	interval := time.NewTicker(time.Duration(wait))
 	defer interval.Stop()
 
@@ -64,7 +64,7 @@ func (r Retry) Do(ctx context.Context, f func(context.Context) error, desc strin
 				errs = errors.Wrap(errs, err.Error())
 			}
 
-			wait := r.waitTime(attempt)
+			wait := r.WaitTime(attempt)
 			interval = time.NewTicker(time.Duration(wait))
 		}
 		if attempt >= r.maxRetry {
@@ -73,9 +73,9 @@ func (r Retry) Do(ctx context.Context, f func(context.Context) error, desc strin
 	}
 }
 
-// waitTime calculates the wait time based off the attempt number based off
+// WaitTime calculates the wait time based off the attempt number based off
 // exponential backoff with a random delay.
-func (r Retry) waitTime(attempt uint) int {
+func (r Retry) WaitTime(attempt uint) int {
 	if r.testMode {
 		return 1
 	}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -165,8 +166,8 @@ func TestWaitTime(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			r := NewRetry(1, 1)
-			a := r.WaitTime(tc.attempt)
+			random := rand.New(rand.NewSource(time.Now().UnixNano()))
+			a := WaitTime(tc.attempt, random)
 
 			actual := float64(a) / float64(time.Second)
 			assert.GreaterOrEqual(t, actual, tc.minReturn)

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -166,7 +166,7 @@ func TestWaitTime(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := NewRetry(1, 1)
-			a := r.waitTime(tc.attempt)
+			a := r.WaitTime(tc.attempt)
 
 			actual := float64(a) / float64(time.Second)
 			assert.GreaterOrEqual(t, actual, tc.minReturn)

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -10,13 +10,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewTestConsulServerHTTPS(tb testing.TB, relPath string) *testutil.TestServer {
+// TestConsulServerConfig configures a test Consul server
+type TestConsulServerConfig struct {
+	HTTPSRelPath string
+	PortHTTPS    int // random port will be generated if unset
+}
+
+// NewTestConsulServer starts a test Consul server as configured
+func NewTestConsulServer(tb testing.TB, config TestConsulServerConfig) *testutil.TestServer {
 	log.SetOutput(ioutil.Discard)
 
-	path, err := filepath.Abs(relPath)
-	require.NoError(tb, err, "unable to get absolute path of test certs")
-	certFile := filepath.Join(path, "cert.pem")
-	keyFile := filepath.Join(path, "key.pem")
+	var certFile string
+	var keyFile string
+	if config.HTTPSRelPath != "" {
+		path, err := filepath.Abs(config.HTTPSRelPath)
+		require.NoError(tb, err, "unable to get absolute path of test certs")
+		certFile = filepath.Join(path, "cert.pem")
+		keyFile = filepath.Join(path, "key.pem")
+	}
 
 	srv, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
@@ -25,9 +36,15 @@ func NewTestConsulServerHTTPS(tb testing.TB, relPath string) *testutil.TestServe
 			c.Stderr = ioutil.Discard
 
 			// Support CTS connecting over HTTP2
-			c.VerifyIncomingHTTPS = false
-			c.CertFile = certFile
-			c.KeyFile = keyFile
+			if config.HTTPSRelPath != "" {
+				c.VerifyIncomingHTTPS = false
+				c.CertFile = certFile
+				c.KeyFile = keyFile
+			}
+
+			if config.PortHTTPS != 0 {
+				c.Ports.HTTPS = config.PortHTTPS
+			}
 		})
 	require.NoError(tb, err, "unable to start Consul server")
 


### PR DESCRIPTION
When hcat polls Consul for changes in Consul catalog, it will now retry on error. It will retry a maximum of 9 times with exponential backoff. 9 retries with some jitter totals to waiting 8.5-12.8 minutes. If after 9 retries there is still an error, then CTS will exit.

Commits (see commit message for more details)
 - Make retry package's waitTime() public
 - Configure hcat watcher with a Consul retry function (this consumes retry.WaitTime()) (modified in last commit)
 - Pull latest hcat version
 - Update CTS to exit when hcat watcher errors since there is a retry now
 - Refactor testutils for changes needed to write a Consul restart e2e test
 - Consul restart e2e test
 - Update naming and comments for clarity

Resolves: https://github.com/hashicorp/consul-terraform-sync/issues/233