### PR TITLE
Weekly benchmark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Run benchmark suite
           no_output_timeout: << parameters.no_output_timeout >>
           command:
-            go test -json ./e2e/benchmarks -timeout 2h -bench=. -tags e2e | /usr/bin/tee /tmp/benchmarks.json
+            make test-benchmarks | /usr/bin/tee /tmp/benchmarks.json
       - store_artifacts:
           path: /tmp/benchmarks.json
           destination: benchmarks.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,13 +98,13 @@ workflows:
     jobs:
       - unit_integration_tests
       - e2e_tests
-  nightly-benchmarks:
+  weekly-benchmarks:
     jobs:
       - benchmarks
     triggers:
       - schedule:
-          # 02:10 UTC every night
-          cron: 10 2 * * *
+          # 02:10 UTC every Wednesday
+          cron: 10 2 * * 3
           filters:
             branches:
               only:

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ test-setup-e2e: dev
 test-e2e-cirecleci: test-setup-e2e test-e2e
 .PHONY: test-e2e-cirecleci
 
+# test-benchmarks requires Terraform in the path of execution and Consul in $PATH.
+test-benchmarks:
+	@echo "==> Running benchmarks for ${NAME}"
+	@go test -json ./e2e/benchmarks -timeout 2h -bench=. -tags e2e
+.PHONY: test-benchmarks
+
 # delete any cruft
 clean:
 	rm -f ./e2e/terraform


### PR DESCRIPTION
Update the benchmark to run weekly instead of nightly

The weekly CI job will appear on the master branch checks on Wednesday at 2:10 UTC every Wednesday. Results are formatted in json and can be found under the “artifacts” tab -> benchmarks.json.
![image](https://user-images.githubusercontent.com/6362111/115052079-230f5f80-9ea3-11eb-856e-6d422269d82f.png)