### PR TITLE
Template newlines and expand tftmpl.Condition interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test-integration:
 # test-e2e runs e2e tests
 test-e2e: dev
 	@echo "==> Testing ${NAME} (e2e)"
-	@go test ./e2e -count=1 -timeout=100s -tags=e2e -v ./... ${TESTARGS}
+	@go test ./e2e -count=1 -timeout=100s -tags=e2e ./... ${TESTARGS}
 .PHONY: test-e2e
 
 # test-setup-e2e sets up the sync binary and permissions to run in circle

--- a/templates/tftmpl/condition.go
+++ b/templates/tftmpl/condition.go
@@ -18,9 +18,9 @@ var (
 // Condition handles appending a run condition's relevant templating for Terraform
 // generated files
 type Condition interface {
-	// sourceIncludesVariable returns if the module source expects to
+	// SourceIncludesVariable returns if the module source expects to
 	// include the condition variable.
-	sourceIncludesVariable() bool
+	SourceIncludesVariable() bool
 
 	// appendModuleAttribute writes to an HCL module body the condition variable
 	// as a module argument in main.tf file.
@@ -42,7 +42,7 @@ type Condition interface {
 // This is the default run condition
 type ServicesCondition struct{}
 
-func (c ServicesCondition) sourceIncludesVariable() bool {
+func (c ServicesCondition) SourceIncludesVariable() bool {
 	return false
 }
 
@@ -68,7 +68,7 @@ type CatalogServicesCondition struct {
 	NodeMeta          map[string]string
 }
 
-func (c CatalogServicesCondition) sourceIncludesVariable() bool {
+func (c CatalogServicesCondition) SourceIncludesVariable() bool {
 	return c.SourceIncludesVar
 }
 

--- a/templates/tftmpl/condition.go
+++ b/templates/tftmpl/condition.go
@@ -23,7 +23,7 @@ type Condition interface {
 type ServicesCondition struct{}
 
 func (c *ServicesCondition) appendTemplate(w io.Writer) error {
-	// no-op: services conditon currently requires no additional condition
+	// no-op: services condition currently requires no additional condition
 	// templating. it relies on the monitoring template as the run condition
 	return nil
 }
@@ -83,18 +83,20 @@ func (c *CatalogServicesCondition) hcatQuery() string {
 	return ""
 }
 
-const catalogServicesConditionTmpl = `{{- with $catalogServices := catalogServicesRegistration %s}}
+const catalogServicesConditionTmpl = `
+{{- with $catalogServices := catalogServicesRegistration %s}}
   {{- range $cs := $catalogServices }}
     {{- /* Empty template. Detects changes in catalog-services */ -}}
 {{- end}}{{- end}}
-
 `
 
-const catalogServicesConditionIncludesVarTmpl = `catalog_services = {
+var catalogServicesConditionIncludesVarTmpl = fmt.Sprintf(`
+catalog_services = {%s}
+`, catalogServicesBaseTmpl)
+
+const catalogServicesBaseTmpl = `
 {{- with $catalogServices := catalogServicesRegistration %s}}
   {{- range $cs := $catalogServices }}
   "{{ $cs.Name }}" = {{ HCLServiceTags $cs.Tags }}
 {{- end}}{{- end}}
-}
-
 `

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -67,8 +67,8 @@ func TestInitRootModule(t *testing.T) {
 			"one":       cty.NumberIntVal(1),
 			"bool_true": cty.BoolVal(true),
 		},
-		Path:      dir,
-		FilePerms: expectedPerm,
+		Path:         dir,
+		FilePerms:    expectedPerm,
 		skipOverride: true,
 	}
 	err = InitRootModule(&input)

--- a/templates/tftmpl/module_variables.go
+++ b/templates/tftmpl/module_variables.go
@@ -68,6 +68,7 @@ func newModuleVariablesTF(w io.Writer, filename string, input *RootModuleInputDa
 
 	hclFile := hclwrite.NewEmptyFile()
 	rootBody := hclFile.Body()
+	rootBody.AppendNewline()
 
 	lastIdx := len(input.Variables) - 1
 	for i, name := range input.Variables.Keys() {

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -386,7 +386,7 @@ func appendRootModuleBlock(body *hclwrite.Body, task Task, cond Condition,
 		hcl.TraverseAttr{Name: "services"},
 	})
 
-	if cond != nil && cond.sourceIncludesVariable() {
+	if cond != nil && cond.SourceIncludesVariable() {
 		cond.appendModuleAttribute(moduleBody)
 	}
 

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -386,11 +386,8 @@ func appendRootModuleBlock(body *hclwrite.Body, task Task, cond Condition,
 		hcl.TraverseAttr{Name: "services"},
 	})
 
-	if v, ok := cond.(*CatalogServicesCondition); ok && v.SourceIncludesVar {
-		moduleBody.SetAttributeTraversal("catalog_services", hcl.Traversal{
-			hcl.TraverseRoot{Name: "var"},
-			hcl.TraverseAttr{Name: "catalog_services"},
-		})
+	if cond != nil && cond.sourceIncludesVariable() {
+		cond.appendModuleAttribute(moduleBody)
 	}
 
 	if len(varNames) != 0 {

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -68,7 +68,6 @@ var (
 	// beginning of generated module files.
 	TaskPreamble = `# Task: %s
 # Description: %s
-
 `
 
 	rootFileFuncs = map[string]tfFileFunc{
@@ -252,6 +251,7 @@ func newMainTF(w io.Writer, filename string, input *RootModuleInputData) error {
 
 	hclFile := hclwrite.NewEmptyFile()
 	rootBody := hclFile.Body()
+	rootBody.AppendNewline()
 	appendRootTerraformBlock(rootBody, input.backend, input.ProviderInfo)
 	rootBody.AppendNewline()
 	appendRootProviderBlocks(rootBody, input.Providers)

--- a/templates/tftmpl/tfvars.go
+++ b/templates/tftmpl/tfvars.go
@@ -41,6 +41,7 @@ func newProvidersTFVars(w io.Writer, filename string, input *RootModuleInputData
 
 	hclFile := hclwrite.NewEmptyFile()
 	body := hclFile.Body()
+	body.AppendNewline()
 
 	lastIdx := len(input.Providers) - 1
 	for i, p := range input.Providers {
@@ -83,6 +84,7 @@ func appendRawServiceTemplateValues(body *hclwrite.Body, services []Service) {
 	tokens = append(tokens, &hclwrite.Token{
 		Bytes: []byte("\n}"),
 	})
+	body.AppendNewline()
 	body.SetAttributeRaw("services", tokens)
 }
 

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -48,17 +48,6 @@ variable "services" {
 }
 `)
 
-// VariableCatalogServices is required for modules that include catalog-services
-// information. It is versioned to track compatibility between the generated
-// root module and modules that include catalog-services.
-var VariableCatalogServices = []byte(`
-# Catalog Services definition protocol v0
-variable "catalog_services" {
-  description = "Consul catalog service names and list of all known tags for a given service"
-  type = map(list(string))
-}
-`)
-
 // newVariablesTF writes variable definitions to a file. This includes the
 // required services variable and generated provider variables based on CTS
 // user configuration for the task.
@@ -72,8 +61,8 @@ func newVariablesTF(w io.Writer, filename string, input *RootModuleInputData) er
 		return err
 	}
 
-	if v, ok := input.Condition.(*CatalogServicesCondition); ok && v.SourceIncludesVar {
-		if _, err = w.Write(VariableCatalogServices); err != nil {
+	if input.Condition != nil && input.Condition.sourceIncludesVariable() {
+		if err = input.Condition.appendVariable(w); err != nil {
 			return err
 		}
 	}

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -61,7 +61,7 @@ func newVariablesTF(w io.Writer, filename string, input *RootModuleInputData) er
 		return err
 	}
 
-	if input.Condition != nil && input.Condition.sourceIncludesVariable() {
+	if input.Condition != nil && input.Condition.SourceIncludesVariable() {
 		if err = input.Condition.appendVariable(w); err != nil {
 			return err
 		}

--- a/templates/tftmpl/variables.go
+++ b/templates/tftmpl/variables.go
@@ -19,8 +19,8 @@ var tfVersionSensitive = goVersion.Must(goVersion.NewSemver("0.14.0"))
 
 // VariableServices is versioned to track compatibility with the generated
 // root module with modules.
-var VariableServices = []byte(
-	`# Service definition protocol v0
+var VariableServices = []byte(`
+# Service definition protocol v0
 variable "services" {
   description = "Consul services monitored by Consul Terraform Sync"
   type = map(

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -28,8 +27,6 @@ type TestConsulServerConfig struct {
 
 // NewTestConsulServer starts a test Consul server as configured
 func NewTestConsulServer(tb testing.TB, config TestConsulServerConfig) *testutil.TestServer {
-	log.SetOutput(ioutil.Discard)
-
 	var certFile string
 	var keyFile string
 	if config.HTTPSRelPath != "" {


### PR DESCRIPTION
The newline changes don't effect the end result, but changes the extra newlines to be added by the caller instead of included in the template bits inconsistently.

The second commit around Condition interface is more of an opinionated change to group all condition related stuff to the Condition types instead of each file template managing the different condition template/generated code independently. Lmk if you prefer for me to leave out the second commit.