### PR TITLE
Fix UpdateTask race

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -32,9 +32,7 @@ type ClientConfig struct {
 // NewClient returns a client to make api requests
 func NewClient(c *ClientConfig, httpClient httpClient) *Client {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: time.Second * 5,
-		}
+		httpClient = &http.Client{}
 	}
 	return &Client{
 		port:    c.Port,

--- a/api/task.go
+++ b/api/task.go
@@ -87,6 +87,8 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		jsonErrorResponse(w, http.StatusNotFound, err)
 		return
 	}
+	h.drivers.SetActive(taskName)
+	defer h.drivers.SetInactive(taskName)
 
 	runOp, err := runOption(r)
 	if err != nil {

--- a/api/task.go
+++ b/api/task.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -121,8 +120,6 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		patch.Enabled = config.BoolVal(conf.Enabled)
 	}
 
-	ctx := context.Background()
-
 	var storedErr error
 	if runOp == driver.RunOptionNow {
 		task := d.Task()
@@ -150,7 +147,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		ev.Start()
 	}
 	var plan driver.InspectPlan
-	plan, storedErr = d.UpdateTask(ctx, patch)
+	plan, storedErr = d.UpdateTask(r.Context(), patch)
 	if storedErr != nil {
 		log.Printf("[TRACE] (api.task) error while updating task '%s': %s",
 			taskName, storedErr)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -26,6 +26,7 @@ type Controller interface {
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
 	Run(context.Context) error
 
+	// ServeAPI runs the API server for the controller
 	ServeAPI(context.Context) error
 
 	// Stop stops underlying clients and connections

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,10 +21,12 @@ import (
 type Controller interface {
 	// Init initializes elements needed by controller. Returns a map of
 	// taskname to driver
-	Init(ctx context.Context) (*driver.Drivers, error)
+	Init(context.Context) error
 
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
-	Run(ctx context.Context) error
+	Run(context.Context) error
+
+	ServeAPI(context.Context) error
 
 	// Stop stops underlying clients and connections
 	Stop()
@@ -35,20 +37,10 @@ type Oncer interface {
 	Once(ctx context.Context) error
 }
 
-// unit of work per template/task
-type unit struct {
-	taskName string
-	driver   driver.Driver
-
-	providers []string
-	services  []string
-	source    string
-}
-
 type baseController struct {
 	conf      *config.Config
 	newDriver func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error)
-	units     []unit
+	drivers   *driver.Drivers
 	watcher   templates.Watcher
 	resolver  templates.Resolver
 }
@@ -68,6 +60,7 @@ func newBaseController(conf *config.Config) (*baseController, error) {
 	return &baseController{
 		conf:      conf,
 		newDriver: nd,
+		drivers:   driver.NewDrivers(),
 		watcher:   watcher,
 		resolver:  hcat.NewResolver(),
 	}, nil
@@ -77,29 +70,29 @@ func (ctrl *baseController) Stop() {
 	ctrl.watcher.Stop()
 }
 
-func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
+func (ctrl *baseController) init(ctx context.Context) error {
 	log.Printf("[INFO] (ctrl) initializing driver")
 
 	// Load provider configuration and evaluate dynamic values
 	providerConfigs, err := ctrl.loadProviderConfigs(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Future: improve by combining tasks into workflows.
 	log.Printf("[INFO] (ctrl) initializing all tasks")
 	tasks, err := newDriverTasks(ctrl.conf, providerConfigs)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	units := make([]unit, 0, len(tasks))
-	drivers := driver.NewDrivers()
+
+	ctrl.drivers.Reset()
 
 	for _, task := range tasks {
 		select {
 		case <-ctx.Done():
 			// Stop initializing remaining tasks if context has stopped.
-			return nil, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
@@ -107,29 +100,20 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 		log.Printf("[DEBUG] (ctrl) initializing task %q", taskName)
 		d, err := ctrl.newDriver(ctrl.conf, task, ctrl.watcher)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = d.InitTask(ctx)
 		if err != nil {
 			log.Printf("[ERR] (ctrl) error initializing task %q", taskName)
-			return nil, err
+			return err
 		}
 
-		units = append(units, unit{
-			taskName:  taskName,
-			driver:    d,
-			providers: task.ProviderNames(),
-			services:  task.ServiceNames(),
-			source:    task.Source(),
-		})
-
-		drivers.Add(taskName, d)
+		ctrl.drivers.Add(taskName, d)
 	}
-	ctrl.units = units
 
 	log.Printf("[INFO] (ctrl) driver initialized")
-	return drivers, nil
+	return nil
 }
 
 // loadProviderConfigs loads provider configs and evaluates provider blocks

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
@@ -66,7 +65,7 @@ func TestNewControllers(t *testing.T) {
 			}
 
 			t.Run("readwrite", func(t *testing.T) {
-				controller, err := NewReadWrite(tc.conf, event.NewStore())
+				controller, err := NewReadWrite(tc.conf)
 				if tc.expectError {
 					assert.Error(t, err)
 					return
@@ -93,10 +92,10 @@ func TestBaseControllerInit(t *testing.T) {
 	conf := singleTaskConfig()
 
 	cases := []struct {
-		name            string
-		expectError     bool
-		initTaskErr     error
-		config          *config.Config
+		name        string
+		expectError bool
+		initTaskErr error
+		config      *config.Config
 	}{
 		{
 			"error on driver.InitTask()",
@@ -122,10 +121,12 @@ func TestBaseControllerInit(t *testing.T) {
 				newDriver: func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 					return d, nil
 				},
-				conf: tc.config,
+				drivers: driver.NewDrivers(),
+				conf:    tc.config,
 			}
+			baseCtrl.drivers.Add("foo", d)
 
-			_, err := baseCtrl.init(ctx)
+			err := baseCtrl.init(ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -76,6 +76,7 @@ func (ctrl *ReadOnly) Run(ctx context.Context) error {
 	}
 }
 
+// ServeAPI runs the API server for the controller
 func (ctrl *ReadOnly) ServeAPI(ctx context.Context) error {
 	return errors.New("server API is not supported for ReadOnly controller")
 }

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/hcat"
@@ -52,19 +53,19 @@ func TestReadOnlyRun(t *testing.T) {
 			w := new(mocks.Watcher)
 			w.On("Size").Return(5)
 
+			ctrl := ReadOnly{baseController: &baseController{
+				watcher: w,
+				drivers: driver.NewDrivers(),
+			}}
+
 			d := new(mocksD.Driver)
-			d.On("Task").Return(enabledTestTask(t))
+			d.On("Task").Return(enabledTestTask(t, "foo"))
 			d.On("RenderTemplate", mock.Anything).
 				Return(true, tc.renderTmplErr)
 			d.On("InspectTask", mock.Anything).Return(tc.inspectTaskErr)
+			ctrl.drivers.Add("foo", d)
 
-			ctrl := ReadOnly{baseController: &baseController{
-				watcher: w,
-				units:   []unit{{driver: d}},
-			}}
-			ctx := context.Background()
-
-			err := ctrl.Run(ctx)
+			err := ctrl.Run(context.Background())
 			if tc.expectError {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tc.name)
@@ -87,12 +88,15 @@ func TestReadOnlyRun_context_cancel(t *testing.T) {
 		On("Stop").Return()
 
 	d := new(mocksD.Driver)
-	d.On("Task").Return(enabledTestTask(t))
+	d.On("Task").Return(enabledTestTask(t, "foo"))
 	d.On("RenderTemplate", mock.Anything).Return(false, nil)
+	drivers := driver.NewDrivers()
+	drivers.Add("foo", d)
+
 	ctrl := ReadOnly{baseController: &baseController{
 		watcher:  w,
 		resolver: r,
-		units:    []unit{{driver: d}},
+		drivers:  drivers,
 	}}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -161,6 +161,7 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 	}
 }
 
+// ServeAPI runs the API server for the controller
 func (rw *ReadWrite) ServeAPI(ctx context.Context) error {
 	return api.NewAPI(rw.store, rw.drivers, config.IntVal(rw.conf.Port)).Serve(ctx)
 }

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -81,23 +81,28 @@ func TestReadWrite_CheckApply(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
+			drivers := driver.NewDrivers()
+			var task *driver.Task
 			if tc.enabledTask {
-				d.On("Task").Return(enabledTestTask(t))
+				task = enabledTestTask(t, tc.taskName)
 				d.On("RenderTemplate", mock.Anything).
 					Return(true, tc.renderTmplErr)
 				d.On("ApplyTask", mock.Anything).Return(tc.applyTaskErr)
 			} else {
-				d.On("Task").Return(disabledTestTask(t))
+				task = disabledTestTask(t, tc.taskName)
 			}
+			d.On("Task").Return(task)
+			drivers.Add(tc.taskName, d)
 
 			controller := ReadWrite{
-				baseController: &baseController{},
-				store:          event.NewStore(),
+				baseController: &baseController{
+					drivers: drivers,
+				},
+				store: event.NewStore(),
 			}
-			u := unit{taskName: tc.taskName, driver: d}
 			ctx := context.Background()
 
-			_, err := controller.checkApply(ctx, u, false)
+			_, err := controller.checkApply(ctx, d, false)
 			data := controller.store.Read(tc.taskName)
 			events := data[tc.taskName]
 
@@ -133,37 +138,35 @@ func TestReadWrite_CheckApply(t *testing.T) {
 func TestReadWrite_CheckApply_Store(t *testing.T) {
 	t.Run("mult-checkapply-store", func(t *testing.T) {
 		d := new(mocksD.Driver)
-		d.On("Task").Return(enabledTestTask(t))
+		d.On("Task").Return(enabledTestTask(t, "task_a"))
 		d.On("RenderTemplate", mock.Anything).Return(true, nil)
 		d.On("ApplyTask", mock.Anything).Return(nil)
 
 		disabledD := new(mocksD.Driver)
-		disabledD.On("Task").Return(disabledTestTask(t))
+		disabledD.On("Task").Return(disabledTestTask(t, "task_b"))
 
 		controller := ReadWrite{
-			baseController: &baseController{},
-			store:          event.NewStore(),
+			baseController: &baseController{
+				drivers: driver.NewDrivers(),
+			},
+			store: event.NewStore(),
 		}
 
-		unitA := unit{taskName: "task_a", driver: d}
-		unitB := unit{taskName: "task_b", driver: d}
-		unitC := unit{taskName: "task_c", driver: disabledD}
+		controller.drivers.Add("task_a", d)
+		controller.drivers.Add("task_b", disabledD)
 		ctx := context.Background()
 
-		controller.checkApply(ctx, unitA, false)
-		controller.checkApply(ctx, unitB, false)
-		controller.checkApply(ctx, unitC, false)
-		controller.checkApply(ctx, unitA, false)
-		controller.checkApply(ctx, unitA, false)
-		controller.checkApply(ctx, unitA, false)
-		controller.checkApply(ctx, unitB, false)
-		controller.checkApply(ctx, unitC, false)
+		controller.checkApply(ctx, d, false)
+		controller.checkApply(ctx, disabledD, false)
+		controller.checkApply(ctx, d, false)
+		controller.checkApply(ctx, d, false)
+		controller.checkApply(ctx, d, false)
+		controller.checkApply(ctx, disabledD, false)
 
 		taskStatuses := controller.store.Read("")
 
 		assert.Equal(t, 4, len(taskStatuses["task_a"]))
-		assert.Equal(t, 2, len(taskStatuses["task_b"]))
-		assert.Equal(t, 0, len(taskStatuses["task_c"]))
+		assert.Equal(t, 0, len(taskStatuses["task_b"]))
 	})
 }
 
@@ -178,11 +181,13 @@ func TestOnce(t *testing.T) {
 		w.On("Size").Return(5)
 
 		d := new(mocksD.Driver)
-		d.On("Task").Return(enabledTestTask(t)).Twice()
+		d.On("Task").Return(enabledTestTask(t, "task")).Twice()
 		d.On("RenderTemplate", mock.Anything).Return(false, nil).Once()
 		d.On("RenderTemplate", mock.Anything).Return(true, nil).Once()
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
 		d.On("ApplyTask", mock.Anything).Return(nil).Once()
+		drivers := driver.NewDrivers()
+		drivers.Add("task", d)
 
 		rw := &ReadWrite{
 			baseController: &baseController{
@@ -190,13 +195,14 @@ func TestOnce(t *testing.T) {
 				newDriver: func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 					return d, nil
 				},
-				conf: conf,
+				drivers: drivers,
+				conf:    conf,
 			},
 			store: event.NewStore(),
 		}
 
 		ctx := context.Background()
-		_, err := rw.Init(ctx)
+		err := rw.Init(ctx)
 		assert.NoError(t, err)
 
 		// testing really starts here...
@@ -223,23 +229,23 @@ func TestOnce(t *testing.T) {
 
 func TestReadWriteUnits(t *testing.T) {
 	t.Run("simple-success", func(t *testing.T) {
-		d := new(mocksD.Driver)
-		d.On("Task").Return(enabledTestTask(t))
-		d.On("InitWork", mock.Anything).Return(nil)
-		d.On("RenderTemplate", mock.Anything).Return(true, nil)
-		d.On("ApplyTask", mock.Anything).Return(nil)
-		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
-
-		u := unit{taskName: "foo", driver: d}
 		controller := ReadWrite{
 			baseController: &baseController{
-				units: []unit{u},
+				drivers: driver.NewDrivers(),
 			},
 			store: event.NewStore(),
 		}
 
+		d := new(mocksD.Driver)
+		d.On("Task").Return(enabledTestTask(t, "foo"))
+		d.On("InitWork", mock.Anything).Return(nil)
+		d.On("RenderTemplate", mock.Anything).Return(true, nil)
+		d.On("ApplyTask", mock.Anything).Return(nil)
+		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
+		controller.drivers.Add("foo", d)
+
 		ctx := context.Background()
-		errCh := controller.runUnits(ctx)
+		errCh := controller.runTasks(ctx)
 		err := <-errCh
 		if err != nil {
 			t.Error(err)
@@ -247,22 +253,22 @@ func TestReadWriteUnits(t *testing.T) {
 	})
 
 	t.Run("apply-error", func(t *testing.T) {
-		d := new(mocksD.Driver)
-		d.On("Task").Return(enabledTestTask(t))
-		d.On("InitWork", mock.Anything).Return(nil)
-		d.On("RenderTemplate", mock.Anything).Return(true, nil)
-		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
-
-		u := unit{taskName: "foo", driver: d}
 		controller := ReadWrite{
 			baseController: &baseController{
-				units: []unit{u},
+				drivers: driver.NewDrivers(),
 			},
 			store: event.NewStore(),
 		}
 
+		d := new(mocksD.Driver)
+		d.On("Task").Return(enabledTestTask(t, "foo"))
+		d.On("InitWork", mock.Anything).Return(nil)
+		d.On("RenderTemplate", mock.Anything).Return(true, nil)
+		d.On("ApplyTask", mock.Anything).Return(fmt.Errorf("test"))
+		controller.drivers.Add("foo", d)
+
 		ctx := context.Background()
-		errCh := controller.runUnits(ctx)
+		errCh := controller.runTasks(ctx)
 		err := <-errCh
 		testErr := fmt.Errorf("could not apply: %s", "test")
 		if errors.Is(err, testErr) {
@@ -280,7 +286,7 @@ func TestReadWriteRun_context_cancel(t *testing.T) {
 
 	ctl := ReadWrite{
 		baseController: &baseController{
-			units:   []unit{},
+			drivers: driver.NewDrivers(),
 			watcher: w,
 		},
 		store: event.NewStore(),
@@ -353,14 +359,20 @@ func singleTaskConfig() *config.Config {
 	return c
 }
 
-func enabledTestTask(tb testing.TB) *driver.Task {
-	task, err := driver.NewTask(driver.TaskConfig{Enabled: true})
+func enabledTestTask(tb testing.TB, name string) *driver.Task {
+	task, err := driver.NewTask(driver.TaskConfig{
+		Name:    name,
+		Enabled: true,
+	})
 	require.NoError(tb, err)
 	return task
 }
 
-func disabledTestTask(tb testing.TB) *driver.Task {
-	task, err := driver.NewTask(driver.TaskConfig{Enabled: false})
+func disabledTestTask(tb testing.TB, name string) *driver.Task {
+	task, err := driver.NewTask(driver.TaskConfig{
+		Name:    name,
+		Enabled: false,
+	})
 	require.NoError(tb, err)
 	return task
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -198,12 +198,14 @@ func (tf *Terraform) RenderTemplate(ctx context.Context) (bool, error) {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
+	taskName := tf.task.Name()
 	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"rendering template", tf.task.Name())
+			"rendering template", taskName)
 		return true, nil
 	}
 
+	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
 	re, err := tf.renderTemplate(ctx)
 	return re.Complete, err
 }
@@ -393,8 +395,6 @@ func (tf *Terraform) initTask(ctx context.Context) error {
 // renderTemplate attempts to render the hashicat template
 func (tf *Terraform) renderTemplate(ctx context.Context) (hcat.ResolveEvent, error) {
 	taskName := tf.task.Name()
-	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
-
 	result, err := tf.resolver.Run(tf.template, tf.watcher)
 	if err != nil {
 		log.Printf("[ERROR] (driver.terraform) checking dependency changes "+

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -166,7 +166,7 @@ task {
 	name = "%s"
 	description = "task is configured as disabled"
 	enabled = false
-	services = ["api"]
+	services = ["api", "web"]
 	providers = ["local"]
 	source = "./test_modules/local_instances_file"
 }

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -64,10 +63,10 @@ func TestServicesRenderRace(t *testing.T) {
 	require.NoError(t, err)
 
 	// run controller
-	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
+	ctrl, err := controller.NewReadWrite(conf)
 	rwCtrl := ctrl.(*controller.ReadWrite)
 	require.NoError(t, err)
-	_, err = rwCtrl.Init(ctx)
+	err = rwCtrl.Init(ctx)
 	require.NoError(t, err)
 	err = rwCtrl.Once(ctx)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0
+	github.com/hashicorp/hcat v0.0.0-20210624002026-a61d66355491
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0 h1:EJu0QUeNQ1teDvoMexPH3QPGepFsxA3VKMejAs03Fnc=
-github.com/hashicorp/hcat v0.0.0-20210621161842-de0babeb95b0/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210624002026-a61d66355491 h1:DS2xd1uop8fqiTaIAO1J8lx89wN6HsfyePYwB0DFKeY=
+github.com/hashicorp/hcat v0.0.0-20210624002026-a61d66355491/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=


### PR DESCRIPTION
An API request to update a task would race against the controller's main go routine and eventually caused a deadlock for the specific edge case when a task with multiple services starts off disabled and then is enabled via CLI/API.

My understanding of the root cause: On enabling, this would be the first time the task is run. The API request would initialize the template and wait for the template to fetch all dependencies. Meanwhile the controller gets notified on those dependency changes and then also attempt to render that same template. The API request is waiting for the controller/watcher to process the dependencies and mark that template as dirty. But that controller routine waits indefinitely for the lock that the API request had obtained and cannot proceed to call `watcher.Wait` in order for the API request to render the template and complete.

Fix: prevent both the controller and API server to run the same task at a given time by monitoring the active status of a task.
* This monitors the drivers that are actively running a task by the API server
* When a driver is active, the controller will skip running it and continue resuming to wait on the Watcher for changes and process dependency updates

Overview of changes
* Connect the context used for `UpdateTask` with the client request context so the API server can exit early if the client connection closes.
* Remove intermediate struct `unit` from the controller since all of that information resides in the driver
* Add active map to `driver.Drivers` and thread safe methods
* Simplify controller inits to only return error and not the driver
* Relate the API server to the controller, this allows the code to simplify what layers need information about `event.Store` and drivers.
