### PR TITLE
Support condition config in task blocks

### DIFF
--- a/config/condition.go
+++ b/config/condition.go
@@ -31,7 +31,17 @@ func DefaultConditionConfig() ConditionConfig {
 // both the type and value. Not needed for checking a ConditionConfig
 // implementation i.e. isNil(ConditionConfig), servicesConditionConfig == nil
 func isNil(c ConditionConfig) bool {
-	return c == nil || reflect.ValueOf(c).IsNil()
+	var result bool
+	// switching on type is a performance enhancement
+	switch v := c.(type) {
+	case *ServicesConditionConfig:
+		result = v == nil
+	case *CatalogServicesConditionConfig:
+		result = v == nil
+	default:
+		return c == nil || reflect.ValueOf(c).IsNil()
+	}
+	return c == nil || result
 }
 
 // conditionToTypeFunc is a decode hook function to decode a ConditionConfig

--- a/config/condition.go
+++ b/config/condition.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"reflect"
+)
+
+// ConditionConfig configures a condition on a task to define the condition on
+// which to execute a task.
+type ConditionConfig interface {
+	Copy() ConditionConfig
+	Merge(ConditionConfig) ConditionConfig
+	Finalize([]string)
+	Validate() error
+	GoString() string
+}
+
+// DefaultConditionConfig returns the default conditions which is an unconfigured
+// 'services' type condition.
+func DefaultConditionConfig() ConditionConfig {
+	return &ServicesConditionConfig{}
+}
+
+// isNil can be used to check if a ConditionConfig interface is nil by checking
+// both the type and value. Not needed for checking a ConditionConfig
+// implementation i.e. isNil(ConditionConfig), servicesConditionConfig == nil
+func isNil(c ConditionConfig) bool {
+	return c == nil || reflect.ValueOf(c).IsNil()
+}

--- a/config/condition.go
+++ b/config/condition.go
@@ -27,10 +27,11 @@ func DefaultConditionConfig() ConditionConfig {
 	return &ServicesConditionConfig{}
 }
 
-// isNil can be used to check if a ConditionConfig interface is nil by checking
-// both the type and value. Not needed for checking a ConditionConfig
-// implementation i.e. isNil(ConditionConfig), servicesConditionConfig == nil
-func isNil(c ConditionConfig) bool {
+// isConditionNil can be used to check if a ConditionConfig interface is nil by
+// checking both the type and value. Not needed for checking a ConditionConfig
+// implementation i.e. isConditionNil(ConditionConfig),
+// servicesConditionConfig == nil
+func isConditionNil(c ConditionConfig) bool {
 	var result bool
 	// switching on type is a performance enhancement
 	switch v := c.(type) {

--- a/config/condition.go
+++ b/config/condition.go
@@ -1,7 +1,14 @@
 package config
 
 import (
+	"fmt"
+	"log"
 	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/consul/lib/decode"
+	"github.com/mitchellh/mapstructure"
 )
 
 // ConditionConfig configures a condition on a task to define the condition on
@@ -25,4 +32,82 @@ func DefaultConditionConfig() ConditionConfig {
 // implementation i.e. isNil(ConditionConfig), servicesConditionConfig == nil
 func isNil(c ConditionConfig) bool {
 	return c == nil || reflect.ValueOf(c).IsNil()
+}
+
+// conditionToTypeFunc is a decode hook function to decode a ConditionConfig
+// into a specific condition implementation structures. Used when decoding
+// cts config overall.
+func conditionToTypeFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		// identify if parsing a ConditionConfig
+		var i ConditionConfig
+		if t != reflect.TypeOf(&i).Elem() {
+			return data, nil
+		}
+
+		// abstract conditions map out depending on hcl vs. json formatting
+		// data hcl ex: [map[catalog-services:[map[regexp:.*]]]]
+		// data json ex: map[catalog-services:map[regexp:.*]]
+		var conditions map[string]interface{}
+		if hcl, ok := data.([]map[string]interface{}); ok {
+			if len(hcl) != 1 {
+				return nil, fmt.Errorf("expected only one item in hcl "+
+					"condition but got %d: %v", len(hcl), data)
+			}
+			conditions = hcl[0]
+		}
+		if json, ok := data.(map[string]interface{}); ok {
+			conditions = json
+		}
+
+		if c, ok := conditions[catalogServicesConditionType]; ok {
+			var config CatalogServicesConditionConfig
+			return decodeConditionToType(c, &config)
+		}
+		if c, ok := conditions[servicesConditionType]; ok {
+			var config ServicesConditionConfig
+			return decodeConditionToType(c, &config)
+		}
+
+		return nil, fmt.Errorf("unsupported condition type: %v", data)
+	}
+}
+
+// decodeConditionToType is used by the overall config mapstructure decode hook
+// conditionToTypeFunc in order to convert ConditionConfig in the form
+// of an interface into an implementation
+func decodeConditionToType(data interface{}, condition ConditionConfig) (ConditionConfig, error) {
+	var md mapstructure.Metadata
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: mapstructure.ComposeDecodeHookFunc(
+			decode.HookWeakDecodeFromSlice,
+		),
+		WeaklyTypedInput: true,
+		ErrorUnused:      false,
+		Metadata:         &md,
+		Result:           &condition,
+	})
+	if err != nil {
+		log.Printf("[ERR] (config) condition mapstructure decoder creation"+
+			"failed: %s", err)
+		return nil, err
+	}
+
+	if err := decoder.Decode(data); err != nil {
+		log.Printf("[ERR] (config) condition mapstructure decode failed: %s",
+			err)
+		return nil, err
+	}
+
+	if len(md.Unused) > 0 {
+		sort.Strings(md.Unused)
+		err := fmt.Errorf("invalid keys: %s", strings.Join(md.Unused, ", "))
+		log.Printf("[ERR] (config) condition %s", err.Error())
+		return nil, err
+	}
+
+	return condition, nil
 }

