### PR TITLE
Update driver interface

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -111,7 +111,7 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 			return nil, err
 		}
 
-		err = d.InitTask(true)
+		err = d.InitTask(ctx)
 		if err != nil {
 			log.Printf("[ERR] (ctrl) error initializing task %q: %s", taskName, err)
 			return nil, err

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -116,7 +116,7 @@ func TestBaseControllerInit(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
-			d.On("InitTask", mock.Anything, mock.Anything).Return(tc.initTaskErr).Once()
+			d.On("InitTask", mock.Anything).Return(tc.initTaskErr).Once()
 
 			baseCtrl := baseController{
 				newDriver: func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -10,7 +10,7 @@ import (
 // downstream to update network infrastructure.
 type Driver interface {
 	// InitTask initializes the task that the driver executes
-	InitTask(force bool) error
+	InitTask(ctx context.Context) error
 
 	// SetBufferPeriod sets the task's buffer period on the watcher
 	SetBufferPeriod()

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -585,7 +585,7 @@ func TestDisabledTask(t *testing.T) {
 
 		ctx := context.Background()
 
-		err := tf.InitTask(true)
+		err := tf.InitTask(ctx)
 		assert.NoError(t, err)
 
 		tf.SetBufferPeriod()

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -28,13 +28,13 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 	return r0
 }
 
-// InitTask provides a mock function with given fields: force
-func (_m *Driver) InitTask(force bool) error {
-	ret := _m.Called(force)
+// InitTask provides a mock function with given fields: ctx
+func (_m *Driver) InitTask(ctx context.Context) error {
+	ret := _m.Called(ctx)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(bool) error); ok {
-		r0 = rf(force)
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -262,7 +262,7 @@ func TestNewFiles(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			input := tc.Input
-			input.Init()
+			input.init()
 			b := new(bytes.Buffer)
 			err := tc.Func(b, tc.Name, &input)
 			require.NoError(t, err)

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -67,9 +67,11 @@ func TestInitRootModule(t *testing.T) {
 			"one":       cty.NumberIntVal(1),
 			"bool_true": cty.BoolVal(true),
 		},
+		Path:      dir,
+		FilePerms: expectedPerm,
+		skipOverride: true,
 	}
-	input.Init()
-	err = InitRootModule(&input, dir, expectedPerm, false)
+	err = InitRootModule(&input)
 	assert.NoError(t, err)
 
 	files := []struct {


### PR DESCRIPTION
The force parameter for `driver.InitTask` is only used for testing and was prematurely added. Updated the signature to remove `force` and be consistent to accept `context`.