### PR TITLE
Deprecate driver.working_dir in preference for global working_dir

### DIFF
--- a/api/server_test.go
+++ b/api/server_test.go
@@ -291,13 +291,12 @@ func Test_Task_Update(t *testing.T) {
 		delete := testutils.MakeTempDir(t, tempDir)
 		defer delete()
 
-		task, err := driver.NewTask(driver.TaskConfig{Enabled: true})
+		task, err := driver.NewTask(driver.TaskConfig{Enabled: true, WorkingDir: tempDir})
 		require.NoError(t, err)
 
 		// add a driver
 		d, err := driver.NewTerraform(&driver.TerraformConfig{
 			Task:       task,
-			WorkingDir: tempDir,
 			ClientType: "test",
 		})
 		require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -281,6 +281,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected := longConfig.Copy()
 	expected.ClientType = String("")
 	expected.Port = Int(8502)
+	expected.WorkingDir = String("working")
 	expected.Syslog.Facility = String("LOCAL0")
 	expected.BufferPeriod.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")
@@ -299,6 +300,7 @@ func TestConfig_Finalize(t *testing.T) {
 	(*expected.Tasks)[0].VarFiles = []string{}
 	(*expected.Tasks)[0].Version = String("")
 	(*expected.Tasks)[0].BufferPeriod = DefaultTaskBufferPeriodConfig()
+	(*expected.Tasks)[0].WorkingDir = String("working/task")
 	(*expected.Services)[0].ID = String("serviceA")
 	(*expected.Services)[0].Namespace = String("")
 	(*expected.Services)[0].Datacenter = String("")

--- a/config/driver_test.go
+++ b/config/driver_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -155,7 +154,7 @@ func TestDriverConfig_Finalize(t *testing.T) {
 					Log:               Bool(false),
 					PersistLog:        Bool(false),
 					Path:              String(wd),
-					WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
+					WorkingDir:        nil,
 					Backend:           map[string]interface{}{},
 					RequiredProviders: map[string]interface{}{},
 				},
@@ -174,7 +173,7 @@ func TestDriverConfig_Finalize(t *testing.T) {
 					Log:               Bool(true),
 					PersistLog:        Bool(false),
 					Path:              String(wd),
-					WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
+					WorkingDir:        nil,
 					Backend:           map[string]interface{}{},
 					RequiredProviders: map[string]interface{}{},
 				},

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -40,6 +40,7 @@ func TestTaskConfig_Copy(t *testing.T) {
 						"key": "value",
 					},
 				},
+				WorkingDir: String("cts-dir"),
 			},
 		},
 	}
@@ -263,6 +264,30 @@ func TestTaskConfig_Merge(t *testing.T) {
 			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
 			&TaskConfig{Condition: &CatalogServicesConditionConfig{Regexp: String(".*")}},
 		},
+		{
+			"working_dir_overrides",
+			&TaskConfig{WorkingDir: String("cts-dir")},
+			&TaskConfig{WorkingDir: String("cts-dir-override")},
+			&TaskConfig{WorkingDir: String("cts-dir-override")},
+		},
+		{
+			"working_dir_empty_one",
+			&TaskConfig{WorkingDir: String("cts-dir")},
+			&TaskConfig{},
+			&TaskConfig{WorkingDir: String("cts-dir")},
+		},
+		{
+			"working_dir_empty_two",
+			&TaskConfig{},
+			&TaskConfig{WorkingDir: String("cts-dir")},
+			&TaskConfig{WorkingDir: String("cts-dir")},
+		},
+		{
+			"working_dir_same",
+			&TaskConfig{WorkingDir: String("cts-dir")},
+			&TaskConfig{WorkingDir: String("cts-dir")},
+			&TaskConfig{WorkingDir: String("cts-dir")},
+		},
 	}
 
 	for i, tc := range cases {
@@ -293,6 +318,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
 				Condition:    DefaultConditionConfig(),
+				WorkingDir:   String("sync-tasks"),
 			},
 		},
 		{
@@ -311,13 +337,14 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
 				Condition:    DefaultConditionConfig(),
+				WorkingDir:   String("sync-tasks/task"),
 			},
 		},
 	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
