### PR TITLE
Refactor e2e functions to testutils

### DIFF
--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -126,22 +126,10 @@ func makeConfig(t testing.TB, services []string, addr string, tls bool,
 	cleanup := testutils.MakeTempDir(t, tmpDir)
 
 	configPath := filepath.Join(tmpDir, configFile)
-	err := writeConfig(configPath, configContents(addr, tls, services))
+	err := testutils.WriteFile(configPath, configContents(addr, tls, services))
 	require.NoError(t, err)
 
 	return configPath, cleanup
-}
-
-// write the (config) contents to the path
-func writeConfig(configPath, contents string) error {
-	f, err := os.Create(configPath)
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-	config := []byte(contents)
-	_, err = f.Write(config)
-	return err
 }
 
 // returns templated contents of config file

--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -126,8 +126,7 @@ func makeConfig(t testing.TB, services []string, addr string, tls bool,
 	cleanup := testutils.MakeTempDir(t, tmpDir)
 
 	configPath := filepath.Join(tmpDir, configFile)
-	err := testutils.WriteFile(configPath, configContents(addr, tls, services))
-	require.NoError(t, err)
+	testutils.WriteFile(t, configPath, configContents(addr, tls, services))
 
 	return configPath, cleanup
 }

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -159,7 +159,8 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	require.NoError(t, err)
 
 	configPath := filepath.Join(tempDir, configFile)
