### PR TITLE
Update e2e test to poll for Consul service registration and CTS events

### DIFF
--- a/api/test.go
+++ b/api/test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/stretchr/testify/require"
@@ -76,5 +77,46 @@ func StartCTS(t *testing.T, configPath string, opts ...string) (*Client, func(t 
 		if err := cmd.Wait(); err != nil {
 			require.Equal(t, sigintErr, err)
 		}
+	}
+}
+
+func WaitForEvent(t *testing.T, client *Client, taskName string, start time.Time, timeout time.Duration) {
+	polling := make(chan struct{})
+	stopPolling := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-stopPolling:
+				return
+			default:
+				q := &QueryParam{IncludeEvents: true}
+				results, err := client.Status().Task(taskName, q)
+				if err != nil {
+					continue
+				}
+				task, ok := results[taskName]
+				if !ok {
+					continue
+				}
+				if len(task.Events) == 0 {
+					continue
+				}
+				mostRecent := task.Events[0]
+				if mostRecent.EndTime.After(start) {
+					polling <- struct{}{}
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-polling:
+		return
+	case <-time.After(timeout):
+		close(stopPolling)
+		t.Logf("\nError: timed out after waiting for %v for new event for task %q\n",
+			timeout, taskName)
 	}
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -41,7 +41,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	cts, stopCTS := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 
 	// wait to run once before registering another instance to collect another event
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 	service := testutil.TestService{
 		ID:      "api-2",
@@ -260,7 +260,7 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Confirm that terraform files were not generated for a disabled task

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -49,10 +49,11 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 		Address: "5.6.7.8",
 		Port:    8080,
 	}
-	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
-
-	// wait and then retrieve status
-	time.Sleep(7 * time.Second)
+	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing,
+		defaultWaitForRegistration)
+	now := time.Now()
+	api.WaitForEvent(t, cts, fakeFailureTaskName, now, defaultWaitForEvent)
+	api.WaitForEvent(t, cts, fakeSuccessTaskName, now, defaultWaitForEvent)
 
 	taskCases := []struct {
 		name       string
@@ -314,8 +315,9 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 		Address: "5.6.7.8",
 		Port:    8080,
 	}
-	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
-	time.Sleep(3 * time.Second)
+	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing,
+		defaultWaitForRegistration)
+	time.Sleep(defaultWaitForNoEvent)
 
 	// Confirm that resources are not recreated for disabled task
 	testutils.CheckDir(t, false, resourcesPath)

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -82,7 +82,7 @@ func BenchmarkTaskTrigger(b *testing.B) {
 				Address: "5.6.7.8",
 				Port:    8080,
 			}
-			testutils.RegisterConsulService(b, srv, service, testutil.HealthPassing)
+			testutils.RegisterConsulService(b, srv, service, testutil.HealthPassing, 0)
 			// b.Logf("service instance registered: %s", service.ID)
 		}()
 

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -102,7 +102,7 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 				Address: "5.6.7.8",
 				Port:    8080,
 			}
