### PR TITLE
Consistent on go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ jobs:
   unit_integration_tests:
     environment:
       GO111MODULE: "on"
+      GO_VERSION: "1.16"
       CONSUL_VERSION: 1.8.0
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:${GO_VERSION}
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout
@@ -25,9 +26,10 @@ jobs:
   e2e_tests:
     environment:
       GO111MODULE: "on"
+      GO_VERSION: "1.16"
       CONSUL_VERSION: 1.8.0
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:${GO_VERSION}
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOPATH=$(shell go env GOPATH)
 GOPATH := $(lastword $(subst :, ,${GOPATH}))# use last GOPATH entry
 
 # Project information
-GOVERSION := 1.14
+GOVERSION := 1.16
 PROJECT := $(shell go list -m)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-terraform-sync
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.78.0 // indirect


### PR DESCRIPTION
The recent 0.1.0 Beta and GA releases were compiled using go 1.16.
Go version was not consistent between go.mod, CI testing, and release.