-	config := baseConfig().appendPort(port).appendConsulBlock(srv).appendDBTask()
+	config := baseConfig().appendPort(port).appendTerraformBlock(tempDir).
+		appendConsulBlock(srv).appendDBTask()
 	config.write(t, configPath)
 
 	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -35,9 +35,8 @@ func TestE2E_MetaCOmmandErrors(t *testing.T) {
 		appendConsulBlock(srv).appendTerraformBlock(tempDir)
 	config.write(t, configPath)
 
-	cmd, err := runSyncDevMode(configPath)
-	defer stopCommand(cmd)
-	require.NoError(t, err)
+	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	defer stop(t)
 	time.Sleep(5 * time.Second)
 
 	cases := []struct {
@@ -102,9 +101,8 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 		appendConsulBlock(srv).appendTerraformBlock(tempDir)
 	config.write(t, configPath)
 
-	cmd, err := runSyncDevMode(configPath)
-	defer stopCommand(cmd)
-	require.NoError(t, err)
+	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	defer stop(t)
 	time.Sleep(5 * time.Second)
 
 	cases := []struct {
@@ -164,9 +162,8 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	config := baseConfig().appendPort(port).appendConsulBlock(srv).appendDBTask()
 	config.write(t, configPath)
 
-	cmd, err := runSyncDevMode(configPath)
-	defer stopCommand(cmd)
-	require.NoError(t, err)
+	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	defer stop(t)
 	time.Sleep(5 * time.Second)
 
 	cases := []struct {

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -26,11 +26,7 @@ func (c hclConfig) appendString(s string) hclConfig {
 }
 
 func (c hclConfig) write(tb testing.TB, path string) {
-	f, err := os.Create(path)
-	require.NoError(tb, err)
-	defer f.Close()
-	_, err = f.Write([]byte(c))
-	require.NoError(tb, err)
+	testutils.WriteFile(tb, path, string(c))
 }
 
 func (c hclConfig) appendPort(port int) hclConfig {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -54,15 +54,15 @@ func TestE2EBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, len(files))
 
-	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_api.txt", tempDir, resourcesDir))
+	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/api.txt", tempDir, resourcesDir))
 	require.NoError(t, err)
 	require.Equal(t, "1.2.3.4", string(contents))
 
-	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_web.txt", tempDir, resourcesDir))
+	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/web.txt", tempDir, resourcesDir))
 	require.NoError(t, err)
 	require.Equal(t, "5.6.7.8", string(contents))
 
-	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_db.txt", tempDir, resourcesDir))
+	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/db.txt", tempDir, resourcesDir))
 	require.NoError(t, err)
 	require.Equal(t, "10.10.10.10", string(contents))
 
@@ -141,7 +141,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	time.Sleep(8 * time.Second)
 
 	// confirm that CTS reconnected with Consul and created resource for latest service
-	_, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/consul_service_api_new.txt", tempDir, resourcesDir))
+	_, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/api_new.txt", tempDir, resourcesDir))
 	require.NoError(t, err)
 
 	cleanup()

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,14 +5,12 @@ package e2e
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
@@ -66,11 +64,8 @@ func TestE2EBasic(t *testing.T) {
 	require.Equal(t, "10.10.10.10", string(contents))
 
 	// check statefiles exist
-	status := checkStateFile(t, srv.HTTPAddr, dbTaskName)
-	require.Equal(t, http.StatusOK, status)
-
-	status = checkStateFile(t, srv.HTTPAddr, webTaskName)
-	require.Equal(t, http.StatusOK, status)
+	testutils.CheckStateFile(t, srv.HTTPAddr, dbTaskName)
+	testutils.CheckStateFile(t, srv.HTTPAddr, webTaskName)
 
 	delete()
 }
@@ -287,13 +282,6 @@ func runSyncOnce(configPath string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func checkStateFile(t *testing.T, consulAddr, taskname string) int {
-	u := fmt.Sprintf("http://%s/v1/kv/%s-env:%s", consulAddr, config.DefaultTFBackendKVPath, taskname)
-	resp := testutils.RequestHTTP(t, http.MethodGet, u, "")
-	defer resp.Body.Close()
-	return resp.StatusCode
 }
 
 // checkStateFileLocally checks if statefile exists

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -48,19 +47,17 @@ func TestE2EBasic(t *testing.T) {
 	err := runSyncStop(configPath, 20*time.Second)
 	require.NoError(t, err)
 
-	files := testutils.CheckDir(t, true, fmt.Sprintf("%s/%s", tempDir, resourcesDir))
+	resourcesPath := fmt.Sprintf("%s/%s", tempDir, resourcesDir)
+	files := testutils.CheckDir(t, true, resourcesPath)
 	require.Equal(t, 3, len(files))
 
-	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/api.txt", tempDir, resourcesDir))
-	require.NoError(t, err)
+	contents := testutils.CheckFile(t, true, resourcesPath, "api.txt")
 	require.Equal(t, "1.2.3.4", string(contents))
 
-	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/web.txt", tempDir, resourcesDir))
-	require.NoError(t, err)
+	contents = testutils.CheckFile(t, true, resourcesPath, "web.txt")
 	require.Equal(t, "5.6.7.8", string(contents))
 
-	contents, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/db.txt", tempDir, resourcesDir))
-	require.NoError(t, err)
+	contents = testutils.CheckFile(t, true, resourcesPath, "db.txt")
 	require.Equal(t, "10.10.10.10", string(contents))
 
 	// check statefiles exist
@@ -135,8 +132,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	time.Sleep(8 * time.Second)
 
 	// confirm that CTS reconnected with Consul and created resource for latest service
-	_, err = ioutil.ReadFile(fmt.Sprintf("%s/%s/api_new.txt", tempDir, resourcesDir))
-	require.NoError(t, err)
+	testutils.CheckFile(t, true, fmt.Sprintf("%s/%s", tempDir, resourcesDir), "api_new.txt")
 
 	cleanup()
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -50,8 +50,7 @@ func TestE2EBasic(t *testing.T) {
 	err := runSyncStop(configPath, 20*time.Second)
 	require.NoError(t, err)
 
-	files, err := ioutil.ReadDir(fmt.Sprintf("%s/%s", tempDir, resourcesDir))
-	require.NoError(t, err)
+	files := testutils.CheckDir(t, true, fmt.Sprintf("%s/%s", tempDir, resourcesDir))
 	require.Equal(t, 3, len(files))
 
 	contents, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/api.txt", tempDir, resourcesDir))
@@ -251,13 +250,8 @@ func TestE2ELocalBackend(t *testing.T) {
 			require.NoError(t, err)
 
 			// check that statefile was created locally
-			exists, err := checkStateFileLocally(tc.dbStateFilePath)
-			require.NoError(t, err)
-			require.True(t, exists)
-
-			exists, err = checkStateFileLocally(tc.webStateFilePath)
-			require.NoError(t, err)
-			require.True(t, exists)
+			checkStateFileLocally(t, tc.dbStateFilePath)
+			checkStateFileLocally(t, tc.webStateFilePath)
 
 			delete()
 		})
@@ -302,21 +296,11 @@ func checkStateFile(t *testing.T, consulAddr, taskname string) int {
 	return resp.StatusCode
 }
 
-// checkStateFileLocally returns whether or not a statefile exists
-func checkStateFileLocally(stateFilePath string) (bool, error) {
-	files, err := ioutil.ReadDir(stateFilePath)
-	if err != nil {
-		return false, err
-	}
-
-	if len(files) != 1 {
-		return false, nil
-	}
+// checkStateFileLocally checks if statefile exists
+func checkStateFileLocally(t *testing.T, stateFilePath string) {
+	files := testutils.CheckDir(t, true, stateFilePath)
+	require.Equal(t, 1, len(files))
 
 	stateFile := files[0]
-	if stateFile.Name() != "terraform.tfstate" {
-		return false, nil
-	}
-
-	return true, nil
+	require.Equal(t, "terraform.tfstate", stateFile.Name())
 }

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -131,12 +130,11 @@ task {
 func loadTFVarsServiceIDs(t *testing.T, file string) []string {
 	// This is a bit hacky using regex but simpler than re-implementing syntax
 	// parsing for Terraform variables
-	content, err := ioutil.ReadFile(file)
-	require.NoError(t, err)
+	content := testutils.CheckFile(t, true, file, "")
 
 	var ids []string
 	re := regexp.MustCompile(`\s+id\s+\= \"([^"]+)`)
-	matches := re.FindAllSubmatch(content, -1)
+	matches := re.FindAllSubmatch([]byte(content), -1)
 	for _, match := range matches {
 		ids = append(ids, string(match[1]))
 	}

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTasksUpdate(t *testing.T) {
@@ -44,11 +43,8 @@ task {
 		appendDBTask().appendWebTask().appendString(apiTask)
 	config.write(t, configPath)
 
-	cmd, err := runSync(configPath)
-	require.NoError(t, err)
-
-	// Stop CTS then stop the Consul agent
-	defer stopCommand(cmd)
+	stop := testutils.StartCTS(t, configPath)
+	defer stop(t)
 
 	t.Run("once mode", func(t *testing.T) {
 		// Wait for tasks to execute once

--- a/e2e/test_modules/e2e_basic_task/main.tf
+++ b/e2e/test_modules/e2e_basic_task/main.tf
@@ -1,5 +1,5 @@
 resource "local_file" "address" {
     for_each = var.services
     content = each.value.address
-    filename = "../resources/consul_service_${each.value.id}.txt"
+    filename = "../resources/${each.value.id}.txt"
 }

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -169,19 +169,19 @@ func TestNewFiles(t *testing.T) {
 			b := new(bytes.Buffer)
 			err := tc.Func(b, tc.Name, &input)
 			require.NoError(t, err)
-			checkGoldenFile(t, tc.Golden, b.Bytes())
+			checkGoldenFile(t, tc.Golden, b.String())
 		})
 	}
 }
 
-func checkGoldenFile(t *testing.T, goldenFile string, actual []byte) {
+func checkGoldenFile(t *testing.T, goldenFile string, actual string) {
 	// update golden files if necessary
 	if *update {
-		if err := ioutil.WriteFile(goldenFile, actual, 0644); err != nil {
+		if err := ioutil.WriteFile(goldenFile, []byte(actual), 0644); err != nil {
 			require.NoError(t, err)
 		}
 	}
 
 	gld := testutils.CheckFile(t, true, goldenFile, "")
-	assert.Equal(t, string(gld), string(actual))
+	assert.Equal(t, gld, actual)
 }

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
 	goVersion "github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -181,10 +182,6 @@ func checkGoldenFile(t *testing.T, goldenFile string, actual []byte) {
 		}
 	}
 
-	gld, err := ioutil.ReadFile(goldenFile)
-	if err != nil {
-		require.NoError(t, err)
-	}
-
+	gld := testutils.CheckFile(t, true, goldenFile, "")
 	assert.Equal(t, string(gld), string(actual))
 }

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -84,8 +84,7 @@ func TestInitRootModule(t *testing.T) {
 	}
 
 	for _, f := range files {
-		actual, err := ioutil.ReadFile(f.ActualFile)
-		require.NoError(t, err)
+		actual := testutils.CheckFile(t, true, f.ActualFile, "")
 		checkGoldenFile(t, f.GoldenFile, actual)
 
 		info, err := os.Stat(f.ActualFile)
@@ -218,9 +217,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 			r := hcat.NewResolver()
 
 			// Load template from disk and render
-			contents, err := ioutil.ReadFile("testdata/terraform.tfvars.tmpl")
-			require.NoError(t, err)
-
+			contents := testutils.CheckFile(t, true, "testdata", "terraform.tfvars.tmpl")
 			input := hcat.TemplateInput{
 				Contents:      string(contents),
 				ErrMissingKey: true,
@@ -231,10 +228,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*8)
 			defer cancel()
 
-			gld, err := ioutil.ReadFile(tc.goldenFile)
-			if err != nil {
-				require.NoError(t, err)
-			}
+			gld := testutils.CheckFile(t, true, tc.goldenFile, "")
 			retry := 0
 			for {
 				re, err := r.Run(tmpl, w)

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -138,4 +139,14 @@ func ShowMeHealth(t testing.TB, srv *testutil.TestServer, svcName string) {
 	resp.Body.Close()
 
 	fmt.Println(string(b))
+}
+
+// CheckStateFile checks statefile in the default Terraform backend ConsulKV.
+func CheckStateFile(t *testing.T, consulAddr, taskname string) {
+	u := fmt.Sprintf("http://%s/v1/kv/%s-env:%s", consulAddr,
+		config.DefaultTFBackendKVPath, taskname)
+	resp := RequestHTTP(t, http.MethodGet, u, "")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Unable to find statefile"+
+		" in Consul KV")
 }

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -9,10 +9,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// defaultTFBackendKVPath is the same as config package. Duplicating to avoid
+// import cycles
+const defaultTFBackendKVPath = "consul-terraform-sync/terraform"
 
 // TestConsulServerConfig configures a test Consul server
 type TestConsulServerConfig struct {
@@ -144,7 +147,7 @@ func ShowMeHealth(t testing.TB, srv *testutil.TestServer, svcName string) {
 // CheckStateFile checks statefile in the default Terraform backend ConsulKV.
 func CheckStateFile(t *testing.T, consulAddr, taskname string) {
 	u := fmt.Sprintf("http://%s/v1/kv/%s-env:%s", consulAddr,
-		config.DefaultTFBackendKVPath, taskname)
+		defaultTFBackendKVPath, taskname)
 	resp := RequestHTTP(t, http.MethodGet, u, "")
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode, "Unable to find statefile"+

--- a/testutils/cts.go
+++ b/testutils/cts.go
@@ -1,0 +1,49 @@
+package testutils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// CTSOnceModeFlag is an optional flag to run CTS
+	CTSOnceModeFlag = "-once"
+	// CTSDevModeFlag is an optional flag to run CTS with development client
+	CTSDevModeFlag = "--client-type=development"
+)
+
+// StartCTS starts the CTS from binary and returns a function to stop CTS. If
+// running once-mode, the function will block until complete so no need to use
+// stop function
+func StartCTS(t *testing.T, configPath string, opts ...string) func(t *testing.T) {
+	opts = append(opts, fmt.Sprintf("--config-file=%s", configPath))
+	cmd := exec.Command("consul-terraform-sync", opts...)
+	// uncomment to see logs
+	// cmd.Stdout = os.Stdout
+	// cmd.Stderr = os.Stderr
+
+	// run CTS in once-mode
+	for _, opt := range opts {
+		if opt == CTSOnceModeFlag {
+			cmd.Run() // blocking
+			return func(t *testing.T) {}
+		}
+	}
+
+	// start CTS regularly
+	err := cmd.Start()
+	require.NoError(t, err)
+
+	return func(t *testing.T) {
+		cmd.Process.Signal(os.Interrupt)
+		sigintErr := errors.New("signal: interrupt")
+		if err := cmd.Wait(); err != nil {
+			require.Equal(t, sigintErr, err)
+		}
+	}
+}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -58,6 +59,21 @@ func WriteFile(t testing.TB, path, content string) {
 	defer f.Close()
 	_, err = f.Write([]byte(content))
 	require.NoError(t, err)
+}
+
+// CheckFile checks whether a file exists or not. If it exists, returns the
+// contents for further checking. If path parameter already includes filename,
+// leave filename parameter as an empty string.
+func CheckFile(t testing.TB, exists bool, path, filename string) string {
+	fp := filepath.Join(path, filename) // handles if filename is empty
+	content, err := ioutil.ReadFile(fp)
+	if !exists {
+		require.Error(t, err)
+		return ""
+	}
+
+	require.NoError(t, err)
+	return string(content)
 }
 
 // RegisterConsulService regsiters a service to the Consul Catalog. The Consul

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -34,8 +35,20 @@ func MakeTempDir(t testing.TB, tempDir string) func() error {
 
 	return func() error {
 		return os.RemoveAll(tempDir)
-
 	}
+}
+
+// CheckDir checks whether or not a directory exists. If it exists, returns the
+// file infos for further checking.
+func CheckDir(t testing.TB, exists bool, dir string) []os.FileInfo {
+	files, err := ioutil.ReadDir(dir)
+	if exists {
+		require.NoError(t, err)
+		return files
+	}
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no such file or directory")
+	return []os.FileInfo{}
 }
 
 // RegisterConsulService regsiters a service to the Consul Catalog. The Consul

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -51,6 +51,15 @@ func CheckDir(t testing.TB, exists bool, dir string) []os.FileInfo {
 	return []os.FileInfo{}
 }
 
+// WriteFile write a content to a file path.
+func WriteFile(t testing.TB, path, content string) {
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	_, err = f.Write([]byte(content))
+	require.NoError(t, err)
+}
+
 // RegisterConsulService regsiters a service to the Consul Catalog. The Consul
 // sdk/testutil package currently does not support a method to register multiple
 // service instances, distinguished by their IDs.


### PR DESCRIPTION
These functions will be shared with the compatibility test (separate PR) which I want to put in a separate package from the other e2e tests. This PR refactors/cleansup a lot of e2e functions to testutils so that they can be used across package.

Note: made changes to benchmark tests. Ran the "lowest" benchmark test for each type of test to confirm still working.

Changes: (see commit for more details)
 - Update module to generate shorter textfile name
 - Refactored functions into testutils.CheckDir
 - Refactored functions into testutils.CheckStateFile (fixed issue later commit)
 - Refactored functions into testutils.WriteFile (fixed issue later commit)
 - Refactored functions into testutils.CheckFile (fixed issue later commit)
 - Refactored functions into testutils.StartCTS
 - Update a test with a Terraform config
 - Fix import cycle issue introduced by CheckStateFile
 - Fix type issue caused by CheckFile
 - Fix bug implementing WriteFile in benchmarks