### PR TITLE
Add support for Terraform v0.15

### DIFF
--- a/examples/sync-tasks/my-task/main.tf
+++ b/examples/sync-tasks/my-task/main.tf
@@ -8,7 +8,7 @@
 # Description: automate services for website X
 
 terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   required_providers {
     myprovider = {
       source  = "namespace/myprovider"

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -31,14 +31,14 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"nil",
 			nil,
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
 }
 `,
 		}, {
 			"empty",
 			map[string]interface{}{"empty": map[string]interface{}{}},
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   backend "empty" {
   }
 }
@@ -47,7 +47,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"invalid structure",
 			map[string]interface{}{"invalid": "unexpected type"},
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
 }
 `,
 		}, {
@@ -56,7 +56,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"path": "relative/path/to/terraform.tfstate",
 			}},
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   backend "local" {
     path = "relative/path/to/terraform.tfstate"
   }
@@ -66,7 +66,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"consul",
 			consulBackend,
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   backend "consul" {
     address   = "consul.example.com"
     ca_file   = "ca_cert"
@@ -84,7 +84,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"conn_str": "postgres://user:pass@db.example.com/terraform_backend",
 			}},
 			`terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   backend "pg" {
     conn_str = "postgres://user:pass@db.example.com/terraform_backend"
   }

--- a/templates/tftmpl/testdata/catalog-services-condition/main_include.tf
+++ b/templates/tftmpl/testdata/catalog-services-condition/main_include.tf
@@ -8,7 +8,7 @@
 # Description: user description for task named 'test'
 
 terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
 }
 
 

--- a/templates/tftmpl/testdata/main.tf
+++ b/templates/tftmpl/testdata/main.tf
@@ -8,7 +8,7 @@
 # Description: user description for task named 'test'
 
 terraform {
-  required_version = ">= 0.13.0, < 0.15"
+  required_version = ">= 0.13.0, < 0.16"
   required_providers {
     testProvider = {
       source  = "namespace/testProvider"

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -13,7 +13,7 @@ import (
 // account for. The upper bound may be removed once CTS has protocols
 // set in place for compatible modules and can handle Terraform syntax changes
 // and enhancements between versions.
-const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 0.15"
+const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 0.16"
 
 // TerraformConstraint is the go-version constraint variable for
 // CompatibleTerraformVersionConstraint

--- a/version/terraform_test.go
+++ b/version/terraform_test.go
@@ -22,12 +22,16 @@ func TestTerraformConstraint(t *testing.T) {
 			"0.14.1",
 			true,
 		}, {
+			"valid 0.15",
+			"0.15.0",
+			true,
+		}, {
 			"invalid lower bound",
 			"0.12.12",
 			false,
 		}, {
 			"invalid upper bound",
-			"0.15.2",
+			"0.16.2",
 			false,
 		}, {
 			"unsupported beta release",


### PR DESCRIPTION
CTS v0.2.0 supports the newly released Terraform v0.15. Users now have the option to [configure CTS to download and use Terraform v0.15](https://www.consul.io/docs/nia/configuration#version-1). Please note that there are a couple breaking changes with Terraform v0.15 to consider before upgrading to v0.15.

Module authors: We identified two breaking changes in v0.15 that may impact your module. Please update your module if it uses the below removed features or update your module’s documented Terraform compatibility to be <0.15

- `list` and `map` functions were deprecated in v0.12 and removed in v0.15. Please replace these with the `tolist([...])` and `tomap({...})` functions respectively. (https://github.com/hashicorp/terraform/issues/26818)
- Declaring variables with quoted type strings was deprecated previously and will error in v0.15. Please replace these with types e.g. use `map(string)` instead of `"map"`. (https://github.com/hashicorp/terraform/issues/27852)


Operators configuring and running CTS:

- Please confirm that the modules configured at the CTS task source are v0.15 compatible. See above bullets to understand how a module may not be v0.15 compatible.
- If you have configured Google Cloud Storage (gcs) as your [Terraform backend](https://www.consul.io/docs/nia/configuration#backend), the `path` config was deprecated in v0.11 and removed in v0.15. Please use the `prefix` config instead. (https://github.com/hashicorp/terraform/issues/26841)
- Terraform has made some updates when running on Windows that do not present any technical hurdles preventing users from running Terraform (and therefore CTS) on earlier versions of Windows. However, we strongly encourage migrating to a newer version of Windows since the Terraform team will only test future releases on up-to-date Windows 10 and make no guarantees on supporting older versions.

For more details on the upgrade notes summarized above, please see the [Terraform 0.15 upgrade notes](https://github.com/hashicorp/terraform/blob/v0.15/website/upgrade-guides/0-15.html.markdown).