### PR TITLE
fix inspect mode log output

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -197,6 +197,15 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 		}
 	}
 
+	switch {
+	case isInspect:
+		log.Printf("[INFO] (cli) running controller in inspect mode")
+	case isOnce:
+		log.Printf("[INFO] (cli) running controller in once mode")
+	default:
+		log.Printf("[INFO] (cli) running controller in daemon mode")
+	}
+
 	// Set up controller
 	conf.ClientType = config.String(clientType)
 	store := event.NewStore()
@@ -232,9 +241,6 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 			return
 		}
 
-		if isOnce {
-			log.Printf("[INFO] (cli) running controller in Once mode")
-		}
 		switch c := ctrl.(type) {
 		case controller.Oncer:
 			if err := c.Once(ctx); err != nil {
@@ -268,7 +274,6 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 			}
 		}()
 
-		log.Printf("[INFO] (cli) running controller in daemon mode")
 		if err := ctrl.Run(ctx); err != nil {
 			if err == context.Canceled {
 				exitCh <- struct{}{}


### PR DESCRIPTION
Inspect mode was being logged as daemon mode. In report it was requested
to be reported as inspect mode, so went with that.

This also collects the log output line for each mode into 1 place. To
make it easier to find and more consistency in when mode log line is output.

Fixes #211 