### PR TITLE
all but last consul retry log set to DEBUG level

### DIFF
--- a/controller/watcher.go
+++ b/controller/watcher.go
@@ -73,7 +73,7 @@ func retryConsul(retryCount int) (bool, time.Duration) {
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 	wait := retry.WaitTime(uint(retryCount), random)
 	dur := time.Duration(wait)
-	log.Printf("[WARN] (hcat) error connecting with Consul. Waiting %v to retry"+
+	log.Printf("[DEBUG] (hcat) error connecting with Consul. Waiting %v to retry"+
 		" attempt #%d", dur, retryCount+1)
 	return true, dur
 }


### PR DESCRIPTION
Consul's retries were logging every retry for every watched field. It
was very verbose. This quiets it down by changing all the retry logs to
DEBUG level except for the last one which is (unchanged from) ERR level.

Fixes #260