### PR TITLE
Move validate call to be part of task initialization

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -113,12 +113,7 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 
 		err = d.InitTask(ctx)
 		if err != nil {
-			log.Printf("[ERR] (ctrl) error initializing task %q: %s", taskName, err)
-			return nil, err
-		}
-
-		err = d.ValidateTask(ctx)
-		if err != nil {
+			log.Printf("[ERR] (ctrl) error initializing task %q", taskName)
 			return nil, err
 		}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -96,27 +96,17 @@ func TestBaseControllerInit(t *testing.T) {
 		name            string
 		expectError     bool
 		initTaskErr     error
-		validateTaskErr error
 		config          *config.Config
 	}{
 		{
 			"error on driver.InitTask()",
 			true,
 			errors.New("error on driver.InitTask()"),
-			nil,
-			conf,
-		},
-		{
-			"error on driver.ValidateTask()",
-			true,
-			nil,
-			errors.New("error on driver.ValidateTask()"),
 			conf,
 		},
 		{
 			"happy path",
 			false,
-			nil,
 			nil,
 			conf,
 		},
@@ -127,7 +117,6 @@ func TestBaseControllerInit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
 			d.On("InitTask", mock.Anything).Return(tc.initTaskErr).Once()
-			d.On("ValidateTask", mock.Anything).Return(tc.validateTaskErr).Once()
 
 			baseCtrl := baseController{
 				newDriver: func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -182,7 +182,6 @@ func TestOnce(t *testing.T) {
 		d.On("RenderTemplate", mock.Anything).Return(false, nil).Once()
 		d.On("RenderTemplate", mock.Anything).Return(true, nil).Once()
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
-		d.On("ValidateTask", mock.Anything).Return(nil).Once()
 		d.On("ApplyTask", mock.Anything).Return(nil).Once()
 
 		rw := &ReadWrite{

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -29,9 +29,6 @@ type Driver interface {
 	// UpdateTask supports updating certain fields of a task
 	UpdateTask(ctx context.Context, task PatchTask) (InspectPlan, error)
 
-	// ValidateTask validates the configurations of the task
-	ValidateTask(ctx context.Context) error
-
 	// Task returns the task information of the driver
 	Task() *Task
 

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -361,8 +361,8 @@ func (tf *Terraform) initTask(ctx context.Context) error {
 	// initialize workspace
 	taskName := tf.task.Name()
 	if err := tf.init(ctx); err != nil {
-		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
-			"skipping validate for '%s'", taskName)
+		log.Printf("[ERR] (driver.terraform) error initializing workspace "+
+			"for task '%s'", taskName)
 		return err
 	}
 

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -148,7 +148,7 @@ func (tf *Terraform) Task() *Task {
 
 // InitTask initializes the task by creating the Terraform root module and related
 // files to execute on.
-func (tf *Terraform) InitTask(context.Context) error {
+func (tf *Terraform) InitTask(ctx context.Context) error {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
@@ -158,7 +158,7 @@ func (tf *Terraform) InitTask(context.Context) error {
 		return nil
 	}
 
-	return tf.initTask()
+	return tf.initTask(ctx)
 }
 
 // SetBufferPeriod sets the buffer period for the task. Do not set this when
@@ -280,7 +280,7 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 	}
 
 	if reinit {
-		if err := tf.initTask(); err != nil {
+		if err := tf.initTask(ctx); err != nil {
 			return InspectPlan{}, fmt.Errorf("Error updating task '%s'. Unable to init "+
 				"task: %s", taskName, err)
 		}
@@ -318,19 +318,6 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 	return InspectPlan{}, nil
 }
 
-// ValidateTask validates the generated configurations
-func (tf *Terraform) ValidateTask(ctx context.Context) error {
-	tf.mu.Lock()
-	defer tf.mu.Unlock()
-
-	if !tf.task.IsEnabled() {
-		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"validating", tf.task.Name())
-		return nil
-	}
-	return tf.validateTask(ctx)
-}
-
 // init initializes the Terraform workspace if needed
 func (tf *Terraform) init(ctx context.Context) error {
 	taskName := tf.task.Name()
@@ -350,7 +337,7 @@ func (tf *Terraform) init(ctx context.Context) error {
 }
 
 // initTask initializes the task
-func (tf *Terraform) initTask() error {
+func (tf *Terraform) initTask(ctx context.Context) error {
 	input := tftmpl.RootModuleInputData{
 		TerraformVersion: TerraformVersion,
 		Backend:          tf.backend,
@@ -370,6 +357,19 @@ func (tf *Terraform) initTask() error {
 	// task will require re-initializing terraform. Reset to false so terraform
 	// will reinit
 	tf.inited = false
+
+	// initialize workspace
+	taskName := tf.task.Name()
+	if err := tf.init(ctx); err != nil {
+		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
+			"skipping validate for '%s'", taskName)
+		return err
+	}
+
+	// validate workspace
+	if err := tf.validateTask(ctx); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -413,12 +413,6 @@ func (tf *Terraform) renderTemplate(ctx context.Context) (bool, error) {
 func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectPlan, error) {
 	taskName := tf.task.Name()
 
-	if err := tf.init(ctx); err != nil {
-		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
-			"skipping plan for '%s'", taskName)
-		return InspectPlan{}, err
-	}
-
 	var buf bytes.Buffer
 	if returnPlan {
 		tf.client.SetStdout(&buf)
@@ -448,12 +442,6 @@ func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectP
 // applyTask applies the task changes.
 func (tf *Terraform) applyTask(ctx context.Context) error {
 	taskName := tf.task.Name()
-
-	if err := tf.init(ctx); err != nil {
-		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
-			"skipping apply for '%s'", taskName)
-		return err
-	}
 
 	log.Printf("[TRACE] (driver.terraform) apply '%s'", taskName)
 	if err := tf.client.Apply(ctx); err != nil {
@@ -511,14 +499,6 @@ func (tf *Terraform) initTaskTemplate() error {
 }
 
 func (tf *Terraform) validateTask(ctx context.Context) error {
-	taskName := tf.task.Name()
-
-	if err := tf.init(ctx); err != nil {
-		log.Printf("[ERR] (driver.terraform) error initializing workspace, "+
-			"skipping validate for '%s'", taskName)
-		return err
-	}
-
 	err := tf.client.Validate(ctx)
 	if err != nil {
 		return err

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -119,20 +119,6 @@ func (_m *Driver) UpdateTask(ctx context.Context, task driver.PatchTask) (driver
 	return r0, r1
 }
 
-// ValidateTask provides a mock function with given fields: ctx
-func (_m *Driver) ValidateTask(ctx context.Context) error {
-	ret := _m.Called(ctx)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Version provides a mock function with given fields:
 func (_m *Driver) Version() string {
 	ret := _m.Called()


### PR DESCRIPTION
We determined that not all drivers may have a validate method, so removed validate
task from the interface and made it part of the Terraform driver InitTask method.
Also moves workspace initialization to InitTask and remove it from apply/inspect/validate.


New output:
```
2021/06/16 17:14:43.618472 [ERR] (ctrl) error initializing task "test-task"
2021/06/16 17:14:43.618496 [ERR] (cli) error initializing controller: 
module for task "test-task" is missing the "services" variable

module for task "test-task" is missing the "catalog_services" variable, add to module or set "source_includes_var" to false
```