### PR TITLE
Update e2e tests to poll API availability

### DIFF
--- a/api/client_test.go
+++ b/api/client_test.go
@@ -125,9 +125,10 @@ func TestStatus(t *testing.T) {
 	defer cancel()
 	api := NewAPI(store, drivers, port)
 	go api.Serve(ctx)
-	time.Sleep(3 * time.Second) // in case tests run before server is ready
 
 	c := NewClient(&ClientConfig{Port: port}, nil)
+	err = c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
+	require.NoError(t, err)
 
 	t.Run("overall-status", func(t *testing.T) {
 		actual, err := c.Status().Overall()
@@ -279,9 +280,10 @@ func Test_Task_Update(t *testing.T) {
 	drivers := driver.NewDrivers()
 	api := NewAPI(event.NewStore(), drivers, port)
 	go api.Serve(ctx)
-	time.Sleep(3 * time.Second) // in case tests run before server is ready
 
 	c := NewClient(&ClientConfig{Port: port}, nil)
+	err = c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
+	require.NoError(t, err)
 
 	t.Run("disable-then-enable", func(t *testing.T) {
 		// setup temp dir
@@ -330,5 +332,30 @@ func Test_Task_Update(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedPlan, *actual.Inspect)
+	})
+}
+
+func TestWaitForAPI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("timeout", func(t *testing.T) {
+		cts := NewClient(&ClientConfig{Port: 0}, nil)
+		err := cts.WaitForAPI(time.Second)
+		assert.Error(t, err, "No CTS API server running, test is expected to timeout")
+	})
+
+	t.Run("available", func(t *testing.T) {
+		// start up server
+		port, err := FreePort()
+		require.NoError(t, err)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		drivers := driver.NewDrivers()
+		api := NewAPI(event.NewStore(), drivers, port)
+		go api.Serve(ctx)
+
+		cts := NewClient(&ClientConfig{Port: port}, nil)
+		err = cts.WaitForAPI(3 * time.Second)
+		assert.NoError(t, err, "CTS API server should be available")
 	})
 }

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
+	ctsTestClient "github.com/hashicorp/consul-terraform-sync/testutils/cts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,17 +30,14 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	port, err := api.FreePort()
-	require.NoError(t, err)
-
 	configPath := filepath.Join(tempDir, configFile)
-	config := fakeHandlerConfig().appendPort(port).
-		appendConsulBlock(srv).appendTerraformBlock(tempDir)
+	config := fakeHandlerConfig().appendConsulBlock(srv).appendTerraformBlock(tempDir)
 	config.write(t, configPath)
 
-	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	cts, stop := ctsTestClient.StartCTS(t, configPath, ctsTestClient.CTSDevModeFlag)
 	defer stop(t)
-	time.Sleep(5 * time.Second)
+	err := cts.WaitForAPI(5 * time.Second)
+	require.NoError(t, err)
 
 	cases := []struct {
 		name           string
@@ -59,12 +56,12 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 		},
 		{
 			"non-existing task",
-			[]string{fmt.Sprintf("-port=%d", port), "non-existent-task"},
+			[]string{fmt.Sprintf("-port=%d", cts.Port()), "non-existent-task"},
 			"does not exist or has not been initialized yet",
 		},
 		{
 			"out of order arguments",
-			[]string{fakeFailureTaskName, fmt.Sprintf("-port %d", port)},
+			[]string{fakeFailureTaskName, fmt.Sprintf("-port %d", cts.Port())},
 			"All flags are required to appear before positional arguments",
 		},
 	}
@@ -98,17 +95,14 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	port, err := api.FreePort()
-	require.NoError(t, err)
-
 	configPath := filepath.Join(tempDir, configFile)
-	config := disabledTaskConfig().appendPort(port).
-		appendConsulBlock(srv).appendTerraformBlock(tempDir)
+	config := disabledTaskConfig().appendConsulBlock(srv).appendTerraformBlock(tempDir)
 	config.write(t, configPath)
 
-	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	cts, stop := ctsTestClient.StartCTS(t, configPath, ctsTestClient.CTSDevModeFlag)
 	defer stop(t)
-	time.Sleep(5 * time.Second)
+	err := cts.WaitForAPI(5 * time.Second)
+	require.NoError(t, err)
 
 	cases := []struct {
 		name           string
@@ -118,13 +112,13 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 	}{
 		{
 			"happy path",
-			[]string{fmt.Sprintf("-port=%d", port), disabledTaskName},
+			[]string{fmt.Sprintf("-port=%d", cts.Port()), disabledTaskName},
 			"yes\n",
 			"enable complete!",
 		},
 		{
 			"user does not approve plan",
-			[]string{fmt.Sprintf("-port=%d", port), disabledTaskName},
+			[]string{fmt.Sprintf("-port=%d", cts.Port()), disabledTaskName},
 			"no\n",
 			"Cancelled enabling task",
 		},
@@ -162,17 +156,15 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	delete := testutils.MakeTempDir(t, tempDir)
 	// no defer to delete directory: only delete at end of test if no errors
 
-	port, err := api.FreePort()
-	require.NoError(t, err)
-
 	configPath := filepath.Join(tempDir, configFile)
-	config := baseConfig().appendPort(port).appendTerraformBlock(tempDir).
+	config := baseConfig().appendTerraformBlock(tempDir).
 		appendConsulBlock(srv).appendDBTask()
 	config.write(t, configPath)
 
-	stop := testutils.StartCTS(t, configPath, testutils.CTSDevModeFlag)
+	cts, stop := ctsTestClient.StartCTS(t, configPath, ctsTestClient.CTSDevModeFlag)
 	defer stop(t)
-	time.Sleep(5 * time.Second)
+	err := cts.WaitForAPI(10 * time.Second)
+	require.NoError(t, err)
 
 	cases := []struct {
 		name           string
@@ -181,7 +173,7 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	}{
 		{
 			"happy path",
-			[]string{fmt.Sprintf("-port=%d", port), dbTaskName},
+			[]string{fmt.Sprintf("-port=%d", cts.Port()), dbTaskName},
 			"disable complete!",
 		},
 		{

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
+	ctsTestClient "github.com/hashicorp/consul-terraform-sync/testutils/cts"
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-getter"
 	"github.com/stretchr/testify/assert"
@@ -101,9 +102,10 @@ func testConsulBackendCompatibility(t *testing.T, port int) {
 	configPath := filepath.Join(tempDir, configFile)
 	testutils.WriteFile(t, configPath, config)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(6 * time.Second)
+	err := cts.WaitForAPI(15 * time.Second)
+	require.NoError(t, err)
 
 	// Test: ConsulKV backend
 	// Register a service and confirm that TF state file is stored in ConsulKV
@@ -126,9 +128,10 @@ func testServiceInstanceCompatibility(t *testing.T, port int) {
 	configPath := filepath.Join(tempDir, configFile)
 	testutils.WriteFile(t, configPath, config)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(6 * time.Second)
+	err := cts.WaitForAPI(15 * time.Second)
+	require.NoError(t, err)
 
 	// Test adding and removing service instances
 	// 0. Confirm no resources created yet
@@ -182,9 +185,10 @@ func testServiceValuesCompatibility(t *testing.T, port int) {
 	configPath := filepath.Join(tempDir, configFile)
 	testutils.WriteFile(t, configPath, config)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(6 * time.Second)
+	err := cts.WaitForAPI(15 * time.Second)
+	require.NoError(t, err)
 
 	// Test updating service-related values
 	// 0. Confirm no services exist in terraform.tfvars
@@ -285,9 +289,10 @@ func testTagQueryCompatibility(t *testing.T, port int) {
 	configPath := filepath.Join(tempDir, configFile)
 	testutils.WriteFile(t, configPath, config)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(6 * time.Second)
+	err := cts.WaitForAPI(15 * time.Second)
+	require.NoError(t, err)
 
 	// Test that filtering by tags
 	// 0. Confirm no resources created yet
@@ -326,9 +331,10 @@ func testNodeValuesCompatibility(t *testing.T, port int) {
 	configPath := filepath.Join(tempDir, configFile)
 	testutils.WriteFile(t, configPath, config)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
-	time.Sleep(6 * time.Second)
+	err := cts.WaitForAPI(15 * time.Second)
+	require.NoError(t, err)
 
 	// Test updating node-related values
 	// 0. Confirm no services exist in terraform.tfvars

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -92,9 +92,6 @@ task {
 func baseConfig() hclConfig {
 	return `log_level = "INFO"
 
-# port 0 will automatically select next free port
-port = 0
-
 service {
   name = "api"
   description = "backend"

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -11,8 +11,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/testutils"
+	ctsTestClient "github.com/hashicorp/consul-terraform-sync/testutils/cts"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestTasksUpdate tests multiple tasks are triggered on service registration
@@ -43,12 +45,13 @@ task {
 		appendDBTask().appendWebTask().appendString(apiTask)
 	config.write(t, configPath)
 
-	stop := testutils.StartCTS(t, configPath)
+	cts, stop := ctsTestClient.StartCTS(t, configPath)
 	defer stop(t)
 
 	t.Run("once mode", func(t *testing.T) {
 		// Wait for tasks to execute once
-		time.Sleep(15 * time.Second)
+		err := cts.WaitForAPI(15 * time.Second)
+		require.NoError(t, err)
 
 		// Verify Catalog information is reflected in terraform.tfvars
 		expectedTaskServices := map[string][]string{


### PR DESCRIPTION
Flakey tests due to sleep times had us increasing them every so often. It seems sensitive to the load of the machine and changes to the underlying CTS logic. The new CTS client method allows the test to configure the max timeout
waiting for the API to start up and not have to wait the full duration. The API availability determines that CTS has completed executing the tasks once through successfully.

Reduces the e2e CI job from 2m to 1m32s