### PR TITLE
Test for CatalogServicesRegistrationQuery query parameter filtering in Fetch()

### DIFF
--- a/e2e/condition_test.go
+++ b/e2e/condition_test.go
@@ -5,7 +5,6 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -245,110 +244,6 @@ func TestCondition_CatalogServices_Regexp(t *testing.T) {
 
 	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
 	assert.Contains(t, content, `"api-web" = []`)
-
-	cleanup()
-}
-
-// TestCondition_CatalogServices_NodeMeta runs the CTS binary. It specifically
-// tests a task configured with a catalog service condition with the node-meta
-// configuration set. This test confirms that when a service is registered with
-// a Consul server that does not have the configured node-meta:
-//  1) the task is not triggered (determined by confirming from the Task Status
-//     API that an event had not been added)
-//  2) the service information does not exist in the tfvars file
-func TestCondition_CatalogServices_NodeMeta(t *testing.T) {
-	t.Parallel()
-
-	// start a regular server
-	srv1 := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
-		HTTPSRelPath: "../testutils",
-	})
-	defer srv1.Stop()
-
-	// start another server with custom node-meta
-	srv2, err := testutil.NewTestServerConfigT(t,
-		func(c *testutil.TestServerConfig) {
-			c.Bootstrap = false
-			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
-			c.NodeMeta = map[string]string{"k": "v"}
-		})
-	require.NoError(t, err, "failed to start consul server 2")
-	defer srv2.Stop()
-
-	// join the two servers
-	srv1.JoinLAN(t, srv2.LANAddr)
-
-	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "cs_condition_node_meta")
-	cleanup := testutils.MakeTempDir(t, tempDir)
-
-	taskName := "catalog_task"
-	conditionTask := fmt.Sprintf(`task {
-	name = "%s"
-	source = "./test_modules/local_tags_file"
-	condition "catalog-services" {
-		regexp = "api"
-		node_meta {
-			k = "v"
-		}
-		source_includes_var = true
-	}
-}
-`, taskName)
-
-	config := baseConfig().appendConsulBlock(srv1).appendTerraformBlock(tempDir).
-		appendString(conditionTask)
-	configPath := filepath.Join(tempDir, configFile)
-	config.write(t, configPath)
-
-	cts, stop := api.StartCTS(t, configPath)
-	defer stop(t)
-
-	err = cts.WaitForAPI(defaultWaitForAPI)
-	require.NoError(t, err)
-
-	// Test that node-meta filter is filtering service registration information
-	// and task triggers
-	// 0. Confirm baseline: check current number of events and that that no
-	//    catalog_service variable contains no service information
-	// 1. Register service with server with no node-meta. Confirm that the task
-	//    was not triggered (no new event) and data is filtered out of
-	//    catalog_service.
-	// 2. Register service with server with configured node-meta. Confirm that
-	//    task was triggered (one new event) and its data exists in catalog_service.
-
-	// 0. Confirm only one event. Confirm empty var catalog_services
-	eventCountBase := eventCount(t, taskName, cts.Port())
-	require.Equal(t, 1, eventCountBase)
-
-	workingDir := fmt.Sprintf("%s/%s", tempDir, taskName)
-	content := testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
-	assert.Contains(t, content, "catalog_services = {\n}")
-
-	// 1. Register a filtered out service with server 1 (no node-meta)
-	srv1.AddAddressableService(t, "api", testutil.HealthPassing, "1.2.3.4", 8080,
-		[]string{"tag_a"})
-	time.Sleep(defaultWaitForNoEvent)
-
-	eventCountNow := eventCount(t, taskName, cts.Port())
-	require.Equal(t, eventCountBase, eventCountNow,
-		"change in event count. task was unexpectedly triggered")
-
-	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
-	assert.Contains(t, content, "catalog_services = {\n}")
-
-	// 2. Register a matched service with server 2 (with configured node-meta)
-	srv2.AddAddressableService(t, "api", testutil.HealthPassing, "1.2.3.4", 8080,
-		[]string{"tag_b"})
-	time.Sleep(defaultWaitForNoEvent)
-
-	eventCountNow = eventCount(t, taskName, cts.Port())
-	require.Equal(t, eventCountBase+1, eventCountNow,
-		"event count did not increment once. task was not triggered as expected")
-
-	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
-	assert.Contains(t, content, `"api" = ["tag_b"]`)
 
 	cleanup()
 }

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -124,7 +124,7 @@ func (d *catalogServicesRegistrationQuery) Fetch(clients dep.Clients) (interface
 
 	var catalogServices []*dep.CatalogSnippet
 	for name, tags := range entries {
-		if !d.regexp.MatchString(name) {
+		if d.regexp != nil && !d.regexp.MatchString(name) {
 			continue
 		}
 		catalogServices = append(catalogServices, &dep.CatalogSnippet{

--- a/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
@@ -1,10 +1,18 @@
 package tmplfunc
 
 import (
+	"io/ioutil"
 	"regexp"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/consul-terraform-sync/testutils"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/hashicorp/hcat/dep"
+	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewCatalogServicesRegistrationQuery(t *testing.T) {
@@ -146,4 +154,150 @@ func TestCatalogServicesRegistrationQuery_String(t *testing.T) {
 			assert.Equal(t, tc.exp, d.String())
 		})
 	}
+}
+
+func TestCatalogServicesRegistrationQuery_Fetch(t *testing.T) {
+	t.Parallel()
+
+	// Test is fetching services from a Consul cluster set-up as:
+	// dc1: (wan joined with dc2)
+	//   - node: srv1 (no node-meta) (lan joined with srv2)
+	//      - server instance: api-1
+	//   - node: srv2 (with node-meta)
+	//      - server instance: api-web-1
+	//      - server instance: web-1
+	// dc2:
+	//   - node: srv3 (no node-meta)
+	//      - server instance: db-1
+
+	// set up nodes
+	srv1 := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{})
+	defer srv1.Stop()
+
+	tb := &testutils.TestingTB{}
+	srv2, err := testutil.NewTestServerConfigT(tb,
+		func(c *testutil.TestServerConfig) {
+			c.Bootstrap = false
+			c.LogLevel = "warn"
+			c.Stdout = ioutil.Discard
+			c.Stderr = ioutil.Discard
+			c.NodeMeta = map[string]string{"k": "v"}
+		})
+
+	require.NoError(t, err, "failed to start consul server 2")
+	defer srv2.Stop()
+
+	srv3, err := testutil.NewTestServerConfigT(tb,
+		func(c *testutil.TestServerConfig) {
+			c.Datacenter = "dc2"
+			c.Bootstrap = true
+			c.LogLevel = "warn"
+			c.Stdout = ioutil.Discard
+			c.Stderr = ioutil.Discard
+		})
+	require.NoError(t, err, "failed to start consul server 3")
+	defer srv3.Stop()
+
+	// join nodes
+	srv1.JoinLAN(t, srv2.LANAddr) // dc1: srv1, srv2
+	srv1.JoinWAN(t, srv3.WANAddr) // dc2: srv3
+
+	// register services
+	service := testutil.TestService{ID: "api-1", Name: "api", Tags: []string{"tag1"}}
+	testutils.RegisterConsulService(t, srv1, service, testutil.HealthPassing, 8*time.Second)
+
+	service = testutil.TestService{ID: "api-web-1", Name: "api-web"}
+	testutils.RegisterConsulService(t, srv2, service, testutil.HealthPassing, 8*time.Second)
+
+	service = testutil.TestService{ID: "web-1", Name: "web"}
+	testutils.RegisterConsulService(t, srv2, service, testutil.HealthPassing, 8*time.Second)
+
+	service = testutil.TestService{ID: "db-1", Name: "db"}
+	testutils.RegisterConsulService(t, srv3, service, testutil.HealthPassing, 8*time.Second)
+
+	// set up consul client for srv1
+	consulConfig := consulapi.DefaultConfig()
+	consulConfig.Address = srv1.HTTPAddr
+	client, err := consulapi.NewClient(consulConfig)
+	require.NoError(t, err, "failed to make consul client")
+
+	cases := []struct {
+		name     string
+		i        []string
+		expected []*dep.CatalogSnippet
+	}{
+		{
+			"no filtering (in dc1)",
+			[]string{},
+			[]*dep.CatalogSnippet{
+				{Name: "api", Tags: dep.ServiceTags([]string{"tag1"})},
+				{Name: "api-web", Tags: dep.ServiceTags([]string{})},
+				{Name: "consul", Tags: dep.ServiceTags([]string{})},
+				{Name: "web", Tags: dep.ServiceTags([]string{})},
+			},
+		},
+		{
+			"node-meta filter (in dc1)",
+			[]string{"node-meta=k:v"},
+			[]*dep.CatalogSnippet{
+				{Name: "api-web", Tags: dep.ServiceTags([]string{})},
+				{Name: "consul", Tags: dep.ServiceTags([]string{})},
+				{Name: "web", Tags: dep.ServiceTags([]string{})},
+			},
+		},
+		{
+			"regexp filter (in dc1)",
+			[]string{"regexp=api"},
+			[]*dep.CatalogSnippet{
+				{Name: "api", Tags: dep.ServiceTags([]string{"tag1"})},
+				{Name: "api-web", Tags: dep.ServiceTags([]string{})},
+			},
+		},
+		{
+			"dc filter",
+			[]string{"dc=dc2"},
+			[]*dep.CatalogSnippet{
+				{Name: "consul", Tags: dep.ServiceTags([]string{})},
+				{Name: "db", Tags: dep.ServiceTags([]string{})},
+			},
+		},
+		{
+			"all filters (besides namespace)",
+			[]string{"dc=dc1", "regexp=api", "node-meta=k:v"},
+			[]*dep.CatalogSnippet{
+				{Name: "api-web", Tags: dep.ServiceTags([]string{})},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := newCatalogServicesRegistrationQuery(tc.i)
+			assert.NoError(t, err)
+
+			actual, _, err := d.Fetch(&testClient{consul: client})
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+// testClient implements hcat's dep.Client interface used to make requests
+// to Consul and Vault
+type testClient struct {
+	consul *consulapi.Client
+}
+
+// Consul returns the Consul client
+func (c *testClient) Consul() *consulapi.Client {
+	if c == nil {
+		return nil
+	}
+	return c.consul
+}
+
+// Vault returns the Vault client
+func (c *testClient) Vault() *vaultapi.Client {
+	// no-op: currently no need to support Vault
+	return nil
 }


### PR DESCRIPTION
Changes:
 - Add testing for various query parameters for Fetch()
 - Catch a regexp nil-pointer edge-case from testing (regexp can't be nil when running
 CTS e2e)
 - Remove e2e test that was only able to test node-meta query parameter
 filtering and was over-scoped (also unnecessarily tested triggering)

Context: addresses's @ findkim comment that testing node-meta as an e2e test was
overscoped and that the main test case is around query filtering (thanks!) https://github.com/hashicorp/consul-terraform-sync/pull/278#discussion_r631158825