### PR TITLE
Fix catalog-service race condition during once-mode

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -482,7 +482,8 @@ func (tf *Terraform) initTaskTemplate() error {
 	})
 	switch tf.task.Condition().(type) {
 	case *config.CatalogServicesConditionConfig:
-		tf.template = &notifier.CatalogServicesRegistration{Template: tmpl}
+		tf.template = notifier.NewCatalogServicesRegistration(tmpl,
+			len(tf.task.Services()))
 	default:
 		tf.template = tmpl
 	}

--- a/templates/tftmpl/notifier/notifier.go
+++ b/templates/tftmpl/notifier/notifier.go
@@ -1,6 +1,8 @@
 package notifier
 
 import (
+	"log"
+
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/hcat/dep"
 )
@@ -14,37 +16,67 @@ import (
 // tmplfuncs and changes to Catalog Services tag data.
 type CatalogServicesRegistration struct {
 	templates.Template
-	once     bool
 	services []string
+
+	// count all dependencies needed to complete once-mode
+	once     bool
+	depTotal int
+	counter  int
 }
 
-// Notify notifies when Catalog Services registration changes
+// NewCatalogServicesRegistration creates a new CatalogServicesRegistration
+// notifier.
+// serviceCount parameter: the number of services the task is configured with
+func NewCatalogServicesRegistration(tmpl templates.Template, serviceCount int) *CatalogServicesRegistration {
+	return &CatalogServicesRegistration{
+		Template: tmpl,
+		depTotal: serviceCount + 1, // for additional catalog-services dep
+	}
+}
+
+// Notify notifies when Catalog Services registration changes.
+//
+// Note: there is a race condition that can cause once-mode to hang. Once-mode
+// requires all dependencies to be retrieved before notifying to render the
+// complete template (and then executing task). During once-mode, if the last
+// dependency received is not a CatalogSnippet dependency with a registration
+// change, we still need to notify or else once-mode will hang
 func (n *CatalogServicesRegistration) Notify(d interface{}) (notify bool) {
-	if v, ok := d.([]*dep.CatalogSnippet); ok {
-		if n.registrationChange(v) {
-			n.Template.Notify(d)
-			return true
+	log.Printf("[DEBUG] (notifier.cs) received dependency change type %T", d)
+	notify = false
+
+	if !n.once {
+		n.counter++
+		// after all dependencies are received, notify so once-mode can complete
+		if n.counter >= n.depTotal {
+			log.Printf("[DEBUG] (notifier.cs) notify once-mode complete")
+			n.once = true
+			notify = true
 		}
 	}
-	return false
+
+	if v, ok := d.([]*dep.CatalogSnippet); ok {
+		if n.registrationChange(v) {
+			log.Printf("[DEBUG] (notifier.cs) notify registration change")
+			notify = true
+		}
+	}
+
+	if notify {
+		n.Template.Notify(d)
+	}
+
+	return notify
 }
 
 // registrationChange determines whether or not the latest Catalog Service
 // changes are registration changes i.e. we want to ignore tag changes.
-// Note: this can cause once-mode to hang if there are no registration changes,
-// so return true for this edge-case
 func (n *CatalogServicesRegistration) registrationChange(new []*dep.CatalogSnippet) bool {
 	newServices := make([]string, len(new))
 	for ix, s := range new {
 		newServices[ix] = s.Name
 	}
 	defer func() { n.services = newServices }()
-
-	// first time through should notify (once-mode)
-	if !n.once {
-		n.once = true
-		return true
-	}
 
 	// change in list of service names should notify
 	if len(n.services) != len(newServices) {

--- a/templates/tftmpl/notifier/notifier_test.go
+++ b/templates/tftmpl/notifier/notifier_test.go
@@ -44,6 +44,72 @@ func Test_CatalogServicesRegistration_Notify(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+
+	t.Run("once-mode-services-last", func(t *testing.T) {
+		// Test that notifier notifies at the end of once-mode, particularly
+		// for the race-condition when the services dependency (which normally
+		// does not notify) is received after catalog-service dependency.
+
+		// Notifier has 3 dependencies: 2 services and 1 catalog-service
+		// 1. receive first services dependency, no notification
+		// 2. receive catalog-service dependency, notify for catalog-service
+		// 3. receive second services dependency, notify for once-mode
+
+		tmpl := new(mocks.Template)
+		tmpl.On("Notify", mock.Anything).Return(true).Twice()
+		n := NewCatalogServicesRegistration(tmpl, 2)
+
+		// 1. first services dependency does not notify
+		notify := n.Notify([]*dep.HealthService{})
+		assert.False(t, notify, "first services dep should not have notified")
+		assert.False(t, n.once, "got 1/3 deps. once-mode should not be completed")
+		assert.Equal(t, 1, n.counter, "first services dep should be 1st dep")
+
+		// 2. catalog-service notifies
+		notify = n.Notify([]*dep.CatalogSnippet{{Name: "api"}})
+		assert.True(t, notify, "catalog-service dep should have notified")
+		assert.False(t, n.once, "got 2/3 deps. once-mode should not be completed")
+		assert.Equal(t, 2, n.counter, "catalog-service dep should be 2nd dep")
+		assert.Equal(t, []string{"api"}, n.services, "api service should be stored")
+
+		// 3. second services notifies
+		notify = n.Notify([]*dep.HealthService{})
+		assert.True(t, notify, "second services dep should have notified")
+		assert.True(t, n.once, "got 3/3 deps. once-mode should be completed")
+		assert.Equal(t, 3, n.counter, "second services should be 3rd dep")
+
+		// check mock template was called twice
+		tmpl.AssertExpectations(t)
+	})
+
+	t.Run("once-mode-catalog-services-last", func(t *testing.T) {
+		// Test that notifier notifies at the end of once-mode, particularly for
+		// the case when the catalog-services dependency is received last.
+
+		// Notifier in test has 2 dependencies: 1 services and 1 catalog-service
+		// 1. receive services dependency, no notification
+		// 2. receive catalog-services dependency, notify
+
+		tmpl := new(mocks.Template)
+		tmpl.On("Notify", mock.Anything).Return(true).Once()
+		n := NewCatalogServicesRegistration(tmpl, 1)
+
+		// 1. services dependency does not notify
+		notify := n.Notify([]*dep.HealthService{})
+		assert.False(t, notify, "services dep should not have notified")
+		assert.False(t, n.once, "got 1/2 deps. once-mode should not be completed")
+		assert.Equal(t, 1, n.counter, "services dep should be 1st dep")
+
+		// 2. catalog-service notifies
+		notify = n.Notify([]*dep.CatalogSnippet{{Name: "api"}})
+		assert.True(t, notify, "catalog-service dep should have notified")
+		assert.True(t, n.once, "got 2/2 deps. once-mode should be completed")
+		assert.Equal(t, 2, n.counter, "catalog-service dep should be 2nd dep")
+		assert.Equal(t, []string{"api"}, n.services, "api service should be stored")
+
+		// check mock template was called once
+		tmpl.AssertExpectations(t)
+	})
 }
 
 func Test_CatalogServicesRegistration_registrationChange(t *testing.T) {
@@ -55,15 +121,6 @@ func Test_CatalogServicesRegistration_registrationChange(t *testing.T) {
 		data     []*dep.CatalogSnippet
 		expected bool
 	}{
-		{
-			"change: once-mode",
-			&CatalogServicesRegistration{
-				once:     false,
-				services: []string{},
-			},
-			[]*dep.CatalogSnippet{},
-			true,
-		},
 		{
 			"change: different number of services",
 			&CatalogServicesRegistration{


### PR DESCRIPTION
Once-mode requires all dependencies to be retrieved before sending a
notification to CTS to render the complete template and execute the task.

A task has a template which can have multiple types of dependencies. A task configured with
catalog-service condition will only notify on a catalog-service type dependency changes and
not on other types of dependency changes.

During once-mode, the template dependencies are received asynchronously and therefore
can cause a race:
 - If catalog-service dependency is received last: this is fine with once-mode i.e. all
 dependencies are received, notification is sent, task is executed
 - If a different dependency is received last: no notification is sent because only catalog-service
 dependencies send notification. However, once-mode is waiting for all the dependencies to
 be received. Therefore, once-mode hangs even though all dependencies are received and task
 is ready to execute for once-mode.

Change:
 - Remove existing code to handle once-mode. This only partially handles the once-mode complexity.
 It only resolves the case when catalog-service dependency has no registration change during once-mode
 - Add new code to use a dependency counter to determine when all dependencies have been received.
 Once received, trigger notification regardless of what type of dependency is received last
 - Alternative ideas welcome!


Sample logs showing the hang:

```
2021/05/26 19:41:05.979458 [INFO] (ctrl) driver initialized
2021/05/26 19:41:05.979477 [INFO] (ctrl) executing all tasks once through
2021/05/26 19:41:05.979917 [DEBUG] (ctrl) rendered template false
2021/05/26 19:41:05.979926 [DEBUG] (ctrl) watching 3 dependencies                                 // notice: waiting for 3 dependency changes
2021/05/26 19:41:06.082522 [DEBUG] (notifier) dependency change type []*dep.HealthService
2021/05/26 19:41:06.086875 [DEBUG] (notifier) dependency change type []*dep.CatalogSnippet
2021/05/26 19:41:06.086891 [DEBUG] (notifier) notify registration change                          // catalog-service dep (log above) sends notification as expected
2021/05/26 19:41:06.087272 [DEBUG] (ctrl) rendered template false                                 // because of once-mode, template is not rendered because still missing 3rd dependency
2021/05/26 19:41:06.088918 [DEBUG] (notifier) dependency change type []*dep.HealthService         // last dependency received. but is not catalog-service type. therefore no notification sent.
2021/05/26 19:41:20.769355 [INFO] (cli) signal received to initiate graceful shutdown: interrupt  // note the timstamp. cts hangs for 14s
2021/05/26 19:41:30.769673 [INFO] (cli) graceful shutdown timed out, exiting
```