### PR TITLE
E2E test for parsing Terraform validate

### DIFF
--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -207,20 +207,21 @@ func (t *TerraformCLI) Validate(ctx context.Context) error {
 		sb.WriteByte('\n')
 		switch d.Detail {
 		case `An argument named "services" is not expected here.`:
-			fmt.Fprintf(&sb, "%s is missing the \"services\" variable\n", *d.Snippet.Context)
+			fmt.Fprintf(&sb, `module for task "%s" is missing the "services" variable`, t.workspace)
 		case `An argument named "catalog_services" is not expected here.`:
 			fmt.Fprintf(
 				&sb,
-				"%s is missing the \"catalog_services\" variable, add to module or set source_includes_var to false\n",
-				*d.Snippet.Context)
+				`module for task "%s" is missing the "catalog_services" variable, add to module or set "source_includes_var" to false`,
+				t.workspace)
 		default:
 			fmt.Fprintf(&sb, "%s: %s\n", d.Severity, d.Summary)
 			if d.Range != nil && d.Snippet != nil {
 				fmt.Fprintf(&sb, "\non %s line %d, in %s\n", d.Range.Filename, d.Range.Start.Line, *d.Snippet.Context)
 				fmt.Fprintf(&sb, "%d:%s\n\n", d.Snippet.StartLine, d.Snippet.Code)
 			}
-			fmt.Fprintf(&sb, "%s\n\n", d.Detail)
+			sb.WriteString(d.Detail)
 		}
