### PR TITLE
Print out log snippet when CTS fails in e2e tests

### DIFF
--- a/e2e/config.go
+++ b/e2e/config.go
@@ -90,7 +90,7 @@ task {
 }
 
 func baseConfig() hclConfig {
-	return `log_level = "INFO"
+	return `log_level = "DEBUG"
 
 service {
   name = "api"


### PR DESCRIPTION
Sometimes e2e tests fail in CircleCI and are not reproducible locally.
Currently no e2e logs are outputted in Circle since the tests are run in
parallel making the logs interwoven and undecipherable.

Change: when CTS stops and tests have failed, output a snippet of the CTS logs.
Update e2e default log-level to DEBUG since we will likely be debugging when
these logs are outputted.

Sample output for a failed test
<img width="1410" alt="Screen Shot 2021-05-27 at 12 43 17 PM" src="https://user-images.githubusercontent.com/6819378/119865011-39b8c580-bee9-11eb-93ca-3131514ee8d9.png">
<img width="1410" alt="Screen Shot 2021-05-27 at 12 43 34 PM" src="https://user-images.githubusercontent.com/6819378/119865025-3d4c4c80-bee9-11eb-89da-85dbad4057e8.png">