-			tc.i.Finalize()
+			tc.i.Finalize(DefaultWorkingDir)
 			assert.Equal(t, tc.r, tc.i)
 		})
 	}
@@ -594,7 +621,7 @@ func TestTaskConfig_FinalizeValidate(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.config.Finalize()
+			tc.config.Finalize(DefaultWorkingDir)
 			err := tc.config.Validate()
 			if tc.valid {
 				assert.NoError(t, err)

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -11,15 +11,9 @@ import (
 	goVersion "github.com/hashicorp/go-version"
 )
 
-const (
-	// DefaultTFBackendKVPath is the default KV path used for configuring the
-	// default backend to use Consul KV.
-	DefaultTFBackendKVPath = "consul-terraform-sync/terraform"
-
-	// DefaultTFWorkingDir is the default location where Sync will use as the
-	// working directory to manage infrastructure.
-	DefaultTFWorkingDir = "sync-tasks"
-)
+// DefaultTFBackendKVPath is the default KV path used for configuring the
+// default backend to use Consul KV.
+const DefaultTFBackendKVPath = "consul-terraform-sync/terraform"
 
 // TerraformConfig is the configuration for the Terraform driver.
 type TerraformConfig struct {
@@ -45,7 +39,6 @@ func DefaultTerraformConfig() *TerraformConfig {
 		Log:               Bool(false),
 		PersistLog:        Bool(false),
 		Path:              String(wd),
-		WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
 		Backend:           make(map[string]interface{}),
 		RequiredProviders: make(map[string]interface{}),
 	}
@@ -230,8 +223,15 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 		c.Path = String(wd)
 	}
 
-	if c.WorkingDir == nil || *c.WorkingDir == "" {
-		c.WorkingDir = String(path.Join(wd, DefaultTFWorkingDir))
+	if c.WorkingDir != nil {
+		// intentionally left as nil for the top-level config to override
+		// log a warning message if the configuration is not configured to the
+		// default location.
+		log.Println("[WARN] (config) The 'driver.working_dir' configuration " +
+			"option was marked for deprecation in v0.3.0 and will be removed in " +
+			"v0.5.0 of Consul-Terraform-Sync. Please update your configuration " +
+			"to use 'working_dir' or configure the working directory individually " +
+			"for each task with the 'task.working_dir' option.")
 	}
 
 	if c.Backend == nil {

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -421,7 +420,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:               Bool(false),
 				PersistLog:        Bool(false),
 				Path:              String(wd),
-				WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir:        nil,
 				Backend:           map[string]interface{}{},
 				RequiredProviders: map[string]interface{}{},
 			},
@@ -435,7 +434,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
-				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir: nil,
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address": *consul.Address,
@@ -461,7 +460,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
-				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir: nil,
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address":   *consul.Address,
@@ -488,7 +487,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(wd),
-				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir: nil,
 				Backend: map[string]interface{}{
 					"consul": map[string]interface{}{
 						"address": "127.0.0.1:8080",
@@ -506,7 +505,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:        Bool(false),
 				PersistLog: Bool(false),
 				Path:       String(""),
-				WorkingDir: String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir: nil,
 			},
 			nil,
 			&TerraformConfig{
@@ -514,7 +513,7 @@ func TestTerraformConfig_Finalize(t *testing.T) {
 				Log:               Bool(false),
 				PersistLog:        Bool(false),
 				Path:              String(wd),
-				WorkingDir:        String(path.Join(wd, DefaultTFWorkingDir)),
+				WorkingDir:        nil,
 				Backend:           map[string]interface{}{},
 				RequiredProviders: map[string]interface{}{},
 			},

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -211,7 +210,6 @@ func newTerraformDriver(conf *config.Config, task *driver.Task, w templates.Watc
 		Log:               *tfConf.Log,
 		PersistLog:        *tfConf.PersistLog,
 		Path:              *tfConf.Path,
-		WorkingDir:        filepath.Join(*tfConf.WorkingDir, task.Name()),
 		Backend:           tfConf.Backend,
 		RequiredProviders: tfConf.RequiredProviders,
 		ClientType:        *conf.ClientType,
@@ -262,6 +260,7 @@ func newDriverTasks(conf *config.Config, providerConfigs driver.TerraformProvide
 			Version:      *t.Version,
 			BufferPeriod: getTemplateBufferPeriod(conf, t),
 			Condition:    t.Condition,
+			WorkingDir:   *t.WorkingDir,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("error initializing task %s: %s", *t.Name, err)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -217,6 +217,7 @@ func TestNewDriverTasks(t *testing.T) {
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,
 				},
+				WorkingDir: "sync-tasks/name",
 			})},
 		}, {
 			// Fetches correct provider and required_providers blocks from config
@@ -282,6 +283,7 @@ func TestNewDriverTasks(t *testing.T) {
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,
 				},
+				WorkingDir: "sync-tasks/name",
 			})},
 		}, {
 			// Task env is fetched from providers and Consul config when using
@@ -332,6 +334,7 @@ func TestNewDriverTasks(t *testing.T) {
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,
 				},
+				WorkingDir: "sync-tasks/name",
 			})},
 		},
 	}

