### PR TITLE
Temporarily disable benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
   weekly-benchmarks:
     jobs:
       - vault_integration_tests
-      - benchmarks
+      # - benchmarks (disabling temporarily)
     triggers:
       - schedule:
           # 02:10 UTC every Wednesday


### PR DESCRIPTION
Benchmarks are currently failing weekly. Disabling until we can prioritize
looking into why it is failing