-			testutils.RegisterConsulService(b, srv, service, testutil.HealthPassing)
+			testutils.RegisterConsulService(b, srv, service, testutil.HealthPassing, 0)
 
 			ctxTimeout, _ := context.WithTimeout(context.Background(), 30*time.Second)
 			completedTasks := make(map[string]bool, len(*conf.Tasks))

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
@@ -36,7 +35,7 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 	defer stop(t)
-	err := cts.WaitForAPI(5 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -101,7 +100,7 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 	defer stop(t)
-	err := cts.WaitForAPI(5 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	cases := []struct {
@@ -163,7 +162,7 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 	defer stop(t)
-	err := cts.WaitForAPI(10 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	cases := []struct {

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -103,7 +103,7 @@ func testConsulBackendCompatibility(t *testing.T, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test: ConsulKV backend
@@ -129,7 +129,7 @@ func testServiceInstanceCompatibility(t *testing.T, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test adding and removing service instances
@@ -186,7 +186,7 @@ func testServiceValuesCompatibility(t *testing.T, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test updating service-related values
@@ -290,7 +290,7 @@ func testTagQueryCompatibility(t *testing.T, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that filtering by tags
@@ -332,7 +332,7 @@ func testNodeValuesCompatibility(t *testing.T, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test updating node-related values

--- a/e2e/condition_test.go
+++ b/e2e/condition_test.go
@@ -55,7 +55,7 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that task is triggered on service registration and deregistration
@@ -122,7 +122,7 @@ func TestCondition_CatalogServices_NoServicesTrigger(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that task is not triggered by service-instance specific changes and
@@ -209,7 +209,7 @@ func TestCondition_CatalogServices_NoTagsTrigger(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that task is not triggered by service tag changes and only by
@@ -340,7 +340,7 @@ func TestCondition_CatalogServices_Regexp(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that regex filter is filtering service registration information and
@@ -445,7 +445,7 @@ func TestCondition_CatalogServices_NodeMeta(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 
-	err = cts.WaitForAPI(15 * time.Second)
+	err = cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// Test that node-meta filter is filtering service registration information

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -14,17 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// tempDirPrefix is the prefix for the directory for a given e2e test
-// where files generated from e2e are stored. This directory is
-// destroyed after e2e testing if no errors.
-const tempDirPrefix = "tmp_"
+const (
+	// tempDirPrefix is the prefix for the directory for a given e2e test
+	// where files generated from e2e are stored. This directory is
+	// destroyed after e2e testing if no errors.
+	tempDirPrefix = "tmp_"
 
-// resourcesDir is the sub-directory of tempDir where the
-// Terraform resources created from running consul-terraform-sync are stored
-const resourcesDir = "resources"
+	// resourcesDir is the sub-directory of tempDir where the
+	// Terraform resources created from running consul-terraform-sync are stored
+	resourcesDir = "resources"
 
-// configFile is the name of the sync config file
-const configFile = "config.hcl"
+	// configFile is the name of the sync config file
+	configFile = "config.hcl"
+
+	// liberal default times to wait
+	defaultWaitForRegistration = 8 * time.Second
+	defaultWaitForEvent        = 8 * time.Second
+
+	// liberal wait time to ensure event doesn't happen
+	defaultWaitForNoEvent = 6 * time.Second
+)
 
 // TestE2EBasic runs the CTS binary in daemon mode with a configuration with 2
 // tasks and a test module that writes IP addresses to disk. This tests for CTS
@@ -135,8 +144,9 @@ func TestE2ERestartConsul(t *testing.T) {
 
 	// register a new service
 	apiInstance := testutil.TestService{ID: "api_new", Name: "api"}
-	testutils.RegisterConsulService(t, consul, apiInstance, testutil.HealthPassing)
-	time.Sleep(8 * time.Second)
+	testutils.RegisterConsulService(t, consul, apiInstance,
+		testutil.HealthPassing, defaultWaitForRegistration)
+	api.WaitForEvent(t, cts, dbTaskName, time.Now(), defaultWaitForEvent)
 
 	// confirm that CTS reconnected with Consul and created resource for latest service
 	testutils.CheckFile(t, true, fmt.Sprintf("%s/%s", tempDir, resourcesDir), "api_new.txt")

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -30,6 +30,7 @@ const (
 	// liberal default times to wait
 	defaultWaitForRegistration = 8 * time.Second
 	defaultWaitForEvent        = 8 * time.Second
+	defaultWaitForAPI          = 20 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
 	defaultWaitForNoEvent = 6 * time.Second
@@ -127,7 +128,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 	// wait enough for cts to cycle through once-mode successfully
-	err := cts.WaitForAPI(15 * time.Second)
+	err := cts.WaitForAPI(defaultWaitForAPI)
 	require.NoError(t, err)
 
 	// stop Consul

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -27,7 +27,6 @@ func TestTasksUpdate(t *testing.T) {
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "multiple_tasks")
 	delete := testutils.MakeTempDir(t, tempDir)
-	testutils.MakeTempDir(t, tempDir)
 
 	apiTaskName := "e2e_task_api"
 	apiTask := fmt.Sprintf(`

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -82,11 +82,15 @@ task {
 			Address: "5.6.7.8",
 			Port:    8080,
 		}
-		testutils.RegisterConsulService(t, srv, apiInstance, testutil.HealthPassing)
-		testutils.RegisterConsulService(t, srv, webInstance, testutil.HealthPassing)
 
-		// Wait for CTS to detect changes and run tasks
-		time.Sleep(15 * time.Second)
+		testutils.RegisterConsulService(t, srv, apiInstance,
+			testutil.HealthPassing, defaultWaitForRegistration)
+		api.WaitForEvent(t, cts, webTaskName, time.Now(), defaultWaitForEvent) // only check one task
+
+		testutils.RegisterConsulService(t, srv, webInstance,
+			testutil.HealthPassing, defaultWaitForRegistration)
+		// takes a little longer due to consecutive registrations
+		api.WaitForEvent(t, cts, webTaskName, time.Now(), defaultWaitForEvent*2)
 
 		// Verify updated Catalog information is reflected in terraform.tfvars
 		expectedTaskServices := map[string][]string{
@@ -106,7 +110,11 @@ task {
 	t.Run("deregister service", func(t *testing.T) {
 		// Deregister service
 		testutils.DeregisterConsulService(t, srv, "api_new")
-		time.Sleep(15 * time.Second)
+		fullWait := defaultWaitForRegistration + defaultWaitForEvent
+		now := time.Now()
+		api.WaitForEvent(t, cts, apiTaskName, now, fullWait)
+		api.WaitForEvent(t, cts, dbTaskName, now, fullWait)
+		api.WaitForEvent(t, cts, webTaskName, now, fullWait)
 
 		// Verify updated Catalog information is reflected in terraform.tfvars
 		expectedTaskServices := map[string][]string{

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -50,7 +50,7 @@ task {
 
 	t.Run("once mode", func(t *testing.T) {
 		// Wait for tasks to execute once
-		err := cts.WaitForAPI(15 * time.Second)
+		err := cts.WaitForAPI(defaultWaitForAPI)
 		require.NoError(t, err)
 
 		// Verify Catalog information is reflected in terraform.tfvars

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -213,7 +213,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 					Address: "5.6.7.8",
 					Port:    8080,
 				}
-				testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing)
+				testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing, 5*time.Second)
 			}
 
 			// Setup another server with an identical API service

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -122,7 +122,7 @@ func serviceRegistered(tb testing.TB, srv *testutil.TestServer, serviceID string
 // Bulk add test data for seeding consul
 func AddServices(t testing.TB, srv *testutil.TestServer, svcs []testutil.TestService) {
 	for _, s := range svcs {
-		RegisterConsulService(t, srv, s, testutil.HealthPassing)
+		RegisterConsulService(t, srv, s, testutil.HealthPassing, 0)
 	}
 }
 

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -4,8 +4,6 @@
 package testutils
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -17,7 +15,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/hashicorp/consul-terraform-sync/testutils/sdk"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -88,23 +85,6 @@ func CheckFile(t testing.TB, exists bool, path, filename string) string {
 
 	require.NoError(t, err)
 	return string(content)
-}
-
-// RegisterConsulService regsiters a service to the Consul Catalog. The Consul
-// sdk/testutil package currently does not support a method to register multiple
-// service instances, distinguished by their IDs.
-func RegisterConsulService(tb testing.TB, srv *testutil.TestServer,
-	s testutil.TestService, health string) {
-
-	var body bytes.Buffer
-	enc := json.NewEncoder(&body)
-	require.NoError(tb, enc.Encode(&s))
-
-	u := fmt.Sprintf("http://%s/v1/agent/service/register", srv.HTTPAddr)
-	resp := RequestHTTP(tb, http.MethodPut, u, body.String())
-	defer resp.Body.Close()
-
-	sdk.AddCheck(srv, tb, s.ID, s.ID, testutil.HealthPassing)
 }
 
 func DeregisterConsulService(tb testing.TB, srv *testutil.TestServer, id string) {


### PR DESCRIPTION
In our e2e tests, there are a lot of `time.Sleep()`s used to wait for a Consul service to register and for CTS to trigger and finish in response to a change. These sleeps can sometimes cause tests to flake and are an arbitrarily long value that cause our tests to sometimes be longer than needed.

Currently, this has a minor improvement on the e2e CI job time. It reduces from ~1min 30-50s to ~1min 10s. However, this change's original intention was for an upcoming e2e test that causes the e2e test suite to timeout. This change reduces this upcoming test's length and prevents it from causing the e2e suite timeout.

Commits:
 - Add new WaitForEvent which polls CTS for triggering
 - Update RegisterConsulService to poll for the service to be registered
 - Update e2e test sleeps with latest WaitForEvent and RegisterConsulService.
 - Update non-e2e tests with latest RegisterConsulService
 - Update existing WaitForApi() polling method with a similar default timeout variable
 - Fix a small extra call to MakeTempDir that I noticed