### PR TITLE
Refactor API server to stem from controller

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -13,7 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
 	"github.com/hashicorp/consul-terraform-sync/event"
@@ -230,7 +229,7 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 
 	go func() {
 		log.Printf("[INFO] (cli) initializing controller")
-		drivers, err := ctrl.Init(ctx)
+		_, err := ctrl.Init(ctx)
 		if err != nil {
 			if err == context.Canceled {
 				exitCh <- struct{}{}
@@ -263,8 +262,7 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 			if isInspect {
 				return
 			}
-			api := api.NewAPI(store, drivers, config.IntVal(conf.Port))
-			if err = api.Serve(ctx); err != nil {
+			if err = ctrl.ServeAPI(ctx); err != nil {
 				if err == context.Canceled {
 					exitCh <- struct{}{}
 					return

--- a/command/cli.go
+++ b/command/cli.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul-terraform-sync/version"
 	mcli "github.com/mitchellh/cli"
@@ -207,7 +206,6 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 
 	// Set up controller
 	conf.ClientType = config.String(clientType)
-	store := event.NewStore()
 	var ctrl controller.Controller
 	if isInspect {
 		log.Printf("[DEBUG] (cli) inspect mode enabled, processing then exiting")
@@ -215,7 +213,7 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 		ctrl, err = controller.NewReadOnly(conf)
 	} else {
 		log.Printf("[INFO] (cli) setting up controller: readwrite")
-		ctrl, err = controller.NewReadWrite(conf, store)
+		ctrl, err = controller.NewReadWrite(conf)
 	}
 	if err != nil {
 		log.Printf("[ERR] (cli) error setting up controller: %s", err)

--- a/command/cli.go
+++ b/command/cli.go
@@ -229,7 +229,7 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 
 	go func() {
 		log.Printf("[INFO] (cli) initializing controller")
-		_, err := ctrl.Init(ctx)
+		err := ctrl.Init(ctx)
 		if err != nil {
 			if err == context.Canceled {
 				exitCh <- struct{}{}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -26,6 +26,9 @@ type Controller interface {
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
 	Run(ctx context.Context) error
 
+	// ServeAPI runs the API server for the controller
+	ServeAPI(context.Context) error
+
 	// Stop stops underlying clients and connections
 	Stop()
 }
@@ -48,6 +51,7 @@ type unit struct {
 type baseController struct {
 	conf      *config.Config
 	newDriver func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error)
+	drivers   *driver.Drivers
 	units     []unit
 	watcher   templates.Watcher
 	resolver  templates.Resolver
@@ -126,6 +130,7 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 
 		drivers.Add(taskName, d)
 	}
+	ctrl.drivers = drivers
 	ctrl.units = units
 
 	log.Printf("[INFO] (ctrl) driver initialized")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -21,7 +21,7 @@ import (
 type Controller interface {
 	// Init initializes elements needed by controller. Returns a map of
 	// taskname to driver
-	Init(ctx context.Context) (*driver.Drivers, error)
+	Init(ctx context.Context) error
 
 	// Run runs the controller by monitoring Consul and triggering the driver as needed
 	Run(ctx context.Context) error
@@ -81,20 +81,20 @@ func (ctrl *baseController) Stop() {
 	ctrl.watcher.Stop()
 }
 
-func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
+func (ctrl *baseController) init(ctx context.Context) error {
 	log.Printf("[INFO] (ctrl) initializing driver")
 
 	// Load provider configuration and evaluate dynamic values
 	providerConfigs, err := ctrl.loadProviderConfigs(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Future: improve by combining tasks into workflows.
 	log.Printf("[INFO] (ctrl) initializing all tasks")
 	tasks, err := newDriverTasks(ctrl.conf, providerConfigs)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	units := make([]unit, 0, len(tasks))
 	drivers := driver.NewDrivers()
@@ -103,7 +103,7 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 		select {
 		case <-ctx.Done():
 			// Stop initializing remaining tasks if context has stopped.
-			return nil, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
@@ -111,13 +111,13 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 		log.Printf("[DEBUG] (ctrl) initializing task %q", taskName)
 		d, err := ctrl.newDriver(ctrl.conf, task, ctrl.watcher)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		err = d.InitTask(ctx)
 		if err != nil {
 			log.Printf("[ERR] (ctrl) error initializing task %q", taskName)
-			return nil, err
+			return err
 		}
 
 		units = append(units, unit{
@@ -134,7 +134,7 @@ func (ctrl *baseController) init(ctx context.Context) (*driver.Drivers, error) {
 	ctrl.units = units
 
 	log.Printf("[INFO] (ctrl) driver initialized")
-	return drivers, nil
+	return nil
 }
 
 // loadProviderConfigs loads provider configs and evaluates provider blocks

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
@@ -66,7 +65,7 @@ func TestNewControllers(t *testing.T) {
 			}
 
 			t.Run("readwrite", func(t *testing.T) {
-				controller, err := NewReadWrite(tc.conf, event.NewStore())
+				controller, err := NewReadWrite(tc.conf)
 				if tc.expectError {
 					assert.Error(t, err)
 					return

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -93,10 +93,10 @@ func TestBaseControllerInit(t *testing.T) {
 	conf := singleTaskConfig()
 
 	cases := []struct {
-		name            string
-		expectError     bool
-		initTaskErr     error
-		config          *config.Config
+		name        string
+		expectError bool
+		initTaskErr error
+		config      *config.Config
 	}{
 		{
 			"error on driver.InitTask()",
@@ -125,7 +125,7 @@ func TestBaseControllerInit(t *testing.T) {
 				conf: tc.config,
 			}
 
-			_, err := baseCtrl.init(ctx)
+			err := baseCtrl.init(ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sort"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
-	"github.com/hashicorp/consul-terraform-sync/driver"
 )
 
 var _ Controller = (*ReadOnly)(nil)
@@ -34,18 +32,8 @@ func NewReadOnly(conf *config.Config) (Controller, error) {
 }
 
 // Init initializes the controller before it can be run
-func (ctrl *ReadOnly) Init(ctx context.Context) (*driver.Drivers, error) {
-	drivers, err := ctrl.init(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Sort units for consistent ordering when inspecting tasks
-	sort.Slice(ctrl.units, func(i, j int) bool {
-		return ctrl.units[i].taskName < ctrl.units[j].taskName
-	})
-
-	return drivers, nil
+func (ctrl *ReadOnly) Init(ctx context.Context) error {
+	return ctrl.init(ctx)
 }
 
 // Run runs the controller in read-only mode by checking Consul catalog once for

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -83,6 +84,11 @@ func (ctrl *ReadOnly) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// ServeAPI runs the API server for the controller
+func (ctrl *ReadOnly) ServeAPI(ctx context.Context) error {
+	return errors.New("server API is not supported for ReadOnly controller")
 }
 
 func (ctrl *ReadOnly) checkInspect(ctx context.Context, u unit) (bool, error) {

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -31,7 +31,7 @@ type ReadWrite struct {
 }
 
 // NewReadWrite configures and initializes a new ReadWrite controller
-func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
+func NewReadWrite(conf *config.Config) (Controller, error) {
 	baseCtrl, err := newBaseController(conf)
 	if err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 
 	return &ReadWrite{
 		baseController: baseCtrl,
-		store:          store,
+		store:          event.NewStore(),
 		retry:          retry.NewRetry(defaultRetry, time.Now().UnixNano()),
 		taskNotify:     make(chan string, len(*conf.Tasks)),
 	}, nil

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
@@ -153,6 +154,11 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// ServeAPI runs the API server for the controller
+func (rw *ReadWrite) ServeAPI(ctx context.Context) error {
+	return api.NewAPI(rw.store, rw.drivers, config.IntVal(rw.conf.Port)).Serve(ctx)
 }
 
 // Single run, render, apply of a unit (task).

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/config"
-	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 )
@@ -48,7 +47,7 @@ func NewReadWrite(conf *config.Config, store *event.Store) (Controller, error) {
 
 // Init initializes the controller before it can be run. Ensures that
 // driver is initializes, works are created for each task.
-func (rw *ReadWrite) Init(ctx context.Context) (*driver.Drivers, error) {
+func (rw *ReadWrite) Init(ctx context.Context) error {
 	return rw.init(ctx)
 }
 

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -196,7 +196,7 @@ func TestOnce(t *testing.T) {
 		}
 
 		ctx := context.Background()
-		_, err := rw.Init(ctx)
+		err := rw.Init(ctx)
 		assert.NoError(t, err)
 
 		// testing really starts here...

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
@@ -40,7 +39,7 @@ func BenchmarkTaskTrigger(b *testing.B) {
 		numServices: 25,
 	})
 
-	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
+	ctrl, err := controller.NewReadWrite(conf)
 	rwCtrl := ctrl.(*controller.ReadWrite)
 	require.NoError(b, err)
 	err = rwCtrl.Init(ctx)

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -43,7 +43,7 @@ func BenchmarkTaskTrigger(b *testing.B) {
 	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
 	rwCtrl := ctrl.(*controller.ReadWrite)
 	require.NoError(b, err)
-	_, err = rwCtrl.Init(ctx)
+	err = rwCtrl.Init(ctx)
 	require.NoError(b, err)
 	err = rwCtrl.Once(ctx)
 	require.NoError(b, err)

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
@@ -57,7 +56,7 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 		numServices: numServices,
 	})
 
-	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
+	ctrl, err := controller.NewReadWrite(conf)
 	require.NoError(b, err)
 	rwCtrl := ctrl.(*controller.ReadWrite)
 

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -63,7 +63,7 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 
 	b.Run("task setup", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err = rwCtrl.Init(ctx)
+			err = rwCtrl.Init(ctx)
 			require.NoError(b, err)
 		}
 	})

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	"github.com/stretchr/testify/require"
 )
@@ -64,7 +63,7 @@ func TestServicesRenderRace(t *testing.T) {
 	require.NoError(t, err)
 
 	// run controller
-	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
+	ctrl, err := controller.NewReadWrite(conf)
 	rwCtrl := ctrl.(*controller.ReadWrite)
 	require.NoError(t, err)
 	err = rwCtrl.Init(ctx)

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -67,7 +67,7 @@ func TestServicesRenderRace(t *testing.T) {
 	ctrl, err := controller.NewReadWrite(conf, event.NewStore())
 	rwCtrl := ctrl.(*controller.ReadWrite)
 	require.NoError(t, err)
-	_, err = rwCtrl.Init(ctx)
+	err = rwCtrl.Init(ctx)
 	require.NoError(t, err)
 	err = rwCtrl.Once(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
The API contains identical objects as the controller and is
dependent on it. This proposes to move the API server to the
controller to keep controller details out of the main function:
drivers and event.Store