### PR TITLE
Support relative paths for task variable files

### DIFF
--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -80,19 +79,19 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 	}
 
 	// Expand any relative paths for variable files to absolute paths
-	var varFiles []string
+	varFiles := make([]string, 0, len(config.VarFiles))
 	for _, vf := range config.VarFiles {
-		if !strings.HasPrefix(vf, "/") {
+		if !filepath.IsAbs(vf) {
 			wd, err := os.Getwd()
 			if err != nil {
 				log.Println("[ERR] (client.terraformcli) unable to retrieve current " +
 					"working directory to determine path to variable files")
-				log.Panic(err)
+				return nil, err
 			}
 			vfAbs := filepath.Join(wd, vf)
 			varFiles = append(varFiles, vfAbs)
 		} else {
-			varFiles = append(varFiles, vf)
+			varFiles = append(varFiles, filepath.Clean(vf))
 		}
 	}
 

--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -77,11 +79,28 @@ func NewTerraformCLI(config *TerraformCLIConfig) (*TerraformCLI, error) {
 		log.Printf("[INFO] (client.terraformcli) persiting Terraform logs on disk: %s", logPath)
 	}
 
+	// Expand any relative paths for variable files to absolute paths
+	var varFiles []string
+	for _, vf := range config.VarFiles {
+		if !strings.HasPrefix(vf, "/") {
+			wd, err := os.Getwd()
+			if err != nil {
+				log.Println("[ERR] (client.terraformcli) unable to retrieve current " +
+					"working directory to determine path to variable files")
+				log.Panic(err)
+			}
+			vfAbs := filepath.Join(wd, vf)
+			varFiles = append(varFiles, vfAbs)
+		} else {
+			varFiles = append(varFiles, vf)
+		}
+	}
+
 	client := &TerraformCLI{
 		tf:         tf,
 		workingDir: config.WorkingDir,
 		workspace:  config.Workspace,
-		varFiles:   config.VarFiles,
+		varFiles:   varFiles,
 	}
 	log.Printf("[TRACE] (client.terraformcli) created Terraform CLI client %s", client.GoString())
 

--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 	"errors"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
@@ -85,7 +85,7 @@ func TestNewTerraformCLI(t *testing.T) {
 				ExecPath:   "path/to/tf",
 				WorkingDir: "./",
 				Workspace:  "my-workspace",
-				VarFiles: []string{"variables.tf", "/path/to/variables.tf"},
+				VarFiles:   []string{"variables.tf", "/path/to/variables.tf"},
 			},
 		},
 	}
@@ -103,7 +103,7 @@ func TestNewTerraformCLI(t *testing.T) {
 			assert.NotNil(t, actual)
 
 			for _, vf := range actual.varFiles {
-				assert.True(t, strings.HasPrefix(vf, "/"))
+				assert.True(t, filepath.IsAbs(vf), "Expected absolute path for variable files")
 			}
 		})
 	}

--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
@@ -77,6 +78,16 @@ func TestNewTerraformCLI(t *testing.T) {
 				Workspace:  "my-workspace",
 			},
 		},
+		{
+			"variable files",
+			false,
+			&TerraformCLIConfig{
+				ExecPath:   "path/to/tf",
+				WorkingDir: "./",
+				Workspace:  "my-workspace",
+				VarFiles: []string{"variables.tf", "/path/to/variables.tf"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -90,6 +101,10 @@ func TestNewTerraformCLI(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.NotNil(t, actual)
+
+			for _, vf := range actual.varFiles {
+				assert.True(t, strings.HasPrefix(vf, "/"))
+			}
 		})
 	}
 }

--- a/examples/reference-example/example-config.hcl
+++ b/examples/reference-example/example-config.hcl
@@ -19,7 +19,7 @@ task {
   version = "1.0.0"
   providers = ["myprovider"]
   services = ["web", "api"]
-  variable_files = ["/path/to/example.module.tfvars"]
+  variable_files = ["example.module.tfvars", "/path/to/example.module.tfvars"]
 }
 
 driver "terraform" {


### PR DESCRIPTION
Expands relative paths to full paths for the task variable files 
to support both relative and full paths.

Closes https://github.com/hashicorp/consul-terraform-sync/issues/279
