### PR TITLE
Update tfvars map to use "key = value"

### DIFF
--- a/examples/sync-tasks/my-task/terraform.tfvars
+++ b/examples/sync-tasks/my-task/terraform.tfvars
@@ -8,7 +8,7 @@
 # Description: automate services for website X
 
 services = {
-  "api.worker-01.dc1" : {
+  "api.worker-01.dc1" = {
     id              = "api"
     name            = "api"
     kind            = ""
@@ -33,7 +33,7 @@ services = {
     }
     cts_user_defined_meta = {}
   },
-  "web.worker-01.dc1" : {
+  "web.worker-01.dc1" = {
     id              = "web"
     name            = "web"
     kind            = ""

--- a/examples/sync-tasks/my-task/terraform.tfvars.tmpl
+++ b/examples/sync-tasks/my-task/terraform.tfvars.tmpl
@@ -10,14 +10,14 @@
 services = {
 {{- with $srv := service "api"}}
   {{- range $s := $srv}}
-  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
 {{ HCLService $s | indent 4 }}
   },
   {{- end}}
 {{- end}}
 {{- with $srv := service "web"}}
   {{- range $s := $srv}}
-  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
 {{ HCLService $s | indent 4 }}
   },
   {{- end}}

--- a/templates/tftmpl/testdata/only_api_service.tfvars
+++ b/templates/tftmpl/testdata/only_api_service.tfvars
@@ -8,7 +8,7 @@
 # Description: user description for task named 'test'
 
 services = {
-  "api.worker-01.dc1" : {
+  "api.worker-01.dc1" = {
     id              = "api"
     name            = "api"
     kind            = ""
@@ -33,7 +33,7 @@ services = {
     }
     cts_user_defined_meta = {}
   },
-  "api-2.worker-01.dc1" : {
+  "api-2.worker-01.dc1" = {
     id              = "api-2"
     name            = "api"
     kind            = ""
@@ -58,7 +58,7 @@ services = {
     }
     cts_user_defined_meta = {}
   },
-  "api.worker-02.dc1" : {
+  "api.worker-02.dc1" = {
     id              = "api"
     name            = "api"
     kind            = ""

--- a/templates/tftmpl/testdata/only_web_service.tfvars
+++ b/templates/tftmpl/testdata/only_web_service.tfvars
@@ -8,7 +8,7 @@
 # Description: user description for task named 'test'
 
 services = {
-  "web.worker-01.dc1" : {
+  "web.worker-01.dc1" = {
     id              = "web"
     name            = "web"
     kind            = ""

--- a/templates/tftmpl/testdata/terraform.tfvars
+++ b/templates/tftmpl/testdata/terraform.tfvars
@@ -8,7 +8,7 @@
 # Description: user description for task named 'test'
 
 services = {
-  "api.worker-01.dc1" : {
+  "api.worker-01.dc1" = {
     id              = "api"
     name            = "api"
     kind            = ""
@@ -33,7 +33,7 @@ services = {
     }
     cts_user_defined_meta = {}
   },
-  "api-2.worker-01.dc1" : {
+  "api-2.worker-01.dc1" = {
     id              = "api-2"
     name            = "api"
     kind            = ""
@@ -58,7 +58,7 @@ services = {
     }
     cts_user_defined_meta = {}
   },
-  "web.worker-01.dc1" : {
+  "web.worker-01.dc1" = {
     id              = "web"
     name            = "web"
     kind            = ""

--- a/templates/tftmpl/testdata/terraform.tfvars.tmpl
+++ b/templates/tftmpl/testdata/terraform.tfvars.tmpl
@@ -10,14 +10,14 @@
 services = {
 {{- with $srv := service "api" "dc=dc1" "\"tag\" in Service.Tags" }}
   {{- range $s := $srv}}
-  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
 {{ HCLService $s | indent 4 }}
   },
   {{- end}}
 {{- end}}
 {{- with $srv := service "web" }}
   {{- range $s := $srv}}
-  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
 {{ HCLService $s | indent 4 }}
   },
   {{- end}}

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -163,7 +163,7 @@ func nonNullMap(m map[string]string) map[string]string {
 const serviceBaseTmpl = `
 {{- with $srv := service %s }}
   {{- range $s := $srv}}
-  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" : {
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
 {{ HCLService $s | indent 4 }}
   },
   {{- end}}


### PR DESCRIPTION
This updates the CTS generated Terraform variables to use the suggested format from the documentation instead of `key : value`. No breaking change, but all generated templates and tfvars will be re-rendered with `=` now.

https://www.terraform.io/docs/language/expressions/types.html#maps-objects

> Maps/objects are represented by a pair of curly braces containing a series of `<KEY> = <VALUE>` pairs:
```hcl
services = {
  "api.worker-01.dc1" = { }
}
```