### PR TITLE
Update fallback Terraform version from 0.13.5 to 0.13.7

### DIFF
--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-exec/tfinstall"
 )
 
-const fallbackTFVersion = "0.13.5"
+const fallbackTFVersion = "0.13.7"
 
 // TerraformVersion is the version of Terraform CLI for the Terraform driver.
 var TerraformVersion *goVersion.Version


### PR DESCRIPTION
Terraform 0.13.7 was just released with the rotated HashiCorp GPG signing key
used for provider package verification ([HCSEC-2021-12](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512)). Update CTS's fallback 
version of Terraform to this release.