+		sb.WriteByte('\n')
 	}
 
 	if !output.Valid {

--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -287,7 +287,10 @@ func TestTerraformCLIValidate(t *testing.T) {
 module for task "test-workspace" is missing the "services" variable
 `,
 			`{
+	"format_version": "0.1",
 	"valid": false,
+	"error_count": 1,
+	"warning_count": 0,
 	"diagnostics": [
 		{
 			"severity": "error",
@@ -296,17 +299,27 @@ module for task "test-workspace" is missing the "services" variable
 			"range": {
 				"filename": "main.tf",
 				"start": {
-					"line": 32
+					"line": 31,
+					"column": 3,
+					"byte": 845
+				},
+				"end": {
+					"line": 31,
+					"column": 11,
+					"byte": 853
 				}
 			},
 			"snippet": {
-				"context": "module \"example-module\"",
-				"code": "  service = var.service",
-				"start_line": 32
+				"context": "module \"example-task\"",
+				"code": "  services = var.services",
+				"start_line": 31,
+				"highlight_start_offset": 2,
+				"highlight_end_offset": 10,
+				"values": []
 			}
 		}
 	]
-}`,
+}`, // Terraform v0.15 output
 		},
 		{
 			"missing catalog_services error",
@@ -315,6 +328,8 @@ module for task "test-workspace" is missing the "catalog_services" variable, add
 `,
 			`{
 	"valid": false,
+	"error_count": 1,
+	"warning_count": 0,
 	"diagnostics": [
 		{
 			"severity": "error",
@@ -323,12 +338,19 @@ module for task "test-workspace" is missing the "catalog_services" variable, add
 			"range": {
 				"filename": "main.tf",
 				"start": {
-					"line": 32
+					"line": 32,
+					"column": 3,
+					"byte": 887
+				},
+				"end": {
+					"line": 32,
+					"column": 19,
+					"byte": 903
 				}
 			}
 		}
 	]
-}`,
+}`,	// Terraform v0.13/v0.14 output
 		},
 		{
 			"warning",

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -284,75 +284,40 @@ func TestE2ELocalBackend(t *testing.T) {
 func TestE2EValidateError(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		version string
-	}{
-		{
-			"",	// default/fallback version
-		},
-		{
-			"0.13.7",
-		},
-		{
-			"0.14.11",
-		},
-		{
-			"0.15.5",
-		},
-	}
+	srv := newTestConsulServer(t)
+	defer srv.Stop()
+
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "validate_errors")
+	delete := testutils.MakeTempDir(t, tempDir)
+	// no defer to delete directory: only delete at end of test if no errors
 	
-	for _, tc := range cases {		
-		srv := newTestConsulServer(t)
-		defer srv.Stop()
-
-		tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "validate_errors")
-		delete := testutils.MakeTempDir(t, tempDir)
-		// no defer to delete directory: only delete at end of test if no errors
-
-		tfPath, err := filepath.Abs(tempDir)
-		require.NoError(t, err)
-		
-		var version string
-		if tc.version != "" {
-			version = fmt.Sprintf(`version = "%s"`, tc.version)
-		}
-		tfBlock := fmt.Sprintf(`
-		driver "terraform" {
-			log = true
-			path = "%s"
-			working_dir = "%s"
-			%s
-		}
-		`, tfPath, tempDir, version)
-
-		configPath := filepath.Join(tempDir, configFile)
-		taskName := "cts_error_task"
-		conditionTask := fmt.Sprintf(`task {
-		name = "%s"
-		source = "./test_modules/incompatible_w_cts"
-		services = ["api", "db"]
-		condition "catalog-services" {
-			source_includes_var = true
-		}
+	configPath := filepath.Join(tempDir, configFile)
+	taskName := "cts_error_task"
+	conditionTask := fmt.Sprintf(`task {
+	name = "%s"
+	source = "./test_modules/incompatible_w_cts"
+	services = ["api", "db"]
+	condition "catalog-services" {
+		source_includes_var = true
 	}
-	`, taskName)
+}
+`, taskName)
 
-		config := baseConfig().appendConsulBlock(srv).appendString(tfBlock).
-			appendString(conditionTask)
-		config.write(t, configPath)
-		cmd := exec.Command("consul-terraform-sync", fmt.Sprintf("--config-file=%s", configPath))
-		var buf bytes.Buffer
-		cmd.Stdout = &buf
-		cmd.Stderr = &buf
+	config := baseConfig().appendConsulBlock(srv).appendTerraformBlock(tempDir).
+		appendString(conditionTask)
+	config.write(t, configPath)
+	cmd := exec.Command("consul-terraform-sync", fmt.Sprintf("--config-file=%s", configPath))
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
 
-		cmd.Run()
-		assert.Contains(t, buf.String(), fmt.Sprintf(`module for task "%s" is missing the "services" variable`, taskName))
-		require.Contains(t,
-			buf.String(),
-			fmt.Sprintf(`module for task "%s" is missing the "catalog_services" variable, add to module or set "source_includes_var" to false`,
-				taskName))
-		delete()
-	}
+	cmd.Run()
+	assert.Contains(t, buf.String(), fmt.Sprintf(`module for task "%s" is missing the "services" variable`, taskName))
+	require.Contains(t,
+		buf.String(),
+		fmt.Sprintf(`module for task "%s" is missing the "catalog_services" variable, add to module or set "source_includes_var" to false`,
+			taskName))
+	delete()
 }
 
 func newTestConsulServer(t *testing.T) *testutil.TestServer {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,14 +3,17 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
+	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -275,6 +278,80 @@ func TestE2ELocalBackend(t *testing.T) {
 
 			delete()
 		})
+	}
+}
+
+func TestE2EValidateError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		version string
+	}{
+		{
+			"",	// default/fallback version
+		},
+		{
+			"0.13.7",
+		},
+		{
+			"0.14.11",
+		},
+		{
+			"0.15.5",
+		},
+	}
+	
+	for _, tc := range cases {		
+		srv := newTestConsulServer(t)
+		defer srv.Stop()
+
+		tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "validate_errors")
+		delete := testutils.MakeTempDir(t, tempDir)
+		// no defer to delete directory: only delete at end of test if no errors
+
+		tfPath, err := filepath.Abs(tempDir)
+		require.NoError(t, err)
+		
+		var version string
+		if tc.version != "" {
+			version = fmt.Sprintf(`version = "%s"`, tc.version)
+		}
+		tfBlock := fmt.Sprintf(`
+		driver "terraform" {
+			log = true
+			path = "%s"
+			working_dir = "%s"
+			%s
+		}
+		`, tfPath, tempDir, version)
+
+		configPath := filepath.Join(tempDir, configFile)
+		taskName := "cts_error_task"
+		conditionTask := fmt.Sprintf(`task {
+		name = "%s"
+		source = "./test_modules/incompatible_w_cts"
+		services = ["api", "db"]
+		condition "catalog-services" {
+			source_includes_var = true
+		}
+	}
+	`, taskName)
+
+		config := baseConfig().appendConsulBlock(srv).appendString(tfBlock).
+			appendString(conditionTask)
+		config.write(t, configPath)
+		cmd := exec.Command("consul-terraform-sync", fmt.Sprintf("--config-file=%s", configPath))
+		var buf bytes.Buffer
+		cmd.Stdout = &buf
+		cmd.Stderr = &buf
+
+		cmd.Run()
+		assert.Contains(t, buf.String(), fmt.Sprintf(`module for task "%s" is missing the "services" variable`, taskName))
+		require.Contains(t,
+			buf.String(),
+			fmt.Sprintf(`module for task "%s" is missing the "catalog_services" variable, add to module or set "source_includes_var" to false`,
+				taskName))
+		delete()
 	}
 }
 

--- a/e2e/test_modules/incompatible_w_cts/main.tf
+++ b/e2e/test_modules/incompatible_w_cts/main.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "address" {}
+

--- a/e2e/test_modules/incompatible_w_cts/variables.tf
+++ b/e2e/test_modules/incompatible_w_cts/variables.tf
@@ -1,0 +1,3 @@
+variable "test" {
+}
+


### PR DESCRIPTION
Also fixes the error message which did not work for TF v0.13 and v0.14 because they did not return the context. I also realized the context was showing the task name and not the module name anyway, so this new message is more informative either way.

- Add e2e test so that if the error messages changes in newer versions of terraform, we will know to adjust accordingly
- Updated error message to determine task name from current workspace and improve some formatting
- Assert that specific error message is returned in unit test
- Include entire validate output in unit test (previously was just the info we cared about)
- Add test cases to unit test for both v0.13/v0.14 and v0.15 outputs
