### PR TITLE
Fix re-enabled task to trigger

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -496,12 +496,18 @@ func (tf *Terraform) initTaskTemplate() error {
 		FuncMapMerge: tmplfunc.HCLMap(metaMap),
 	})
 
-	if tf.template != nil && tf.template.ID() == tmpl.ID() {
-		// if the new template ID is the same as an existing one (e.g. during a
-		// task update), then the template content is the same. Template
-		// content must be unique.
-		// See: https://github.com/hashicorp/consul-terraform-sync/pull/167
-		return nil
+	if tf.template != nil {
+		if tf.template.ID() == tmpl.ID() {
+			// if the new template ID is the same as an existing one (e.g.
+			// during a task update), then the template content is the same.
+			// Template content must be unique.
+			// See: https://github.com/hashicorp/consul-terraform-sync/pull/167
+			return nil
+		}
+
+		// cleanup old template from watcher
+		tf.watcher.Mark(tf.template)
+		tf.watcher.Sweep(tf.template)
 	}
 
 	switch tf.task.Condition().(type) {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -389,6 +389,14 @@ func (tf *Terraform) renderTemplate(ctx context.Context) (bool, error) {
 			taskName, err)
 	}
 
+	// result.NoChange can occur when template rendering is forced even though
+	// there may be no dependency changes rather than naturally triggered
+	// e.g. when a task is re-enabled
+	if result.NoChange {
+		log.Printf("[DEBUG] (driver.terraform) no changes detected for task %s", taskName)
+		return true, nil
+	}
+
 	// result.Complete is only `true` if the template has new data that has been
 	// completely fetched.
 	if result.Complete {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -487,6 +487,15 @@ func (tf *Terraform) initTaskTemplate() error {
 		Renderer:     renderer,
 		FuncMapMerge: tmplfunc.HCLMap(metaMap),
 	})
+
+	if tf.template != nil && tf.template.ID() == tmpl.ID() {
+		// if the new template ID is the same as an existing one (e.g. during a
+		// task update), then the template content is the same. Template
+		// content must be unique.
+		// See: https://github.com/hashicorp/consul-terraform-sync/pull/167
+		return nil
+	}
+
 	switch tf.task.Condition().(type) {
 	case *config.CatalogServicesConditionConfig:
 		tf.template = notifier.NewCatalogServicesRegistration(tmpl,

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -30,12 +30,20 @@ func TestRenderTemplate(t *testing.T) {
 		runResult      hcat.ResolveEvent
 	}{
 		{
-			"happy path",
+			"happy path: changes",
 			false,
 			true,
 			nil,
 			nil,
 			hcat.ResolveEvent{Complete: true},
+		},
+		{
+			"happy path: no changes",
+			false,
+			true,
+			nil,
+			nil,
+			hcat.ResolveEvent{NoChange: true},
 		},
 		{
 			"data not completely fetched",

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -9,9 +9,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
+	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -194,6 +196,62 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	}
 
 	delete()
+}
+
+// TestE2E_ReenableTaskTriggers specifically tests the case were an enabled task
+// is disabled and then re-enabled. It confirms that the task triggered as
+// expected once re-enabled.
+// See https://github.com/hashicorp/consul-terraform-sync/issues/320
+func TestE2E_ReenableTaskTriggers(t *testing.T) {
+	t.Parallel()
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "reenable_trigger")
+	cleanup := testutils.MakeTempDir(t, tempDir)
+
+	configPath := filepath.Join(tempDir, configFile)
+	config := baseConfig().appendConsulBlock(srv).appendTerraformBlock(tempDir).appendDBTask()
+	config.write(t, configPath)
+
+	cts, stop := api.StartCTS(t, configPath)
+	defer stop(t)
+	err := cts.WaitForAPI(defaultWaitForAPI)
+	require.NoError(t, err)
+
+	// Test that regex filter is filtering service registration information and
+	// task triggers
+	// 0. Setup: disable task, re-enable it
+	// 1. Confirm baseline: check current number of events
+	// 2. Register api service instance. Confirm that the task was triggered
+	//    (one new event)
+
+	// 0. disable then re-enable the task
+	subcmd := []string{"task", "disable", fmt.Sprintf("-port=%d", cts.Port()), dbTaskName}
+	output, err := runSubcommand(t, "", subcmd...)
+	assert.NoError(t, err, output)
+
+	subcmd = []string{"task", "enable", fmt.Sprintf("-port=%d", cts.Port()), dbTaskName}
+	output, err = runSubcommand(t, "yes\n", subcmd...)
+	assert.NoError(t, err, output)
+
+	// 1. get current number of events
+	eventCountBase := eventCount(t, dbTaskName, cts.Port())
+
+	// 2. register api service. check triggers task
+	service := testutil.TestService{ID: "api-1", Name: "api"}
+	testutils.RegisterConsulService(t, srv, service, testutil.HealthPassing,
+		defaultWaitForRegistration)
+	api.WaitForEvent(t, cts, dbTaskName, time.Now(), defaultWaitForEvent)
+
+	eventCountNow := eventCount(t, dbTaskName, cts.Port())
+	require.Equal(t, eventCountBase+1, eventCountNow,
+		"event count did not increment once. task was not triggered as expected")
+
+	cleanup()
 }
 
 // runSubcommand runs a CTS subcommand and its arguments. If user input is

--- a/go.mod
+++ b/go.mod
@@ -23,15 +23,14 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-syslog v1.0.0
-	github.com/hashicorp/go-tfe v0.12.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586
+	github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/terraform-exec v0.13.3
-	github.com/hashicorp/terraform-json v0.10.0 // indirect
+	github.com/hashicorp/terraform-json v0.10.0
 	github.com/hashicorp/vault/api v1.1.0
 	github.com/hashicorp/vault/sdk v0.2.0 // indirect
 	github.com/klauspost/compress v1.11.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,7 +297,6 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -386,7 +385,6 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-raftchunking v0.6.1/go.mod h1:cGlg3JtDy7qy6c/3Bu660Mic1JF+7lWqIwCFSb08fX0=
-github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.2/go.mod h1:gEx6HMUGxYYhJScX7W1Il64m6cc2C1mDaW3NQ9sY1FY=
@@ -399,15 +397,11 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
-github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
-github.com/hashicorp/go-tfe v0.12.0 h1:teL523WPxwYzL5Gjc2QFxExndrMfWY4BXS2/olVpULM=
-github.com/hashicorp/go-tfe v0.12.0/go.mod h1:oT0AG5u/ROzWiw8JZFLDY6FLh6AZnJIG0Ahhvp10txg=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
@@ -423,8 +417,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586 h1:vXRdAjmBKNGs5rBi6yKB+jNONSpuqI1fjDwburKjPzk=
-github.com/hashicorp/hcat v0.0.0-20210519214441-ed61ff082586/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0 h1:EJu0QUeNQ1teDvoMexPH3QPGepFsxA3VKMejAs03Fnc=
+github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
@@ -710,8 +704,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=
-github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d/go.mod h1:BSTlc8jOjh0niykqEGVXOLXdi9o0r0kR8tCYiMvjFgw=
 github.com/tencentcloud/tencentcloud-sdk-go v3.0.83+incompatible/go.mod h1:0PfYow01SHPMhKY31xa+EFz2RStxIqj6JFAJS+IkCi4=
 github.com/tent/http-link-go v0.0.0-20130702225549-ac974c61c2f9/go.mod h1:RHkNRtSLfOK7qBTHaeSX1D6BNpI3qw7NTxsmNr4RvN8=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -44,6 +44,11 @@ func (_m *Watcher) Complete(_a0 hcat.Notifier) bool {
 	return r0
 }
 
+// Mark provides a mock function with given fields: notifier
+func (_m *Watcher) Mark(notifier hcat.IDer) {
+	_m.Called(notifier)
+}
+
 // Recaller provides a mock function with given fields: _a0
 func (_m *Watcher) Recaller(_a0 hcat.Notifier) hcat.Recaller {
 	ret := _m.Called(_a0)
@@ -89,6 +94,11 @@ func (_m *Watcher) Size() int {
 // Stop provides a mock function with given fields:
 func (_m *Watcher) Stop() {
 	_m.Called()
+}
+
+// Sweep provides a mock function with given fields: notifier
+func (_m *Watcher) Sweep(notifier hcat.IDer) {
+	_m.Called(notifier)
 }
 
 // WaitCh provides a mock function with given fields: _a0

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -42,9 +42,11 @@ type Resolver interface {
 type Watcher interface {
 	WaitCh(context.Context) <-chan error
 	Buffer(tmplID string) bool
+	Mark(notifier hcat.IDer)
 	SetBufferPeriod(min, max time.Duration, tmplIDs ...string)
 	Size() int
 	Stop()
+	Sweep(notifier hcat.IDer)
 	// not used but needed to meet the hcat.Watcherer interface
 	Complete(hcat.Notifier) bool
 	Recaller(hcat.Notifier) hcat.Recaller


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/consul-terraform-sync/issues/320

Draft PR: 
 - Depends on related hcat proposal https://github.com/hashicorp/hcat/pull/57 to be okayed
 - Failing e2e test requires this hcat update
 - Depends on a bug fix in branch `enable-event`. Once that branch is merged into v0.2.0, I'll adjust this PR to merge into v0.2.0 as well.

Fixes an issue where tasks that were originally enabled, then disabled, then re-enabled :) would hang and not trigger even when condition satisfied.

Commits (more details in commit msg):
 - Fix the original issue which occurs when a task is re-enabled, it creates another hcat template with the same template content (hcat template content must be unique https://github.com/hashicorp/consul-terraform-sync/pull/167 - thanks @ findkim!). Fix this by only creating a new hcat template only if content is different.
 - Fix a new issue that the fix above introduced. New issue occurs when existing (vs. new) hcat templates are forced to re-render when there are no dependency changes (as can happen when a task is enabled), the re-rendering will hang. Fix this by proposing an [hcat change](https://github.com/hashicorp/hcat/pull/57) to return result.Complete == true (which will prevent hanging) when there are no dependency changes