--- a/driver/task.go
+++ b/driver/task.go
@@ -64,6 +64,7 @@ type Task struct {
 	version      string
 	bufferPeriod *BufferPeriod // nil when disabled
 	condition    config.ConditionConfig
+	workingDir   string
 }
 
 type TaskConfig struct {
@@ -79,6 +80,7 @@ type TaskConfig struct {
 	Version      string
 	BufferPeriod *BufferPeriod
 	Condition    config.ConditionConfig
+	WorkingDir   string
 }
 
 func NewTask(conf TaskConfig) (*Task, error) {
@@ -107,6 +109,7 @@ func NewTask(conf TaskConfig) (*Task, error) {
 		version:      conf.Version,
 		bufferPeriod: conf.BufferPeriod,
 		condition:    conf.Condition,
+		workingDir:   conf.WorkingDir,
 	}, nil
 }
 
@@ -255,6 +258,14 @@ func (t *Task) Version() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.version
+}
+
+// WorkingDir returns the working directory to manage generated artifacts for
+// the task.
+func (t *Task) WorkingDir() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.workingDir
 }
 
 func (s Service) Copy() Service {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -55,10 +55,9 @@ type Terraform struct {
 	watcher    templates.Watcher
 	fileReader func(string) ([]byte, error)
 
-	workingDir string
-	client     client.Client
-	logClient  bool
-	postApply  handler.Handler
+	client    client.Client
+	logClient bool
+	postApply handler.Handler
 
 	inited bool
 }
@@ -69,7 +68,6 @@ type TerraformConfig struct {
 	Log               bool
 	PersistLog        bool
 	Path              string
-	WorkingDir        string
 	Backend           map[string]interface{}
 	RequiredProviders map[string]interface{}
 	Watcher           templates.Watcher
@@ -80,22 +78,23 @@ type TerraformConfig struct {
 // NewTerraform configures and initializes a new Terraform driver for a task.
 // The underlying Terraform CLI client and out-of-band handlers are prepared.
 func NewTerraform(config *TerraformConfig) (*Terraform, error) {
-	if _, err := os.Stat(config.WorkingDir); os.IsNotExist(err) {
-		if err := os.Mkdir(config.WorkingDir, workingDirPerms); err != nil {
+	task := config.Task
+	taskName := task.Name()
+	wd := task.WorkingDir()
+	if _, err := os.Stat(wd); os.IsNotExist(err) {
+		if err := os.MkdirAll(wd, workingDirPerms); err != nil {
 			log.Printf("[ERR] (driver.terraform) error creating task work directory: %s", err)
 			return nil, err
 		}
 	}
 
-	task := config.Task
-	taskName := task.Name()
 	tfClient, err := newClient(&clientConfig{
 		clientType: config.ClientType,
 		log:        config.Log,
 		taskName:   taskName,
 		persistLog: config.PersistLog,
 		path:       config.Path,
-		workingDir: config.WorkingDir,
+		workingDir: wd,
 		varFiles:   task.VariableFiles(),
 	})
 	if err != nil {
@@ -126,7 +125,6 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 		task:              config.Task,
 		backend:           config.Backend,
 		requiredProviders: config.RequiredProviders,
-		workingDir:        config.WorkingDir,
 		client:            tfClient,
 		logClient:         config.Log,
 		postApply:         handler,
@@ -354,7 +352,7 @@ func (tf *Terraform) initTask() error {
 	input := tftmpl.RootModuleInputData{
 		TerraformVersion: TerraformVersion,
 		Backend:          tf.backend,
-		Path:             tf.workingDir,
+		Path:             tf.task.WorkingDir(),
 		FilePerms:        filePerms,
 	}
 	tf.task.configureRootModuleInput(&input)
@@ -473,8 +471,9 @@ func (tf *Terraform) applyTask(ctx context.Context) error {
 
 // initTaskTemplate creates templates to be monitored and rendered.
 func (tf *Terraform) initTaskTemplate() error {
-	tmplFullpath := filepath.Join(tf.workingDir, tftmpl.TFVarsTmplFilename)
-	tfvarsFilepath := filepath.Join(tf.workingDir, tftmpl.TFVarsFilename)
+	wd := tf.task.WorkingDir()
+	tmplFullpath := filepath.Join(wd, tftmpl.TFVarsTmplFilename)
+	tfvarsFilepath := filepath.Join(wd, tftmpl.TFVarsFilename)
 
 	content, err := tf.fileReader(tmplFullpath)
 	if err != nil {

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -280,12 +280,11 @@ func TestUpdateTask(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			tf := &Terraform{
-				mu:         &sync.RWMutex{},
-				workingDir: tc.dirName,
-				task:       &Task{name: "test_task", enabled: tc.orig.Enabled},
-				client:     c,
-				resolver:   r,
-				watcher:    w,
+				mu:       &sync.RWMutex{},
+				task:     &Task{name: "test_task", enabled: tc.orig.Enabled, workingDir: tc.dirName},
+				client:   c,
+				resolver: r,
+				watcher:  w,
 			}
 
 			if tc.callInit {
@@ -380,12 +379,11 @@ func TestUpdateTask(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			tf := &Terraform{
-				mu:         &sync.RWMutex{},
-				workingDir: tc.dirName,
-				task:       &Task{name: "test_task", enabled: false},
-				client:     c,
-				resolver:   r,
-				watcher:    w,
+				mu:       &sync.RWMutex{},
+				task:     &Task{name: "test_task", enabled: false, workingDir: tc.dirName},
+				client:   c,
+				resolver: r,
+				watcher:  w,
 				fileReader: func(string) ([]byte, error) {
 					return []byte{}, tc.fileReaderErr
 				},

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -48,13 +48,13 @@ func TestServicesRenderRace(t *testing.T) {
 	}
 	conf.Tasks = &config.TaskConfigs{
 		&config.TaskConfig{
-			Name:     config.String("serv_rend_race_task"),
-			Source:   config.String("./test_modules/null_resource"),
-			Services: serviceNames,
+			Name:       config.String("serv_rend_race_task"),
+			Source:     config.String("./test_modules/null_resource"),
+			Services:   serviceNames,
+			WorkingDir: config.String(tempDir),
 		}}
 	conf.Consul.Address = config.String(srv.HTTPAddr)
 	conf.Finalize()
-	conf.Driver.Terraform.WorkingDir = config.String(tempDir)
 	path, err := filepath.Abs("./")
 	require.NoError(t, err)
 	conf.Driver.Terraform.Path = config.String(path)

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -73,7 +73,7 @@ func TestServicesRenderRace(t *testing.T) {
 	require.NoError(t, err)
 
 	// veryify results
-	tfvarsFile := filepath.Join(tempDir, "serv_rend_race_task", "terraform.tfvars")
+	tfvarsFile := filepath.Join(tempDir, "terraform.tfvars")
 	data, err := os.ReadFile(tfvarsFile)
 	require.NoError(t, err)
 	// 'svc_name_' is unique per service and much easier to count than


### PR DESCRIPTION
The working directory is more associated with each task and its Terraform workspace than the driver.

Related #314