### PR TITLE
Refactor driver.Task to be thread safe

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -64,11 +64,14 @@ func TestServe(t *testing.T) {
 	port, err := testutils.FreePort()
 	require.NoError(t, err)
 
+	task, err := driver.NewTask(driver.TaskConfig{Enabled: true})
+	require.NoError(t, err)
+
 	drivers := driver.NewDrivers()
 	d := new(mocks.Driver)
 	d.On("UpdateTask", mock.Anything, mock.Anything).
 		Return(driver.InspectPlan{}, nil).Once()
-	d.On("Task").Return(driver.Task{Enabled: true})
+	d.On("Task").Return(task)
 	drivers.Add("task_b", d)
 
 	api := NewAPI(event.NewStore(), drivers, port)

--- a/api/overall_status.go
+++ b/api/overall_status.go
@@ -80,7 +80,7 @@ func (h *overallStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			taskSummary.Status.Unknown++
 		}
 
-		if d.Task().Enabled {
+		if d.Task().IsEnabled() {
 			taskSummary.Enabled.True++
 		} else {
 			taskSummary.Enabled.False++

--- a/api/overall_status_test.go
+++ b/api/overall_status_test.go
@@ -74,11 +74,11 @@ func TestOverallStatus_ServeHTTP(t *testing.T) {
 
 	// set up driver
 	drivers := driver.NewDrivers()
-	drivers.Add("success_a", createDriver("success_a", true))
-	drivers.Add("success_b", createDriver("success_b", true))
-	drivers.Add("errored_c", createDriver("errored_c", true))
-	drivers.Add("critical_d", createDriver("critical_d", true))
-	drivers.Add("disabled_e", createDriver("disabled_e", false))
+	drivers.Add("success_a", createDriver(t, "success_a", true))
+	drivers.Add("success_b", createDriver(t, "success_b", true))
+	drivers.Add("errored_c", createDriver(t, "errored_c", true))
+	drivers.Add("critical_d", createDriver(t, "critical_d", true))
+	drivers.Add("disabled_e", createDriver(t, "disabled_e", false))
 
 	handler := newOverallStatusHandler(store, drivers, "v1")
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -114,9 +114,9 @@ func TestStatus(t *testing.T) {
 
 	// setup drivers
 	drivers := driver.NewDrivers()
-	drivers.Add("task_a", createDriver("task_a", true))
-	drivers.Add("task_b", createDriver("task_b", true))
-	drivers.Add("task_c", createDriver("task_c", true))
+	drivers.Add("task_a", createDriver(t, "task_a", true))
+	drivers.Add("task_b", createDriver(t, "task_b", true))
+	drivers.Add("task_c", createDriver(t, "task_c", true))
 
 	// start up server
 	port, err := testutils.FreePort()
@@ -291,21 +291,24 @@ func Test_Task_Update(t *testing.T) {
 		delete := testutils.MakeTempDir(t, tempDir)
 		defer delete()
 
+		task, err := driver.NewTask(driver.TaskConfig{Enabled: true})
+		require.NoError(t, err)
+
 		// add a driver
 		d, err := driver.NewTerraform(&driver.TerraformConfig{
-			Task:       driver.Task{Enabled: true},
+			Task:       task,
 			WorkingDir: tempDir,
 			ClientType: "test",
 		})
 		require.NoError(t, err)
 		drivers.Add("task_a", d)
 
-		assert.True(t, d.Task().Enabled)
+		assert.True(t, d.Task().IsEnabled())
 		plan, err := c.Task().Update("task_a", UpdateTaskConfig{
 			Enabled: config.Bool(false),
 		}, nil)
 		require.NoError(t, err)
-		assert.False(t, d.Task().Enabled)
+		assert.False(t, d.Task().IsEnabled())
 		assert.Empty(t, plan)
 	})
 	t.Run("task-not-found-error", func(t *testing.T) {

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -114,7 +114,7 @@ func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // makeTaskStatus takes event data for a task and returns a task status
-func makeTaskStatus(events []event.Event, task driver.Task,
+func makeTaskStatus(events []event.Event, task *driver.Task,
 	version string) TaskStatus {
 
 	successes := make([]bool, len(events))
@@ -134,23 +134,24 @@ func makeTaskStatus(events []event.Event, task driver.Task,
 		}
 	}
 
+	taskName := task.Name()
 	return TaskStatus{
-		TaskName:  task.Name,
+		TaskName:  taskName,
 		Status:    successToStatus(successes),
-		Enabled:   task.Enabled,
+		Enabled:   task.IsEnabled(),
 		Providers: mapKeyToArray(uniqProviders),
 		Services:  mapKeyToArray(uniqServices),
-		EventsURL: makeEventsURL(events, version, task.Name),
+		EventsURL: makeEventsURL(events, version, taskName),
 	}
 }
 
 // makeTaskStatusUnknown returns a task status for tasks that do not have events
 // but still exist within CTS. Example: a task that has been disabled from the start
-func makeTaskStatusUnknown(task driver.Task) TaskStatus {
+func makeTaskStatusUnknown(task *driver.Task) TaskStatus {
 	return TaskStatus{
-		TaskName:  task.Name,
+		TaskName:  task.Name(),
 		Status:    StatusUnknown,
-		Enabled:   task.Enabled,
+		Enabled:   task.IsEnabled(),
 		Providers: task.ProviderNames(),
 		Services:  task.ServiceNames(),
 		EventsURL: "",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -47,7 +47,7 @@ type unit struct {
 
 type baseController struct {
 	conf      *config.Config
-	newDriver func(*config.Config, driver.Task, templates.Watcher) (driver.Driver, error)
+	newDriver func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error)
 	units     []unit
 	watcher   templates.Watcher
 	resolver  templates.Resolver
@@ -88,7 +88,10 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 
 	// Future: improve by combining tasks into workflows.
 	log.Printf("[INFO] (ctrl) initializing all tasks")
-	tasks := newDriverTasks(ctrl.conf, providerConfigs)
+	tasks, err := newDriverTasks(ctrl.conf, providerConfigs)
+	if err != nil {
+		return nil, err
+	}
 	units := make([]unit, 0, len(tasks))
 	drivers := driver.NewDrivers()
 
@@ -100,27 +103,30 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 		default:
 		}
 
-		log.Printf("[DEBUG] (ctrl) initializing task %q", task.Name)
+		taskName := task.Name()
+		log.Printf("[DEBUG] (ctrl) initializing task %q", taskName)
 		d, err := ctrl.newDriver(ctrl.conf, task, ctrl.watcher)
 		if err != nil {
 			return nil, err
 		}
 
-		err = d.InitTask(true)
-		if err != nil {
-			log.Printf("[ERR] (ctrl) error initializing task %q: %s", task.Name, err)
-			return nil, err
+		if task.IsEnabled() {
+			err = d.InitTask(true)
+			if err != nil {
+				log.Printf("[ERR] (ctrl) error initializing task %q: %s", taskName, err)
+				return nil, err
+			}
 		}
 
 		units = append(units, unit{
-			taskName:  task.Name,
+			taskName:  taskName,
 			driver:    d,
 			providers: task.ProviderNames(),
 			services:  task.ServiceNames(),
-			source:    task.Source,
+			source:    task.Source(),
 		})
 
-		drivers.Add(task.Name, d)
+		drivers.Add(taskName, d)
 	}
 	ctrl.units = units
 
@@ -184,7 +190,7 @@ func InstallDriver(ctx context.Context, conf *config.Config) error {
 
 // newDriverFunc is a constructor abstraction for all of supported drivers
 func newDriverFunc(conf *config.Config) (
-	func(conf *config.Config, task driver.Task, w templates.Watcher) (driver.Driver, error), error) {
+	func(conf *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error), error) {
 	if conf.Driver.Terraform != nil {
 		return newTerraformDriver, nil
 	}
@@ -193,7 +199,7 @@ func newDriverFunc(conf *config.Config) (
 
 // newTerraformDriver maps user configuration to initialize a Terraform driver
 // for a task
-func newTerraformDriver(conf *config.Config, task driver.Task, w templates.Watcher) (driver.Driver, error) {
+func newTerraformDriver(conf *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 	tfConf := *conf.Driver.Terraform
 	return driver.NewTerraform(&driver.TerraformConfig{
 		Task:              task,
@@ -201,7 +207,7 @@ func newTerraformDriver(conf *config.Config, task driver.Task, w templates.Watch
 		Log:               *tfConf.Log,
 		PersistLog:        *tfConf.PersistLog,
 		Path:              *tfConf.Path,
-		WorkingDir:        filepath.Join(*tfConf.WorkingDir, task.Name),
+		WorkingDir:        filepath.Join(*tfConf.WorkingDir, task.Name()),
 		Backend:           tfConf.Backend,
 		RequiredProviders: tfConf.RequiredProviders,
 		ClientType:        *conf.ClientType,
@@ -210,12 +216,12 @@ func newTerraformDriver(conf *config.Config, task driver.Task, w templates.Watch
 
 // newDriverTasks converts user-defined task configurations to the task object
 // used by drivers.
-func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProviderBlocks) []driver.Task {
+func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProviderBlocks) ([]*driver.Task, error) {
 	if conf == nil {
-		return []driver.Task{}
+		return []*driver.Task{}, nil
 	}
 
-	tasks := make([]driver.Task, len(*conf.Tasks))
+	tasks := make([]*driver.Task, len(*conf.Tasks))
 	for i, t := range *conf.Tasks {
 
 		services := make([]driver.Service, len(t.Services))
@@ -238,7 +244,7 @@ func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProvide
 			}
 		}
 
-		tasks[i] = driver.Task{
+		task, err := driver.NewTask(driver.TaskConfig{
 			Description:     *t.Description,
 			Name:            *t.Name,
 			Enabled:         *t.Enabled,
@@ -252,10 +258,14 @@ func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProvide
 			UserDefinedMeta: conf.Services.CTSUserDefinedMeta(t.Services),
 			BufferPeriod:    getTemplateBufferPeriod(conf, t),
 			Condition:       t.Condition,
+		})
+		if err != nil {
+			return nil, err
 		}
+		tasks[i] = task
 	}
 
-	return tasks
+	return tasks, nil
 }
 
 // getService is a helper to find and convert a user-defined service

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -87,10 +87,14 @@ func (ctrl *ReadOnly) Run(ctx context.Context) error {
 
 func (ctrl *ReadOnly) checkInspect(ctx context.Context, u unit) (bool, error) {
 	taskName := u.taskName
+	d := u.driver
+	if !d.Task().IsEnabled() {
+		log.Printf("[TRACE] (ctrl) skipping disabled task '%s'", taskName)
+		return true, nil
+	}
 
 	log.Printf("[TRACE] (ctrl) checking dependencies changes for task %s", taskName)
 
-	d := u.driver
 	rendered, err := d.RenderTemplate(ctx)
 	if err != nil {
 		return false, fmt.Errorf("error rendering template for task %s: %s",

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -53,6 +53,7 @@ func TestReadOnlyRun(t *testing.T) {
 			w.On("Size").Return(5)
 
 			d := new(mocksD.Driver)
+			d.On("Task").Return(enabledTestTask(t))
 			d.On("RenderTemplate", mock.Anything).
 				Return(true, tc.renderTmplErr)
 			d.On("InspectTask", mock.Anything).Return(tc.inspectTaskErr)
@@ -86,6 +87,7 @@ func TestReadOnlyRun_context_cancel(t *testing.T) {
 		On("Stop").Return()
 
 	d := new(mocksD.Driver)
+	d.On("Task").Return(enabledTestTask(t))
 	d.On("RenderTemplate", mock.Anything).Return(false, nil)
 	ctrl := ReadOnly{baseController: &baseController{
 		watcher:  w,

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -165,7 +165,7 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 func (rw *ReadWrite) checkApply(ctx context.Context, u unit, retry bool) (bool, error) {
 	taskName := u.taskName
 	d := u.driver
-	if !d.Task().Enabled {
+	if !d.Task().IsEnabled() {
 		log.Printf("[TRACE] (ctrl) skipping disabled task '%s'", taskName)
 		return true, nil
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -30,7 +30,7 @@ type Driver interface {
 	UpdateTask(ctx context.Context, task PatchTask) (InspectPlan, error)
 
 	// Task returns the task information of the driver
-	Task() Task
+	Task() *Task
 
 	// Version returns the version of the driver.
 	Version() string

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -42,7 +42,6 @@ func TestNewClient(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := newClient(&clientConfig{
-				task:       Task{},
 				clientType: tc.clientType,
 			})
 			if tc.expectError {
@@ -71,7 +70,7 @@ func TestTask_ProviderNames(t *testing.T) {
 		{
 			"happy path",
 			Task{
-				Providers: NewTerraformProviderBlocks(
+				providers: NewTerraformProviderBlocks(
 					hcltmpl.NewNamedBlocksTest([]map[string]interface{}{
 						{"local": map[string]interface{}{
 							"configs": "stuff",
@@ -107,7 +106,7 @@ func TestTask_ServiceNames(t *testing.T) {
 		{
 			"happy path",
 			Task{
-				Services: []Service{
+				services: []Service{
 					Service{Name: "web"},
 					Service{Name: "api"},
 				},

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/handler"
 	"github.com/hashicorp/consul-terraform-sync/templates"
-	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl/notifier"
 	"github.com/hashicorp/consul-terraform-sync/templates/tftmpl/tmplfunc"
@@ -47,7 +46,7 @@ var (
 type Terraform struct {
 	mu *sync.RWMutex
 
-	task              Task
+	task              *Task
 	backend           map[string]interface{}
 	requiredProviders map[string]interface{}
 
@@ -66,7 +65,7 @@ type Terraform struct {
 
 // TerraformConfig configures the Terraform driver
 type TerraformConfig struct {
-	Task              Task
+	Task              *Task
 	Log               bool
 	PersistLog        bool
 	Path              string
@@ -88,20 +87,23 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 		}
 	}
 
+	task := config.Task
+	taskName := task.Name()
 	tfClient, err := newClient(&clientConfig{
-		task:       config.Task,
 		clientType: config.ClientType,
 		log:        config.Log,
+		name:       taskName,
 		persistLog: config.PersistLog,
 		path:       config.Path,
 		workingDir: config.WorkingDir,
+		varFiles:   task.VariableFiles(),
 	})
 	if err != nil {
 		log.Printf("[ERR] (driver.terraform) init client type '%s' error: %s", config.ClientType, err)
 		return nil, err
 	}
 
-	if taskEnv := config.Task.Env; len(taskEnv) > 0 {
+	if taskEnv := task.Env(); len(taskEnv) > 0 {
 		// Terraform init requires discovering git in the PATH env.
 		//
 		// The terraform-exec package disables inheriting from the os environment
@@ -114,7 +116,7 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 		tfClient.SetEnv(env)
 	}
 
-	handler, err := getTerraformHandlers(config.Task)
+	handler, err := getTerraformHandlers(taskName, task.Providers())
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +142,7 @@ func (tf *Terraform) Version() string {
 }
 
 // Task returns the task config info
-func (tf *Terraform) Task() Task {
+func (tf *Terraform) Task() *Task {
 	return tf.task
 }
 
@@ -150,9 +152,9 @@ func (tf *Terraform) InitTask(force bool) error {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.Enabled {
+	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"initializing", tf.task.Name)
+			"initializing", tf.task.Name())
 		return nil
 	}
 
@@ -165,13 +167,12 @@ func (tf *Terraform) SetBufferPeriod() {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.Enabled {
+	taskName := tf.task.Name()
+	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"setting buffer period", tf.task.Name)
+			"setting buffer period", taskName)
 		return
 	}
-
-	taskName := tf.task.Name
 
 	if tf.template == nil {
 		log.Printf("[WARN] (driver.terraform) attempted to set buffer for "+
@@ -179,8 +180,8 @@ func (tf *Terraform) SetBufferPeriod() {
 		return
 	}
 
-	bp := tf.task.BufferPeriod
-	if bp == nil {
+	bp, ok := tf.task.BufferPeriod()
+	if !ok {
 		log.Printf("[TRACE] (driver.terraform) no buffer period for '%s'", taskName)
 		return
 	}
@@ -198,9 +199,9 @@ func (tf *Terraform) RenderTemplate(ctx context.Context) (bool, error) {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.Enabled {
+	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"rendering template", tf.task.Name)
+			"rendering template", tf.task.Name())
 		return true, nil
 	}
 
@@ -213,9 +214,9 @@ func (tf *Terraform) InspectTask(ctx context.Context) error {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.Enabled {
+	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"inspecting", tf.task.Name)
+			"inspecting", tf.task.Name())
 		return nil
 	}
 
@@ -228,9 +229,9 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.Enabled {
+	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"applying", tf.task.Name)
+			"applying", tf.task.Name())
 		return nil
 	}
 
@@ -247,6 +248,7 @@ type InspectPlan struct {
 // depending on the fields updated. If update task is requested with the inspect
 // run option, then returns the inspected plan
 func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPlan, error) {
+	taskName := tf.task.Name()
 	switch patch.RunOption {
 	case "", RunOptionInspect, RunOptionNow:
 		// valid options
@@ -260,10 +262,12 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 
 	reinit := false
 
-	if tf.task.Enabled != patch.Enabled {
-		tf.task.Enabled = patch.Enabled
-		if tf.task.Enabled {
+	if tf.task.IsEnabled() != patch.Enabled {
+		if patch.Enabled {
+			tf.task.Enable()
 			reinit = true
+		} else {
+			tf.task.Disable()
 		}
 	}
 
@@ -278,14 +282,14 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 	if reinit {
 		if err := tf.initTask(true); err != nil {
 			return InspectPlan{}, fmt.Errorf("Error updating task '%s'. Unable to init "+
-				"task: %s", tf.task.Name, err)
+				"task: %s", taskName, err)
 		}
 
 		for i := int64(0); ; i++ {
 			rendered, err := tf.renderTemplate(ctx)
 			if err != nil {
 				return InspectPlan{}, fmt.Errorf("Error updating task '%s'. Unable to "+
-					"render template for task: %s", tf.task.Name, err)
+					"render template for task: %s", taskName, err)
 			}
 			if rendered {
 				break
@@ -295,18 +299,18 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 
 	if patch.RunOption == RunOptionInspect {
 		log.Printf("[TRACE] (driver.terraform) update task '%s'. inspect run "+
-			"option", tf.task.Name)
+			"option", taskName)
 		plan, err := tf.inspectTask(ctx, true)
 		if err != nil {
 			return InspectPlan{}, fmt.Errorf("Error updating task '%s'. Unable to inspect "+
-				"task: %s", tf.task.Name, err)
+				"task: %s", taskName, err)
 		}
 		return plan, nil
 	}
 
 	if patch.RunOption == RunOptionNow {
 		log.Printf("[TRACE] (driver.terraform) update task '%s'. run now "+
-			"option", tf.task.Name)
+			"option", taskName)
 		return InspectPlan{}, tf.applyTask(ctx)
 	}
 
@@ -316,7 +320,7 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 
 // init initializes the Terraform workspace if needed
 func (tf *Terraform) init(ctx context.Context) error {
-	taskName := tf.task.Name
+	taskName := tf.task.Name()
 
 	if tf.inited {
 		log.Printf("[TRACE] (driver.terraform) workspace for task already "+
@@ -334,72 +338,12 @@ func (tf *Terraform) init(ctx context.Context) error {
 
 // initTask initializes the task
 func (tf *Terraform) initTask(force bool) error {
-	task := tf.task
-
-	services := make([]tftmpl.Service, len(task.Services))
-	for i, s := range task.Services {
-		services[i] = tftmpl.Service{
-			Datacenter:  s.Datacenter,
-			Description: s.Description,
-			Name:        s.Name,
-			Namespace:   s.Namespace,
-			Tag:         s.Tag,
-		}
-	}
-
-	var vars hcltmpl.Variables
-	for _, vf := range task.VarFiles {
-		tfvars, err := tftmpl.LoadModuleVariables(vf)
-		if err != nil {
-			return err
-		}
-
-		if len(vars) == 0 {
-			vars = tfvars
-			continue
-		}
-
-		for k, v := range tfvars {
-			vars[k] = v
-		}
-	}
-
-	var condition tftmpl.Condition
-	switch v := task.Condition.(type) {
-	case *config.CatalogServicesConditionConfig:
-		condition = &tftmpl.CatalogServicesCondition{
-			Regexp:            *v.Regexp,
-			SourceIncludesVar: *v.SourceIncludesVar,
-			Datacenter:        *v.Datacenter,
-			Namespace:         *v.Namespace,
-			NodeMeta:          v.NodeMeta,
-		}
-	case *config.ServicesConditionConfig:
-		condition = &tftmpl.ServicesCondition{}
-	default:
-		// expected only for test scenarios
-		log.Printf("[WARN] (driver.terraform) task '%s' condition config unset."+
-			" defaulting to services condition", task.Name)
-		condition = &tftmpl.ServicesCondition{}
-	}
-
 	input := tftmpl.RootModuleInputData{
 		TerraformVersion: TerraformVersion,
 		Backend:          tf.backend,
-		Providers:        task.Providers.ProviderBlocks(),
-		ProviderInfo:     task.ProviderInfo,
-		Services:         services,
-		Task: tftmpl.Task{
-			Description: task.Description,
-			Name:        task.Name,
-			Source:      task.Source,
-			Version:     task.Version,
-		},
-		Variables: vars,
-		Condition: condition,
 	}
+	tf.task.configureRootModuleInput(&input)
 	input.Init()
-
 	if err := tftmpl.InitRootModule(&input, tf.workingDir, filePerms, force); err != nil {
 		return err
 	}
@@ -418,7 +362,7 @@ func (tf *Terraform) initTask(force bool) error {
 
 // renderTemplate attempts to render the hashicat template
 func (tf *Terraform) renderTemplate(ctx context.Context) (bool, error) {
-	taskName := tf.task.Name
+	taskName := tf.task.Name()
 	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
 
 	var err error
@@ -428,7 +372,7 @@ func (tf *Terraform) renderTemplate(ctx context.Context) (bool, error) {
 			"for '%s': %s", taskName, err)
 
 		return false, fmt.Errorf("error fetching template dependencies for task %s: %s",
-			tf.task.Name, err)
+			taskName, err)
 	}
 
 	// result.Complete is only `true` if the template has new data that has been
@@ -453,7 +397,7 @@ func (tf *Terraform) renderTemplate(ctx context.Context) (bool, error) {
 // inspectTask inspects the task changes. Option to return inspection plan
 // details rather than logging out
 func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectPlan, error) {
-	taskName := tf.task.Name
+	taskName := tf.task.Name()
 
 	if err := tf.init(ctx); err != nil {
 		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
@@ -489,7 +433,7 @@ func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectP
 
 // applyTask applies the task changes.
 func (tf *Terraform) applyTask(ctx context.Context) error {
-	taskName := tf.task.Name
+	taskName := tf.task.Name()
 
 	if err := tf.init(ctx); err != nil {
 		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
@@ -521,7 +465,7 @@ func (tf *Terraform) initTaskTemplate() error {
 	content, err := tf.fileReader(tmplFullpath)
 	if err != nil {
 		log.Printf("[ERR] (driver.terraform) unable to read file for '%s': %s",
-			tf.task.Name, err)
+			tf.task.Name(), err)
 		return err
 	}
 
@@ -533,9 +477,9 @@ func (tf *Terraform) initTaskTemplate() error {
 	tmpl := hcat.NewTemplate(hcat.TemplateInput{
 		Contents:     string(content),
 		Renderer:     renderer,
-		FuncMapMerge: tmplfunc.HCLMap(tf.task.UserDefinedMeta),
+		FuncMapMerge: tmplfunc.HCLMap(tf.task.UserDefinedMeta()),
 	})
-	switch tf.task.Condition.(type) {
+	switch tf.task.Condition().(type) {
 	case *config.CatalogServicesConditionConfig:
 		tf.template = &notifier.CatalogServicesRegistration{Template: tmpl}
 	default:
@@ -550,10 +494,10 @@ func (tf *Terraform) initTaskTemplate() error {
 //
 // Returned handler may be nil even if returned err is nil. This happens when
 // no providers have a handler.
-func getTerraformHandlers(task Task) (handler.Handler, error) {
+func getTerraformHandlers(name string, providers TerraformProviderBlocks) (handler.Handler, error) {
 	counter := 0
 	var next handler.Handler
-	for _, p := range task.Providers {
+	for _, p := range providers {
 		h, err := handler.TerraformProviderHandler(p.Name(), p.ProviderBlock().RawConfig())
 		if err != nil {
 			log.Printf(
@@ -570,7 +514,7 @@ func getTerraformHandlers(task Task) (handler.Handler, error) {
 		}
 	}
 	log.Printf("[INFO] (driver.terraform) retrieved %d Terraform handlers for task '%s'",
-		counter, task.Name)
+		counter, name)
 	return next, nil
 }
 

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -83,14 +83,16 @@ func (_m *Driver) SetBufferPeriod() {
 }
 
 // Task provides a mock function with given fields:
-func (_m *Driver) Task() driver.Task {
+func (_m *Driver) Task() *driver.Task {
 	ret := _m.Called()
 
-	var r0 driver.Task
-	if rf, ok := ret.Get(0).(func() driver.Task); ok {
+	var r0 *driver.Task
+	if rf, ok := ret.Get(0).(func() *driver.Task); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(driver.Task)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*driver.Task)
+		}
 	}
 
 	return r0


### PR DESCRIPTION
Task attributes are now only readable by the API and controller.