### PR TITLE
Catalog service registration notifier to suppress non-registration changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-integration:
 # test-e2e runs e2e tests
 test-e2e: dev
 	@echo "==> Testing ${NAME} (e2e)"
-	@go test ./e2e -count=1 -timeout=80s -tags=e2e -v ./... ${TESTARGS}
+	@go test ./e2e -count=1 -timeout=100s -tags=e2e -v ./... ${TESTARGS}
 .PHONY: test-e2e
 
 # test-setup-e2e sets up the sync binary and permissions to run in circle

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
+	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl/notifier"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl/tmplfunc"
 	"github.com/hashicorp/hcat"
 	"github.com/pkg/errors"
@@ -529,11 +530,17 @@ func (tf *Terraform) initTaskTemplate() error {
 		Perms: filePerms,
 	})
 
-	tf.template = hcat.NewTemplate(hcat.TemplateInput{
+	tmpl := hcat.NewTemplate(hcat.TemplateInput{
 		Contents:     string(content),
 		Renderer:     renderer,
 		FuncMapMerge: tmplfunc.HCLMap(tf.task.UserDefinedMeta),
 	})
+	switch tf.task.Condition.(type) {
+	case *config.CatalogServicesConditionConfig:
+		tf.template = &notifier.CatalogServicesRegistration{Template: tmpl}
+	default:
+		tf.template = tmpl
+	}
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/hashicorp/go-tfe v0.12.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20210430144333-5970348d8f49
+	github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210430144333-5970348d8f49 h1:f1keHn7rvW3hUECpWG5M9S06utu9x0c52o2H+ETHYyA=
-github.com/hashicorp/hcat v0.0.0-20210430144333-5970348d8f49/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586 h1:vXRdAjmBKNGs5rBi6yKB+jNONSpuqI1fjDwburKjPzk=
+github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/mocks/templates/template.go
+++ b/mocks/templates/template.go
@@ -13,11 +13,11 @@ type Template struct {
 }
 
 // Execute provides a mock function with given fields: _a0
-func (_m *Template) Execute(_a0 hcat.Watcherer) ([]byte, error) {
+func (_m *Template) Execute(_a0 hcat.Recaller) ([]byte, error) {
 	ret := _m.Called(_a0)
 
 	var r0 []byte
-	if rf, ok := ret.Get(0).(func(hcat.Watcherer) []byte); ok {
+	if rf, ok := ret.Get(0).(func(hcat.Recaller) []byte); ok {
 		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
@@ -26,7 +26,7 @@ func (_m *Template) Execute(_a0 hcat.Watcherer) ([]byte, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(hcat.Watcherer) error); ok {
+	if rf, ok := ret.Get(1).(func(hcat.Recaller) error); ok {
 		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
@@ -44,6 +44,20 @@ func (_m *Template) ID() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// Notify provides a mock function with given fields: _a0
+func (_m *Template) Notify(_a0 interface{}) bool {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(interface{}) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -23,8 +23,9 @@ const DepSizeWarning = 128
 // which implements the interfaces Templater and Renderer
 // https://github.com/hashicorp/hcat
 type Template interface {
+	Notify(interface{}) bool
 	Render(content []byte) (hcat.RenderResult, error)
-	Execute(hcat.Watcherer) ([]byte, error)
+	Execute(hcat.Recaller) ([]byte, error)
 	ID() string
 }
 

--- a/templates/tftmpl/notifier/notifier.go
+++ b/templates/tftmpl/notifier/notifier.go
@@ -1,0 +1,59 @@
+package notifier
+
+import (
+	"github.com/hashicorp/consul-terraform-sync/templates"
+	"github.com/hashicorp/hcat/dep"
+)
+
+// CatalogServicesRegistration is a custom notifier expected to be used
+// for a template that contains catalogServicesRegistration template function
+// (tmplfunc) and any other tmplfuncs e.g. services tmplfunc.
+//
+// This notifier only notifies on changes to Catalog Services registration
+// information and once-mode. It suppresses notifications for changes to other
+// tmplfuncs and changes to Catalog Services tag data.
+type CatalogServicesRegistration struct {
+	templates.Template
+	once     bool
+	services []string
+}
+
+// Notify notifies when Catalog Services registration changes
+func (n *CatalogServicesRegistration) Notify(d interface{}) (notify bool) {
+	if v, ok := d.([]*dep.CatalogSnippet); ok {
+		if n.registrationChange(v) {
+			n.Template.Notify(d)
+			return true
+		}
+	}
+	return false
+}
+
+// registrationChange determines whether or not the latest Catalog Service
+// changes are registration changes i.e. we want to ignore tag changes.
+// Note: this can cause once-mode to hang if there are no registration changes,
+// so return true for this edge-case
+func (n *CatalogServicesRegistration) registrationChange(new []*dep.CatalogSnippet) bool {
+	newServices := make([]string, len(new))
+	for ix, s := range new {
+		newServices[ix] = s.Name
+	}
+	defer func() { n.services = newServices }()
+
+	// first time through should notify (once-mode)
+	if !n.once {
+		n.once = true
+		return true
+	}
+
+	// change in list of service names should notify
+	if len(n.services) != len(newServices) {
+		return true
+	}
+	for i, v := range n.services {
+		if v != newServices[i] {
+			return true
+		}
+	}
+	return false
+}

--- a/templates/tftmpl/notifier/notifier_test.go
+++ b/templates/tftmpl/notifier/notifier_test.go
@@ -1,0 +1,108 @@
+package notifier
+
+import (
+	"testing"
+
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
+	"github.com/hashicorp/hcat/dep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_CatalogServicesRegistration_Notify(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		dep      interface{}
+		expected bool
+	}{
+		{
+			"don't notify: other type of change",
+			[]*dep.HealthService{},
+			false,
+		},
+		{
+			"don't notify: no change in services",
+			[]*dep.CatalogSnippet{},
+			false,
+		},
+		{
+			"notify: new service registration",
+			[]*dep.CatalogSnippet{{Name: "api"}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := new(mocks.Template)
+			tmpl.On("Notify", mock.Anything).Return(true)
+
+			n := CatalogServicesRegistration{Template: tmpl, once: true}
+			actual := n.Notify(tc.dep)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func Test_CatalogServicesRegistration_registrationChange(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		notifier *CatalogServicesRegistration
+		data     []*dep.CatalogSnippet
+		expected bool
+	}{
+		{
+			"change: once-mode",
+			&CatalogServicesRegistration{
+				once:     false,
+				services: []string{},
+			},
+			[]*dep.CatalogSnippet{},
+			true,
+		},
+		{
+			"change: different number of services",
+			&CatalogServicesRegistration{
+				once:     true,
+				services: []string{"api", "db"},
+			},
+			[]*dep.CatalogSnippet{{Name: "db"}},
+			true,
+		},
+		{
+			"change: same number but different services",
+			&CatalogServicesRegistration{
+				once:     true,
+				services: []string{"api", "db"},
+			},
+			[]*dep.CatalogSnippet{{Name: "redis"}, {Name: "web"}},
+			true,
+		},
+		{
+			"no change",
+			&CatalogServicesRegistration{
+				once:     true,
+				services: []string{"api", "db"},
+			},
+			[]*dep.CatalogSnippet{{Name: "api"}, {Name: "db"}},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.notifier.registrationChange(tc.data)
+			assert.Equal(t, tc.expected, actual)
+
+			services := make([]string, len(tc.data))
+			for ix, s := range tc.data {
+				services[ix] = s.Name
+			}
+			assert.Equal(t, tc.notifier.services, services)
+		})
+	}
+}


### PR DESCRIPTION
For the catalog-services condition, we only want service [de]registration
changes to trigger tasks. Currently health services changes and catalog service
tag changes can additionally trigger tasks.

Commits:
 - Pull latest hcat Notify() which will allow CTS to write custom notifications
 - Add new notifier for catalog-services condition that will only notify (and
 therefore only trigger) on service [de]registration
 - Increase e2e timeout