### PR TITLE
Add error when setting terraform_version config option per task in OSS

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -297,6 +297,7 @@ func TestConfig_Finalize(t *testing.T) {
 	backend["ca_file"] = "ca_cert"
 	backend["key_file"] = "key"
 	(*expected.Tasks)[0].Enabled = Bool(true)
+	(*expected.Tasks)[0].TFVersion = String("")
 	(*expected.Tasks)[0].VarFiles = []string{}
 	(*expected.Tasks)[0].Version = String("")
 	(*expected.Tasks)[0].BufferPeriod = DefaultTaskBufferPeriodConfig()

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -217,6 +217,30 @@ func TestTaskConfig_Merge(t *testing.T) {
 			&TaskConfig{Version: String("0.0.0")},
 		},
 		{
+			"tf_version_merges",
+			&TaskConfig{TFVersion: String("0.14.0")},
+			&TaskConfig{TFVersion: String("0.15.5")},
+			&TaskConfig{TFVersion: String("0.15.5")},
+		},
+		{
+			"tf_version_empty_one",
+			&TaskConfig{TFVersion: String("0.15.0")},
+			&TaskConfig{},
+			&TaskConfig{TFVersion: String("0.15.0")},
+		},
+		{
+			"tf_version_empty_two",
+			&TaskConfig{},
+			&TaskConfig{TFVersion: String("0.15.0")},
+			&TaskConfig{TFVersion: String("0.15.0")},
+		},
+		{
+			"tf_version_same",
+			&TaskConfig{TFVersion: String("0.15.0")},
+			&TaskConfig{TFVersion: String("0.15.0")},
+			&TaskConfig{TFVersion: String("0.15.0")},
+		},
+		{
 			"enabled_overrides",
 			&TaskConfig{Enabled: Bool(false)},
 			&TaskConfig{Enabled: Bool(true)},
@@ -315,6 +339,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				Source:       String(""),
 				VarFiles:     []string{},
 				Version:      String(""),
+				TFVersion:    String(""),
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
 				Condition:    DefaultConditionConfig(),
@@ -334,6 +359,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				Source:       String(""),
 				VarFiles:     []string{},
 				Version:      String(""),
+				TFVersion:    String(""),
 				BufferPeriod: DefaultTaskBufferPeriodConfig(),
 				Enabled:      Bool(true),
 				Condition:    DefaultConditionConfig(),
@@ -451,6 +477,16 @@ func TestTaskConfig_Validate(t *testing.T) {
 			false,
 		},
 		{
+			"unsupported TF version per task",
+			&TaskConfig{
+				Name:      String("task"),
+				Services:  []string{"service"},
+				Source:    String("source"),
+				TFVersion: String("0.15.0"),
+			},
+			false,
+		},
+		{
 			"duplicate provider",
 			&TaskConfig{
 				Name:      String("task"),
@@ -491,12 +527,12 @@ func TestTasksConfig_Validate(t *testing.T) {
 		isValid bool
 	}{
 		{
-			"nil",
-			nil,
-			false,
+			name:    "nil",
+			i:       nil,
+			isValid: false,
 		}, {
-			"one task",
-			[]*TaskConfig{
+			name: "one task",
+			i: []*TaskConfig{
 				{
 					Name:      String("task"),
 					Services:  []string{"serviceA", "serviceB"},
@@ -504,10 +540,10 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Providers: []string{"providerA", "providerB"},
 				},
 			},
-			true,
+			isValid: true,
 		}, {
-			"two tasks",
-			[]*TaskConfig{
+			name: "two tasks",
+			i: []*TaskConfig{
 				{
 					Name:      String("task"),
 					Services:  []string{"serviceA", "serviceB"},
@@ -521,10 +557,10 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Providers: []string{"providerC"},
 				},
 			},
-			true,
+			isValid: true,
 		}, {
-			"duplicate task names",
-			[]*TaskConfig{
+			name: "duplicate task names",
+			i: []*TaskConfig{
 				{
 					Name:      String("task"),
 					Services:  []string{"serviceA", "serviceB"},
@@ -537,10 +573,10 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Providers: []string{"providerA"},
 				},
 			},
-			false,
+			isValid: false,
 		}, {
-			"one invalid",
-			[]*TaskConfig{
+			name: "one invalid",
+			i: []*TaskConfig{
 				{
 					Name:      String("task"),
 					Services:  []string{"serviceA", "serviceB"},
@@ -550,16 +586,27 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Name: String("invalid"),
 				},
 			},
-			false,
+			isValid: false,
 		}, {
-			"duplicate provider instances",
-			[]*TaskConfig{
+			name: "duplicate provider instances",
+			i: []*TaskConfig{
 				{
 					Name:      String("task"),
 					Providers: []string{"provider.A", "provider.B"},
 				},
 			},
-			false,
+			isValid: false,
+		}, {
+			name: "unsupported TF version per task",
+			i: []*TaskConfig{
+				{
+					Name:      String("task"),
+					Services:  []string{"serviceA", "serviceB"},
+					Source:    String("source"),
+					TFVersion: String("0.15.0"),
+				},
+			},
+			isValid: false,
 		},
 	}
 


### PR DESCRIPTION
The Terraform Cloud API allows configuring the Terraform CLI version for each workspace. A new option is being added to CTS enterprise to independently configure the TF version per task. The PR adds a user-friendly error to CTS OSS when trying to use an enterprise configuration option.

```
2021/07/06 14:56:09 [ERR] (cli) error validating configuration: unsupported configuration 'terraform_version' for task "test". This option is available for Consul-Terraform-Sync enterprise when using the Terraform Cloud driver, or configure the Terraform client version within the Terraform driver block
```

Related #327