### PR TITLE
Update expected relative path of task source for local modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 terraform
 vendor/
 examples/runnable-example/sync-tasks
+e2e/tmp_*
+e2e/benchmarks/sync-tasks
 
 # ignore builds
 /pkg

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -194,7 +194,7 @@ func TestJsonResponse(t *testing.T) {
 							Config: &event.Config{
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
-								Source:    "../../test_modules/e2e_basic_task",
+								Source:    "./test_modules/e2e_basic_task",
 							},
 						},
 						event.Event{
@@ -209,7 +209,7 @@ func TestJsonResponse(t *testing.T) {
 							Config: &event.Config{
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
-								Source:    "../../test_modules/e2e_basic_task",
+								Source:    "./test_modules/e2e_basic_task",
 							},
 						},
 					},

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -348,7 +348,7 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 		require.NotNil(t, e.Config)
 		assert.Equal(t, []string{"fake-sync"}, e.Config.Providers)
 		assert.Equal(t, []string{"api"}, e.Config.Services)
-		assert.Equal(t, "../../test_modules/e2e_basic_task", e.Config.Source)
+		assert.Equal(t, "./test_modules/e2e_basic_task", e.Config.Source)
 
 		if taskName == fakeSuccessTaskName {
 			assert.True(t, e.Success)

--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -157,7 +157,7 @@ terraform_provider "local" {}
 
 task {
   name = "test-services-task"
-  source = "../../../test_modules/null_resource"
+  source = "../test_modules/null_resource"
   providers = ["local"]
   services = %s
 }

--- a/e2e/benchmarks/tasks_test.go
+++ b/e2e/benchmarks/tasks_test.go
@@ -104,7 +104,7 @@ func generateConf(bConf benchmarkConfig) *config.Config {
 	for i := 0; i < bConf.numTasks; i++ {
 		taskConfigs[i] = &config.TaskConfig{
 			Name:     config.String(fmt.Sprintf("task_%03d", i)),
-			Source:   config.String("../../../test_modules/local_file"),
+			Source:   config.String("../test_modules/local_file"),
 			Services: serviceNames,
 		}
 	}

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -536,7 +536,7 @@ task {
 	description = "null task for api & db"
 	services = ["api", "db"]
 	providers = ["null"]
-	source = "../../../test_modules/null_resource"
+	source = "../test_modules/null_resource"
 }
 `, nullTaskName)
 }
@@ -549,7 +549,7 @@ task {
 	description = "basic task"
 	services = ["%s", "%s"]
 	providers = ["local"]
-	source = "../../../test_modules/e2e_basic_task"
+	source = "../test_modules/e2e_basic_task"
 }
 `, taskName, service1, service2)
 }

--- a/e2e/condition_test.go
+++ b/e2e/condition_test.go
@@ -36,7 +36,7 @@ func TestCondition_CatalogServices_Include(t *testing.T) {
 	conditionTask := `task {
 	name = "catalog_task"
 	services = ["api"]
-	source = "../../test_modules/local_tags_file"
+	source = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "db|web"
 		source_includes_var = true
@@ -86,7 +86,7 @@ func TestCondition_CatalogServices_Regexp(t *testing.T) {
 	conditionTask := fmt.Sprintf(`task {
 	name = "%s"
 	services = ["unrelated"]
-	source = "../../test_modules/local_tags_file"
+	source = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "api-"
 		source_includes_var = true
@@ -187,7 +187,7 @@ func TestCondition_CatalogServices_NodeMeta(t *testing.T) {
 	conditionTask := fmt.Sprintf(`task {
 	name = "%s"
 	services = ["unrelated"]
-	source = "../../test_modules/local_tags_file"
+	source = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "api"
 		node_meta {

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -72,7 +72,7 @@ task {
 	description = "basic read-write e2e task for api & db"
 	services = ["api", "db"]
 	providers = ["local"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 `, dbTaskName))
 }
@@ -84,7 +84,7 @@ task {
 	description = "basic read-write e2e task api & web"
 	services = ["api", "web"]
 	providers = ["local"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 `, webTaskName))
 }
@@ -133,7 +133,7 @@ task {
 	description = "basic e2e task with fake handler. expected to error"
 	services = ["api"]
 	providers = ["fake-sync.failure"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 
 task {
@@ -141,7 +141,7 @@ task {
 	description = "basic e2e task with fake handler. expected to not error"
 	services = ["api"]
 	providers = ["fake-sync.success"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 
 task {
@@ -150,7 +150,7 @@ task {
 	enabled = false
 	services = ["api"]
 	providers = ["fake-sync.success"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 `, fakeFailureTaskName, fakeSuccessTaskName, disabledTaskName))
 }
