### PR TITLE
Set Terraform path to working directory if empty string

### DIFF
--- a/config/terraform.go
+++ b/config/terraform.go
@@ -226,7 +226,7 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 		c.PersistLog = Bool(false)
 	}
 
-	if c.Path == nil {
+	if c.Path == nil || *c.Path == "" {
 		c.Path = String(wd)
 	}
 

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -499,6 +499,26 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				RequiredProviders: map[string]interface{}{},
 			},
 		},
+		{
+			"terraform path empty string",
+			&TerraformConfig{
+				Version:    String(""),
+				Log:        Bool(false),
+				PersistLog: Bool(false),
+				Path:       String(""),
+				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
+			},
+			nil,
+			&TerraformConfig{
+				Version:           String(""),
+				Log:               Bool(false),
+				PersistLog:        Bool(false),
+				Path:              String(wd),
+				WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
+				Backend:           map[string]interface{}{},
+				RequiredProviders: map[string]interface{}{},
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Fixes the issue where if the path was an empty string, Terraform would be installed in
a temporary directory, but CTS expected the binary to be in the current working directory.
This aligns now with the behavior for when no path is provided.

Closes https://github.com/hashicorp/consul-terraform-sync/issues/212