### PR TITLE
Handle local module source relative paths in Terraform driver

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -346,6 +346,20 @@ func (tf *Terraform) initTask(ctx context.Context) error {
 		Path:             tf.task.WorkingDir(),
 		FilePerms:        filePerms,
 	}
+
+	// convert relative paths to absolute paths for local module sources
+	moduleSource := tf.task.source
+	if strings.HasPrefix(moduleSource, "./") || strings.HasPrefix(moduleSource, "../") {
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Println("[ERR] (driver.terraform) unable to retrieve current " +
+				"working directory to determine path to local module")
+			return err
+		}
+		moduleSource = filepath.Join(wd, tf.task.source)
+		tf.task.source = moduleSource
+	}
+
 	tf.task.configureRootModuleInput(&input)
 	if err := tftmpl.InitRootModule(&input); err != nil {
 		return err

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -349,7 +349,10 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 		require.NotNil(t, e.Config)
 		assert.Equal(t, []string{"fake-sync"}, e.Config.Providers)
 		assert.Equal(t, []string{"api"}, e.Config.Services)
-		assert.Equal(t, "./test_modules/local_instances_file", e.Config.Source)
+		wd, err := os.Getwd()
+		assert.NoError(t, err)
+		source := filepath.Join(wd, "./test_modules/local_instances_file")
+		assert.Equal(t, source, e.Config.Source)
 
 		if taskName == fakeSuccessTaskName {
 			assert.True(t, e.Success)

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -365,17 +365,7 @@ func appendRootModuleBlock(body *hclwrite.Body, task Task, cond Condition,
 	moduleBlock := body.AppendNewBlock("module", []string{task.Name})
 	moduleBody := moduleBlock.Body()
 
-	moduleSource := task.Source
-	if strings.HasPrefix(moduleSource, "./") || strings.HasPrefix(moduleSource, "../") {
-		wd, err := os.Getwd()
-		if err != nil {
-			log.Println("[ERR] (templates.tftmpl) unable to retrieve current " +
-				"working directory to determine path to local module")
-			log.Panic(err)
-		}
-		moduleSource = filepath.Join(wd, task.Source)
-	}
-	moduleBody.SetAttributeValue("source", cty.StringVal(moduleSource))
+	moduleBody.SetAttributeValue("source", cty.StringVal(task.Source))
 
 	if len(task.Version) > 0 {
 		moduleBody.SetAttributeValue("version", cty.StringVal(task.Version))

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -1,9 +1,6 @@
 package tftmpl
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
@@ -174,10 +171,6 @@ func TestAppendRootProviderBlocks(t *testing.T) {
 }
 
 func TestAppendRootModuleBlocks(t *testing.T) {
-	workingDir, err := os.Getwd()
-	require.Nil(t, err, "Error determining current working directory")
-	wdParent := filepath.Dir(workingDir)
-
 	testCases := []struct {
 		name     string
 		task     Task
@@ -243,40 +236,6 @@ module "test" {
   test2 = var.test2
 }
 `},
-		{
-			"local module within current directory",
-			Task{
-				Description: "user description for task named 'test'",
-				Name:        "test",
-				Source:      "./local-test-module",
-				Version:     "1.0.0",
-			},
-			nil,
-			nil,
-			fmt.Sprintf(`# user description for task named 'test'
-module "test" {
-  source   = "%s/local-test-module"
-  version  = "1.0.0"
-  services = var.services
-}
-`, workingDir)},
-		{
-			"local module in parent directory",
-			Task{
-				Description: "user description for task named 'test'",
-				Name:        "test",
-				Source:      "../local-test-module",
-				Version:     "1.0.0",
-			},
-			nil,
-			nil,
-			fmt.Sprintf(`# user description for task named 'test'
-module "test" {
-  source   = "%s/local-test-module"
-  version  = "1.0.0"
-  services = var.services
-}
-`, wdParent)},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The logic for converting the relative path to an absolute path is specific to
the Terraform driver, so moving it from the template code.