@@ -164,7 +164,7 @@ task {
 	enabled = false
 	services = ["api"]
 	providers = ["local"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 
 service {

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -49,7 +49,7 @@ func TestServicesRenderRace(t *testing.T) {
 	conf.Tasks = &config.TaskConfigs{
 		&config.TaskConfig{
 			Name:     config.String("serv_rend_race_task"),
-			Source:   config.String("../../test_modules/null_resource"),
+			Source:   config.String("./test_modules/null_resource"),
 			Services: serviceNames,
 		}}
 	conf.Consul.Address = config.String(srv.HTTPAddr)

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -36,7 +36,7 @@ task {
 	description = "basic read-write e2e task api only"
 	services = ["api"]
 	providers = ["local"]
-	source = "../../test_modules/e2e_basic_task"
+	source = "./test_modules/e2e_basic_task"
 }
 `, apiTaskName)
 	configPath := filepath.Join(tempDir, configFile)

--- a/examples/runnable-example/config.hcl
+++ b/examples/runnable-example/config.hcl
@@ -7,7 +7,7 @@ consul {
 task {
   name = "example-task"
   description = "Writes the service name, id, and IP address to a file"
-  source = "../../example-module"
+  source = "./example-module"
   providers = ["local"]
   services = ["web", "api"]
   variable_files = []

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -334,7 +334,19 @@ func appendRootModuleBlock(body *hclwrite.Body, task Task, cond Condition,
 
 	moduleBlock := body.AppendNewBlock("module", []string{task.Name})
 	moduleBody := moduleBlock.Body()
-	moduleBody.SetAttributeValue("source", cty.StringVal(task.Source))
+
+	moduleSource := task.Source
+	if strings.HasPrefix(moduleSource, "./") || strings.HasPrefix(moduleSource, "../") {
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Println("[ERR] (templates.tftmpl) unable to retrieve current " +
+				"working directory to determine path to local module")
+			log.Panic(err)
+		}
+		moduleSource = filepath.Join(wd, task.Source)
+	}
+	moduleBody.SetAttributeValue("source", cty.StringVal(moduleSource))
+
 	if len(task.Version) > 0 {
 		moduleBody.SetAttributeValue("version", cty.StringVal(task.Version))
 	}

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -175,7 +175,7 @@ func TestAppendRootProviderBlocks(t *testing.T) {
 
 func TestAppendRootModuleBlocks(t *testing.T) {
 	workingDir, err := os.Getwd()
-	assert.Nil(t, err, "Error determining current working directory")
+	require.Nil(t, err, "Error determining current working directory")
 	wdParent := filepath.Dir(workingDir)
 
 	testCases := []struct {


### PR DESCRIPTION
**Breaking Change:**
When using a local module for a task, the relative path provided as the source is now based on the working directory of CTS. Previously, the path was based on the task directory (e.g., `sync-tasks/<task-name>`).

Operators with tasks that use local modules will need to update the task's source variable. For example, when running CTS with the following directory structure:
```
.
| -- config.hcl
| -- my-local-module/
| -- sync-tasks/example-task  
```
Previous to this change, the source would have been specified as follows:
```hcl
task {
  name = "example-task"
  description = "this task prints output and creates files with content"
  source = "../../my-local-module"
  services = ["api", "web"]
}
```
With this change, the source needs to be updated to:
```hcl
task {
  name = "example-task"
  description = "this task prints output and creates files with content"
  source = "./my-local-module"
  services = ["api", "web"]
}
```


Closes https://github.com/hashicorp/consul-terraform-sync/issues/264