### PR TITLE
Remove intermediate struct units

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -38,21 +38,10 @@ type Oncer interface {
 	Once(ctx context.Context) error
 }
 
-// unit of work per template/task
-type unit struct {
-	taskName string
-	driver   driver.Driver
-
-	providers []string
-	services  []string
-	source    string
-}
-
 type baseController struct {
 	conf      *config.Config
 	newDriver func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error)
 	drivers   *driver.Drivers
-	units     []unit
 	watcher   templates.Watcher
 	resolver  templates.Resolver
 }
@@ -96,7 +85,6 @@ func (ctrl *baseController) init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	units := make([]unit, 0, len(tasks))
 	drivers := driver.NewDrivers()
 
 	for _, task := range tasks {
@@ -119,19 +107,9 @@ func (ctrl *baseController) init(ctx context.Context) error {
 			log.Printf("[ERR] (ctrl) error initializing task %q", taskName)
 			return err
 		}
-
-		units = append(units, unit{
-			taskName:  taskName,
-			driver:    d,
-			providers: task.ProviderNames(),
-			services:  task.ServiceNames(),
-			source:    task.Source(),
-		})
-
 		drivers.Add(taskName, d)
 	}
 	ctrl.drivers = drivers
-	ctrl.units = units
 
 	log.Printf("[INFO] (ctrl) driver initialized")
 	return nil

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/hcat"
@@ -52,19 +53,19 @@ func TestReadOnlyRun(t *testing.T) {
 			w := new(mocks.Watcher)
 			w.On("Size").Return(5)
 
+			ctrl := ReadOnly{baseController: &baseController{
+				watcher: w,
+				drivers: driver.NewDrivers(),
+			}}
+
 			d := new(mocksD.Driver)
-			d.On("Task").Return(enabledTestTask(t))
+			d.On("Task").Return(enabledTestTask(t, "task"))
 			d.On("RenderTemplate", mock.Anything).
 				Return(true, tc.renderTmplErr)
 			d.On("InspectTask", mock.Anything).Return(tc.inspectTaskErr)
+			ctrl.drivers.Add("task", d)
 
-			ctrl := ReadOnly{baseController: &baseController{
-				watcher: w,
-				units:   []unit{{driver: d}},
-			}}
-			ctx := context.Background()
-
-			err := ctrl.Run(ctx)
+			err := ctrl.Run(context.Background())
 			if tc.expectError {
 				if assert.Error(t, err) {
 					assert.Contains(t, err.Error(), tc.name)
@@ -87,12 +88,15 @@ func TestReadOnlyRun_context_cancel(t *testing.T) {
 		On("Stop").Return()
 
 	d := new(mocksD.Driver)
-	d.On("Task").Return(enabledTestTask(t))
+	d.On("Task").Return(enabledTestTask(t, "task"))
 	d.On("RenderTemplate", mock.Anything).Return(false, nil)
+	drivers := driver.NewDrivers()
+	drivers.Add("task", d)
+
 	ctrl := ReadOnly{baseController: &baseController{
 		watcher:  w,
 		resolver: r,
-		units:    []unit{{driver: d}},
+		drivers:  drivers,
 	}}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 )
@@ -58,9 +59,7 @@ func (rw *ReadWrite) Init(ctx context.Context) error {
 func (rw *ReadWrite) Run(ctx context.Context) error {
 	// Only initialize buffer periods for running the full loop and not for Once
 	// mode so it can immediately render the first time.
-	for _, u := range rw.units {
-		u.driver.SetBufferPeriod()
-	}
+	rw.drivers.SetBufferPeriod()
 
 	for i := int64(1); ; i++ {
 		// Blocking on Wait is first as we just ran in Once mode so we want
@@ -79,8 +78,8 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 
-		for err := range rw.runUnits(ctx) {
-			// aggregate error collector for runUnits, just logs everything for now
+		for err := range rw.runTasks(ctx) {
+			// aggregate error collector for runTasks, just logs everything for now
 			log.Printf("[ERR] (ctrl) %s", err)
 		}
 
@@ -90,23 +89,23 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 
 // A single run through of all the units/tasks/templates
 // Returned error channel closes when done with all units
-func (rw *ReadWrite) runUnits(ctx context.Context) chan error {
+func (rw *ReadWrite) runTasks(ctx context.Context) chan error {
 	// keep error chan and waitgroup here to keep runTask simple (on task)
 	errCh := make(chan error, 1)
 	wg := sync.WaitGroup{}
-	for _, u := range rw.units {
+	for taskName, d := range rw.drivers.Map() {
 		wg.Add(1)
-		go func(u unit) {
-			complete, err := rw.checkApply(ctx, u, true)
+		go func(taskName string, d driver.Driver) {
+			complete, err := rw.checkApply(ctx, d, true)
 			if err != nil {
 				errCh <- err
 			}
 
 			if rw.testMode && complete {
-				rw.taskNotify <- u.taskName
+				rw.taskNotify <- taskName
 			}
 			wg.Done()
-		}(u)
+		}(taskName, d)
 	}
 
 	go func() {
@@ -122,16 +121,17 @@ func (rw *ReadWrite) runUnits(ctx context.Context) chan error {
 func (rw *ReadWrite) Once(ctx context.Context) error {
 	log.Println("[INFO] (ctrl) executing all tasks once through")
 
-	completed := make(map[string]bool, len(rw.units))
+	driversCopy := rw.drivers.Map()
+	completed := make(map[string]bool, len(driversCopy))
 	for i := int64(0); ; i++ {
 		done := true
-		for _, u := range rw.units {
-			if !completed[u.taskName] {
-				complete, err := rw.checkApply(ctx, u, false)
+		for taskName, d := range driversCopy {
+			if !completed[taskName] {
+				complete, err := rw.checkApply(ctx, d, false)
 				if err != nil {
 					return err
 				}
-				completed[u.taskName] = complete
+				completed[taskName] = complete
 				if !complete && done {
 					done = false
 				}
@@ -167,19 +167,19 @@ func (rw *ReadWrite) ServeAPI(ctx context.Context) error {
 // driver.RenderTemplate() may be called many times per full task execution
 // since there could be many per full task execution i.e. when driver.RenderTemplate()
 // returns false, no event is stored.
-func (rw *ReadWrite) checkApply(ctx context.Context, u unit, retry bool) (bool, error) {
-	taskName := u.taskName
-	d := u.driver
-	if !d.Task().IsEnabled() {
+func (rw *ReadWrite) checkApply(ctx context.Context, d driver.Driver, retry bool) (bool, error) {
+	task := d.Task()
+	taskName := task.Name()
+	if !task.IsEnabled() {
 		log.Printf("[TRACE] (ctrl) skipping disabled task '%s'", taskName)
 		return true, nil
 	}
 
 	// setup to store event information
 	ev, err := event.NewEvent(taskName, &event.Config{
-		Providers: u.providers,
-		Services:  u.services,
-		Source:    u.source,
+		Providers: task.ProviderNames(),
+		Services:  task.ServiceNames(),
+		Source:    task.Source(),
 	})
 	if err != nil {
 		return false, fmt.Errorf("error creating event for task %s: %s",

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -67,3 +67,11 @@ func (d *Drivers) Map() map[string]Driver {
 	}
 	return copy
 }
+
+func (d *Drivers) SetBufferPeriod() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for _, driver := range d.drivers {
+		driver.SetBufferPeriod()
+	}
+}


### PR DESCRIPTION
Units became a redundant abstraction with the usage of drivers