--- a/config/condition_catalog_services.go
+++ b/config/condition_catalog_services.go
@@ -1,0 +1,170 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const catalogServicesConditionType = "catalog-services"
+
+var _ ConditionConfig = (*CatalogServicesConditionConfig)(nil)
+
+// CatalogServicesConditionConfig configures a condition configuration block
+// of type 'catalog-services'. A catalog-services condition is triggered by
+// that occur to services in the catalog-services api.
+type CatalogServicesConditionConfig struct {
+	Regexp      *string           `mapstructure:"regexp"`
+	EnableTfVar *bool             `mapstructure:"enable_tf_var"`
+	Datacenter  *string           `mapstructure:"datacenter"`
+	Namespace   *string           `mapstructure:"namespace"`
+	NodeMeta    map[string]string `mapstructure:"node_meta"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *CatalogServicesConditionConfig) Copy() ConditionConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o CatalogServicesConditionConfig
+
+	o.Regexp = StringCopy(c.Regexp)
+	o.EnableTfVar = BoolCopy(c.EnableTfVar)
+	o.Datacenter = StringCopy(c.Datacenter)
+	o.Namespace = StringCopy(c.Namespace)
+
+	if c.NodeMeta != nil {
+		o.NodeMeta = make(map[string]string)
+		for k, v := range c.NodeMeta {
+			o.NodeMeta[k] = v
+		}
+	}
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *CatalogServicesConditionConfig) Merge(o ConditionConfig) ConditionConfig {
+	if c == nil {
+		if isNil(o) { // o is interface, use isNil()
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if isNil(o) {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+	o2, ok := o.(*CatalogServicesConditionConfig)
+	if !ok {
+		return r
+	}
+
+	r2 := r.(*CatalogServicesConditionConfig)
+
+	if o2.Regexp != nil {
+		r2.Regexp = StringCopy(o2.Regexp)
+	}
+
+	if o2.EnableTfVar != nil {
+		r2.EnableTfVar = BoolCopy(o2.EnableTfVar)
+	}
+
+	if o2.Datacenter != nil {
+		r2.Datacenter = StringCopy(o2.Datacenter)
+	}
+
+	if o2.Namespace != nil {
+		r2.Namespace = StringCopy(o2.Namespace)
+	}
+
+	if o2.NodeMeta != nil {
+		if r2.NodeMeta == nil {
+			r2.NodeMeta = make(map[string]string)
+		}
+		for k, v := range o2.NodeMeta {
+			r2.NodeMeta[k] = v
+		}
+	}
+
+	return r2
+}
+
+// Finalize ensures there no nil pointers.
+func (c *CatalogServicesConditionConfig) Finalize(services []string) {
+	if c == nil { // config not required, return early
+		return
+	}
+
+	if c.Regexp == nil {
+		// default behavior: exact match on any of the services configured for
+		// the task. cannot default to "" since it is possible regex config.
+		// ex: ["api", "web", "db"] => "^api$|^web$|^db$"
+		regex := make([]string, len(services))
+		for ix, s := range services {
+			regex[ix] = fmt.Sprintf("^%s$", s) // exact match on service's name
+		}
+		c.Regexp = String(strings.Join(regex, "|"))
+
+		if len(services) == 0 {
+			// for testing. can't occur when running cts due to config validation
+			c.Regexp = String("")
+		}
+	}
+
+	if c.EnableTfVar == nil {
+		c.EnableTfVar = Bool(false)
+	}
+
+	if c.Datacenter == nil {
+		c.Datacenter = String("")
+	}
+
+	if c.Namespace == nil {
+		c.Namespace = String("")
+	}
+
+	if c.NodeMeta == nil {
+		c.NodeMeta = make(map[string]string)
+	}
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *CatalogServicesConditionConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if _, err := regexp.Compile(StringVal(c.Regexp)); err != nil {
+		return fmt.Errorf("unable to compile catalog-services regexp: %s", err)
+	}
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *CatalogServicesConditionConfig) GoString() string {
+	if c == nil {
+		return "(*CatalogServicesConditionConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&CatalogServicesConditionConfig{"+
+		"Regexp:%s, "+
+		"EnableTfVar:%v, "+
+		"Datacenter:%v, "+
+		"Namespace:%v, "+
+		"NodeMeta:%s"+
+		"}",
+		StringVal(c.Regexp),
+		BoolVal(c.EnableTfVar),
+		StringVal(c.Datacenter),
+		StringVal(c.Namespace),
+		c.NodeMeta,
+	)
+}

--- a/config/condition_catalog_services.go
+++ b/config/condition_catalog_services.go
@@ -50,13 +50,13 @@ func (c *CatalogServicesConditionConfig) Copy() ConditionConfig {
 // structs define their own merge functionality.
 func (c *CatalogServicesConditionConfig) Merge(o ConditionConfig) ConditionConfig {
 	if c == nil {
-		if isNil(o) { // o is interface, use isNil()
+		if isConditionNil(o) { // o is interface, use isConditionNil()
 			return nil
 		}
 		return o.Copy()
 	}
 
-	if isNil(o) {
+	if isConditionNil(o) {
 		return c.Copy()
 	}
 

--- a/config/condition_catalog_services_test.go
+++ b/config/condition_catalog_services_test.go
@@ -1,0 +1,304 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCatalogServicesConditionConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *CatalogServicesConditionConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&CatalogServicesConditionConfig{},
+		},
+		{
+			"fully_configured",
+			&CatalogServicesConditionConfig{
+				Regexp:      String(".*"),
+				EnableTfVar: Bool(true),
+				Datacenter:  String("dc2"),
+				Namespace:   String("ns2"),
+				NodeMeta: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			if tc.a == nil {
+				// returned nil interface has nil type, which is unequal to tc.a
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.a, r)
+			}
+		})
+	}
+}
+
+func TestCatalogServicesConditionConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *CatalogServicesConditionConfig
+		b    *CatalogServicesConditionConfig
+		r    *CatalogServicesConditionConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{},
+		},
+		{
+			"nil_b",
+			&CatalogServicesConditionConfig{},
+			nil,
+			&CatalogServicesConditionConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{},
+		},
+		{
+			"regexp_overrides",
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+			&CatalogServicesConditionConfig{Regexp: String("different")},
+			&CatalogServicesConditionConfig{Regexp: String("different")},
+		},
+		{
+			"regexp_empty_one",
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+		},
+		{
+			"regexp_empty_two",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+		},
+		{
+			"regexp_empty_same",
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+			&CatalogServicesConditionConfig{Regexp: String("same")},
+		},
+		{
+			"enable_tf_var_overrides",
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(false)},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(false)},
+		},
+		{
+			"enable_tf_var_empty_one",
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+		},
+		{
+			"enable_tf_var_empty_two",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+		},
+		{
+			"enable_tf_var_empty_same",
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+			&CatalogServicesConditionConfig{EnableTfVar: Bool(true)},
+		},
+		{
+			"datacenter_overrides",
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+			&CatalogServicesConditionConfig{Datacenter: String("different")},
+			&CatalogServicesConditionConfig{Datacenter: String("different")},
+		},
+		{
+			"datacenter_empty_one",
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"datacenter_empty_two",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"datacenter_empty_same",
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+			&CatalogServicesConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"namespace_overrides",
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+			&CatalogServicesConditionConfig{Namespace: String("different")},
+			&CatalogServicesConditionConfig{Namespace: String("different")},
+		},
+		{
+			"namespace_empty_one",
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+		},
+		{
+			"namespace_empty_two",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+		},
+		{
+			"namespace_empty_same",
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+			&CatalogServicesConditionConfig{Namespace: String("same")},
+		},
+		{
+			"node_meta_overrides",
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "new-value"}},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "new-value"}},
+		},
+		{
+			"node_meta_empty_one",
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"node_meta_empty_two",
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"node_meta_same",
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+			&CatalogServicesConditionConfig{NodeMeta: map[string]string{"key": "value"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				// returned nil interface has nil type, which is unequal to tc.r
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.r, r)
+			}
+		})
+	}
+}
+
+func TestCatalogServicesConditionConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		s    []string
+		i    *CatalogServicesConditionConfig
+		r    *CatalogServicesConditionConfig
+	}{
+		{
+			"empty",
+			[]string{},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{
+				Regexp:      String(""),
+				EnableTfVar: Bool(false),
+				Datacenter:  String(""),
+				Namespace:   String(""),
+				NodeMeta:    map[string]string{},
+			},
+		},
+		{
+			"pass_in_services",
+			[]string{"api"},
+			&CatalogServicesConditionConfig{},
+			&CatalogServicesConditionConfig{
+				Regexp:      String("^api$"),
+				EnableTfVar: Bool(false),
+				Datacenter:  String(""),
+				Namespace:   String(""),
+				NodeMeta:    map[string]string{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize(tc.s)
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestCatalogServicesConditionConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *CatalogServicesConditionConfig
+	}{
+		{
+			"happy_path",
+			false,
+			&CatalogServicesConditionConfig{
+				Regexp:      String(".*"),
+				EnableTfVar: Bool(true),
+				Datacenter:  String("dc2"),
+				Namespace:   String("ns2"),
+				NodeMeta: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+		},
+		{
+			"invalid_regexp",
+			true,
+			&CatalogServicesConditionConfig{
+				Regexp: String("*"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/condition_services.go
+++ b/config/condition_services.go
@@ -1,0 +1,60 @@
+package config
+
+const servicesConditionType = "services"
+
+var _ ConditionConfig = (*ServicesConditionConfig)(nil)
+
+// ServicesConditionConfig configures a condition configuration block of type
+// 'services'. This is the default type of condition. A services condition is
+// triggered when changes occur to the the task's services.
+type ServicesConditionConfig struct{}
+
+// Copy returns a deep copy of this configuration.
+func (c *ServicesConditionConfig) Copy() ConditionConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o ServicesConditionConfig
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *ServicesConditionConfig) Merge(o ConditionConfig) ConditionConfig {
+	if c == nil {
+		if isNil(o) { // o is interface, use isNil()
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if isNil(o) {
+		return c.Copy()
+	}
+
+	return c.Copy()
+}
+
+// Finalize ensures there no nil pointers.
+func (c *ServicesConditionConfig) Finalize(services []string) {
+	// no-op: no fields to finalize yet
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *ServicesConditionConfig) Validate() error {
+	// no-op: no fields to validate yet
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *ServicesConditionConfig) GoString() string {
+	if c == nil {
+		return "(*ServicesConditionConfig)(nil)"
+	}
+
+	return "&ServicesConditionConfig{}"
+}

--- a/config/condition_services.go
+++ b/config/condition_services.go
@@ -25,13 +25,13 @@ func (c *ServicesConditionConfig) Copy() ConditionConfig {
 // structs define their own merge functionality.
 func (c *ServicesConditionConfig) Merge(o ConditionConfig) ConditionConfig {
 	if c == nil {
-		if isNil(o) { // o is interface, use isNil()
+		if isConditionNil(o) { // o is interface, use isConditionNil()
 			return nil
 		}
 		return o.Copy()
 	}
 
-	if isNil(o) {
+	if isConditionNil(o) {
 		return c.Copy()
 	}
 

--- a/config/condition_services_test.go
+++ b/config/condition_services_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServicesConditionConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ServicesConditionConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&ServicesConditionConfig{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			if tc.a == nil {
+				// returned nil interface has nil type, which is unequal to tc.a
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.a, r)
+			}
+		})
+	}
+}
+
+func TestServicesConditionConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ServicesConditionConfig
+		b    *ServicesConditionConfig
+		r    *ServicesConditionConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&ServicesConditionConfig{},
+			&ServicesConditionConfig{},
+		},
+		{
+			"nil_b",
+			&ServicesConditionConfig{},
+			nil,
+			&ServicesConditionConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ServicesConditionConfig{},
+			&ServicesConditionConfig{},
+			&ServicesConditionConfig{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				// returned nil interface has nil type, which is unequal to tc.r
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.r, r)
+			}
+		})
+	}
+}

--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -1,0 +1,216 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition_DecodeConfig(t *testing.T) {
+	// specifically test decoding condition configs
+	cases := []struct {
+		name      string
+		expectErr bool
+		expected  ConditionConfig
+		filename  string
+		config    string
+	}{
+		{
+			"catalog-services: happy path",
+			false,
+			&CatalogServicesConditionConfig{
+				Regexp:      String(".*"),
+				EnableTfVar: Bool(true),
+				Datacenter:  String("dc2"),
+				Namespace:   String("ns2"),
+				NodeMeta: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "catalog-services" {
+		regexp = ".*"
+		enable_tf_var = true
+		namespace = "ns2"
+		datacenter = "dc2"
+		node_meta {
+		  "key1" = "value1"
+		  "key2" = "value2"
+		}
+	}
+}`,
+		},
+		{
+			"catalog-services: unconfigured",
+			false,
+			&CatalogServicesConditionConfig{
+				Regexp:      String("^api$"),
+				EnableTfVar: Bool(false),
+				Datacenter:  String(""),
+				Namespace:   String(""),
+				NodeMeta:    map[string]string{},
+			},
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "catalog-services" {
+	}
+}`,
+		},
+		{
+			"no condition: defaults to services condition",
+			false,
+			&ServicesConditionConfig{},
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+}`,
+		},
+		{
+			"services: happy path",
+			false,
+			&ServicesConditionConfig{},
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "services" {
+	}
+}`,
+		},
+		{
+			"services: unsupported field",
+			true,
+			nil,
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "services" {
+		nonexistent_field = true
+	}
+}`,
+		},
+		{
+			"catalog-services: unsupported field",
+			true,
+			nil,
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "catalog-services" {
+		nonexistent_field = true
+	}
+}`,
+		},
+		{
+			"error: two conditions",
+			true,
+			nil,
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "catalog-services" {
+	}
+	condition "catalog-services" {
+		regexp = ".*"
+		enable_tf_var = false
+	}
+}`,
+		},
+		{
+			"error: nonexistent condition type",
+			true,
+			nil,
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	services = ["api"]
+	source = "..."
+	condition "nonexistent-condition" {
+	}
+}`,
+		},
+		{
+			"json happy path",
+			false,
+			&CatalogServicesConditionConfig{
+				Regexp:      String(".*"),
+				EnableTfVar: Bool(true),
+				Datacenter:  String("dc2"),
+				Namespace:   String("ns2"),
+				NodeMeta: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			"config.json",
+			`
+{
+	"task": [
+		{
+		  "name": "task",
+		  "description": "automate services for X to do Y",
+		  "services": ["serviceA", "serviceB", "serviceC"],
+		  "providers": ["X"],
+		  "source": "Y",
+		  "condition": {
+			"catalog-services": {
+			  "regexp": ".*",
+			  "enable_tf_var": true,
+			  "datacenter": "dc2",
+			  "namespace": "ns2",
+			  "node_meta": {
+				"key1": "value1",
+				"key2": "value2"
+			  }
+			}
+		  }
+		}
+]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// replicate decoding process used by cts cli
+			config, err := decodeConfig([]byte(tc.config), tc.filename)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			config.Finalize()
+			err = config.Validate()
+			require.NoError(t, err)
+
+			// confirm that condition decoding
+			tasks := *config.Tasks
+			require.Equal(t, 1, len(tasks))
+			require.Equal(t, tc.expected, tasks[0].Condition)
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -356,12 +356,14 @@ func decodeConfig(content []byte, file string) (*Config, error) {
 	case "json":
 		err = json.Unmarshal(content, &raw)
 		decodeHook = mapstructure.ComposeDecodeHookFunc(
+			conditionToTypeFunc(),
 			mapstructure.StringToTimeDurationHookFunc(),
 			decode.HookTranslateKeys,
 		)
 	case "hcl":
 		err = hcl.Decode(&raw, string(content))
 		decodeHook = mapstructure.ComposeDecodeHookFunc(
+			conditionToTypeFunc(),
 			decode.HookWeakDecodeFromSlice,
 			mapstructure.StringToTimeDurationHookFunc(),
 			decode.HookTranslateKeys)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -93,6 +93,16 @@ var (
 				Services:    []string{"serviceA", "serviceB", "serviceC"},
 				Providers:   []string{"X"},
 				Source:      String("Y"),
+				Condition: &CatalogServicesConditionConfig{
+					Regexp:      String(".*"),
+					EnableTfVar: Bool(true),
+					Datacenter:  String("dc2"),
+					Namespace:   String("ns2"),
+					NodeMeta: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
 			},
 		},
 		TerraformProviders: &TerraformProviderConfigs{{
@@ -329,6 +339,7 @@ func TestConfig_Validate(t *testing.T) {
 		Services:    []string{"serviceD"},
 		Providers:   []string{"Y"},
 		Source:      String("Z"),
+		Condition:   &ServicesConditionConfig{},
 	})
 	*validMultiTask.TerraformProviders = append(*validMultiTask.TerraformProviders,
 		&TerraformProviderConfig{"Y": map[string]interface{}{}})

--- a/config/task.go
+++ b/config/task.go
@@ -89,7 +89,7 @@ func (c *TaskConfig) Copy() *TaskConfig {
 
 	o.Enabled = BoolCopy(c.Enabled)
 
-	if !isNil(c.Condition) {
+	if !isConditionNil(c.Condition) {
 		o.Condition = c.Condition.Copy()
 	}
 
@@ -150,8 +150,8 @@ func (c *TaskConfig) Merge(o *TaskConfig) *TaskConfig {
 		r.Enabled = BoolCopy(o.Enabled)
 	}
 
-	if !isNil(o.Condition) {
-		if isNil(r.Condition) {
+	if !isConditionNil(o.Condition) {
+		if isConditionNil(r.Condition) {
 			r.Condition = o.Condition.Copy()
 		} else {
 			r.Condition = r.Condition.Merge(o.Condition)
@@ -204,7 +204,7 @@ func (c *TaskConfig) Finalize() {
 		c.Enabled = Bool(true)
 	}
 
-	if isNil(c.Condition) {
+	if isConditionNil(c.Condition) {
 		c.Condition = DefaultConditionConfig()
 	}
 	c.Condition.Finalize(c.Services)
@@ -251,7 +251,7 @@ func (c *TaskConfig) Validate() error {
 		return err
 	}
 
-	if !isNil(c.Condition) {
+	if !isConditionNil(c.Condition) {
 		if err := c.Condition.Validate(); err != nil {
 			return err
 		}

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -30,6 +30,15 @@ func TestTaskConfig_Copy(t *testing.T) {
 				Source:      String("source"),
 				Version:     String("0.0.0"),
 				Enabled:     Bool(true),
+				Condition: &CatalogServicesConditionConfig{
+					Regexp:      String(".*"),
+					EnableTfVar: Bool(true),
+					Datacenter:  String("dc2"),
+					Namespace:   String("ns2"),
+					NodeMeta: map[string]string{
+						"key": "value",
+					},
+				},
 			},
 		},
 	}
@@ -229,6 +238,30 @@ func TestTaskConfig_Merge(t *testing.T) {
 			&TaskConfig{Enabled: Bool(false)},
 			&TaskConfig{Enabled: Bool(false)},
 		},
+		{
+			"condition_overrides",
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String("")}},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String("")}},
+		},
+		{
+			"condition_empty_one",
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+			&TaskConfig{},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+		},
+		{
+			"condition_empty_two",
+			&TaskConfig{},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+		},
+		{
+			"condition_same",
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
+		},
 	}
 
 	for i, tc := range cases {
@@ -258,6 +291,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				Version:      String(""),
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
+				Condition:    DefaultConditionConfig(),
 			},
 		},
 		{
@@ -275,6 +309,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				Version:      String(""),
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
+				Condition:    DefaultConditionConfig(),
 			},
 		},
 	}
@@ -305,6 +340,17 @@ func TestTaskConfig_Validate(t *testing.T) {
 		},
 		{
 			"valid",
+			&TaskConfig{
+				Name:      String("task"),
+				Services:  []string{"serviceA", "serviceB"},
+				Source:    String("source"),
+				Providers: []string{"providerA", "providerB"},
+				Condition: DefaultConditionConfig(),
+			},
+			true,
+		},
+		{
+			"valid (missing condition)",
 			&TaskConfig{
 				Name:      String("task"),
 				Services:  []string{"serviceA", "serviceB"},

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -75,4 +75,14 @@ task {
   services = ["serviceA", "serviceB", "serviceC"]
   providers = ["X"]
   source = "Y"
+  condition "catalog-services" {
+    regexp = ".*"
+    enable_tf_var = true
+    namespace = "ns2"
+    datacenter = "dc2"
+    node_meta {
+      "key1" = "value1"
+      "key2" = "value2"
+    }
+  }
 }

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -78,7 +78,19 @@
       "description": "automate services for X to do Y",
       "services": ["serviceA", "serviceB", "serviceC"],
       "providers": ["X"],
-      "source": "Y"
+      "source": "Y",
+      "condition": {
+        "catalog-services": {
+          "regexp": ".*",
+          "enable_tf_var": true,
+          "datacenter": "dc2",
+          "namespace": "ns2",
+          "node_meta": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      }  
     }
   ]
 }


### PR DESCRIPTION
Currently tasks run depending on service changes. We want to start supporting a
new feature where tasks can be configure to run depending on different
conditions. For the feature, we will add a condition configuration that allows
different condition types. The default type is the current run condition,
service changes.

Commits (see message for more details)
 - Add ConditionConfig interface and ServicesConditionConfig{} (default)
 - Add CatalogServicesConditionConfig{}
 - Update TaskConfig with new Condition field
 - Update configuration decoding to support ConditionConfig