### PR TITLE
Increase wait time on E2E test on restarting Consul

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -116,7 +116,8 @@ func TestE2ERestartConsul(t *testing.T) {
 	// start CTS
 	stop := testutils.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(5 * time.Second)
+	// wait enough for cts to cycle through once-mode successfully
+	time.Sleep(12 * time.Second)
 
 	// stop Consul
 	consul.Stop()


### PR DESCRIPTION
Recently the `TestE2ERestartConsul` has been intermittently failing ([ex](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/876/workflows/714e38e5-7551-4243-9f14-6a86027a2d92/jobs/1719)). Replicating
locally, failures seems to be consistently caused by a connection-refused error
when CTS tries to create a terraform workspace for the task (truncated):

```
[INFO] running Terraform command: terraform workspace new -no-color e2e_task_api_db
Failed to get configured named states: Get "https://127.0.0.1:47503/v1/kv/consul-terraform-sync/terraform-env:?keys=&separator=%2F": dial tcp 127.0.0.1:47503: connect: connection refused
[ERR] (client.terraformcli) unable to create workspace: "e2e_task_api_db"
[ERR] (driver.terraform) error initializing workspace, skipping apply for 'e2e_task_api_db'
[ERR] (cli) error running controller in Once mode: could not apply changes for task e2e_task_api_db: error tf-init for 'e2e_task_api_db': exit status 1
```

In the e2e test, the Consul server was stopped ~5 seconds after CTS started.
Since CTS had not yet successfully finished once-mode, it hit a connection-
refused error. This then caused CTS to exit and subsequent checks for successful
Consul re-registration to fail.

While testing locally, CTS completed once-mode in 4-7 seconds - hence occasional
errors when Consul stopped after 5 seconds.

Change:
 - Increase Consul to wait 12 seconds (7 seconds + decent buffer since circle
 machine will vary)