### PR TITLE
Fix handler to use http.Request context to react to client connection

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -32,9 +32,7 @@ type ClientConfig struct {
 // NewClient returns a client to make api requests
 func NewClient(c *ClientConfig, httpClient httpClient) *Client {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: time.Second * 5,
-		}
+		httpClient = &http.Client{}
 	}
 	return &Client{
 		port:    c.Port,

--- a/api/task.go
+++ b/api/task.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -121,8 +120,6 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		patch.Enabled = config.BoolVal(conf.Enabled)
 	}
 
-	ctx := context.Background()
-
 	var storedErr error
 	if runOp == driver.RunOptionNow {
 		task := d.Task()
@@ -150,7 +147,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		ev.Start()
 	}
 	var plan driver.InspectPlan
-	plan, storedErr = d.UpdateTask(ctx, patch)
+	plan, storedErr = d.UpdateTask(r.Context(), patch)
 	if storedErr != nil {
 		log.Printf("[TRACE] (api.task) error while updating task '%s': %s",
 			taskName, storedErr)


### PR DESCRIPTION
When client connection closes, the server would still attempt process the request to completion. Changes allow server to error and exit early