### PR TITLE
Fix update race bug

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -32,9 +32,7 @@ type ClientConfig struct {
 // NewClient returns a client to make api requests
 func NewClient(c *ClientConfig, httpClient httpClient) *Client {
 	if httpClient == nil {
-		httpClient = &http.Client{
-			Timeout: time.Second * 5,
-		}
+		httpClient = &http.Client{}
 	}
 	return &Client{
 		port:    c.Port,

--- a/api/task.go
+++ b/api/task.go
@@ -88,6 +88,8 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		jsonErrorResponse(w, http.StatusNotFound, err)
 		return
 	}
+	h.drivers.SetActive(taskName)
+	defer h.drivers.SetInactive(taskName)
 
 	runOp, err := runOption(r)
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -61,6 +61,7 @@ func newBaseController(conf *config.Config) (*baseController, error) {
 	return &baseController{
 		conf:      conf,
 		newDriver: nd,
+		drivers:   driver.NewDrivers(),
 		watcher:   watcher,
 		resolver:  hcat.NewResolver(),
 	}, nil
@@ -85,7 +86,7 @@ func (ctrl *baseController) init(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	drivers := driver.NewDrivers()
+	ctrl.drivers.Reset()
 
 	for _, task := range tasks {
 		select {
@@ -107,9 +108,8 @@ func (ctrl *baseController) init(ctx context.Context) error {
 			log.Printf("[ERR] (ctrl) error initializing task %q", taskName)
 			return err
 		}
-		drivers.Add(taskName, d)
+		ctrl.drivers.Add(taskName, d)
 	}
-	ctrl.drivers = drivers
 
 	log.Printf("[INFO] (ctrl) driver initialized")
 	return nil

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -121,8 +121,10 @@ func TestBaseControllerInit(t *testing.T) {
 				newDriver: func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 					return d, nil
 				},
-				conf: tc.config,
+				drivers: driver.NewDrivers(),
+				conf:    tc.config,
 			}
+			baseCtrl.drivers.Add("task", d)
 
 			err := baseCtrl.init(ctx)
 

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -12,6 +12,7 @@ type Drivers struct {
 	mu *sync.RWMutex
 
 	drivers map[string]Driver
+	active  sync.Map
 }
 
 // NewDrivers returns a new drivers object
@@ -56,6 +57,16 @@ func (d *Drivers) Get(taskName string) (Driver, bool) {
 	return driver, true
 }
 
+func (d *Drivers) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for k := range d.drivers {
+		delete(d.drivers, k)
+		d.active.Delete(k)
+	}
+}
+
 // Map returns a copy of the map containing the drivers
 func (d *Drivers) Map() map[string]Driver {
 	d.mu.RLock()
@@ -74,4 +85,22 @@ func (d *Drivers) SetBufferPeriod() {
 	for _, driver := range d.drivers {
 		driver.SetBufferPeriod()
 	}
+}
+
+func (d *Drivers) SetActive(name string) bool {
+	d.active.Store(name, struct{}{})
+	return true
+}
+
+func (d *Drivers) SetInactive(name string) bool {
+	_, ok := d.active.Load(name)
+	if ok {
+		d.active.Delete(name)
+	}
+	return ok
+}
+
+func (d *Drivers) IsActive(name string) bool {
+	_, ok := d.active.Load(name)
+	return ok
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -197,13 +197,15 @@ func (tf *Terraform) SetBufferPeriod() {
 func (tf *Terraform) RenderTemplate(ctx context.Context) (bool, error) {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
+	taskName := tf.task.Name()
 
 	if !tf.task.IsEnabled() {
 		log.Printf("[TRACE] (driver.terraform) task '%s' disabled. skip"+
-			"rendering template", tf.task.Name())
+			"rendering template", taskName)
 		return true, nil
 	}
 
+	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
 	re, err := tf.renderTemplate(ctx)
 	return re.Complete, err
 }
@@ -285,7 +287,7 @@ func (tf *Terraform) UpdateTask(ctx context.Context, patch PatchTask) (InspectPl
 				"task: %s", taskName, err)
 		}
 
-		for i := int64(0); ; i++ {
+		for {
 			result, err := tf.renderTemplate(ctx)
 			if err != nil {
 				return InspectPlan{}, fmt.Errorf("Error updating task '%s'. Unable to "+
@@ -393,7 +395,6 @@ func (tf *Terraform) initTask(ctx context.Context) error {
 // renderTemplate attempts to render the hashicat template
 func (tf *Terraform) renderTemplate(ctx context.Context) (hcat.ResolveEvent, error) {
 	taskName := tf.task.Name()
-	log.Printf("[TRACE] (driver.terraform) checking dependency changes for task %s", taskName)
 
 	result, err := tf.resolver.Run(tf.template, tf.watcher)
 	if err != nil {
@@ -417,8 +418,8 @@ func (tf *Terraform) renderTemplate(ctx context.Context) (hcat.ResolveEvent, err
 	if result.Complete {
 		log.Printf("[DEBUG] (driver.terraform) change detected for task %s", taskName)
 
-		var rendered hcat.RenderResult
-		if rendered, err = tf.template.Render(result.Contents); err != nil {
+		rendered, err := tf.template.Render(result.Contents)
+		if err != nil {
 			log.Printf("[ERR] (driver.terraform) rendering template for '%s': %s",
 				taskName, err)
 

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -166,7 +166,7 @@ task {
 	name = "%s"
 	description = "task is configured as disabled"
 	enabled = false
-	services = ["api"]
+	services = ["api", "web"]
 	providers = ["local"]
 	source = "./test_modules/local_instances_file"
 }


### PR DESCRIPTION
An API request to update a task would race against the controller's main go routine and eventually caused a deadlock for the specific edge case when a task with multiple services starts off disabled and then is enabled via CLI/API.

My understanding of the root cause: On enabling, this would be the first time the task is run. The API request would initialize the template and wait for the template to fetch all dependencies. Meanwhile the controller gets notified on those dependency changes and then also attempt to render that same template. The API request is waiting for the controller/watcher to process the dependencies and mark that template as dirty. But that controller routine waits indefinitely for the lock that the API request had obtained and cannot proceed to call watcher.Wait in order for the API request to render the template and complete.

Fix: prevent both the controller and API server to run the same task at a given time by monitoring the active status of a task.
* This monitors the drivers that are actively running a task by the API server
* When a driver is active, the controller will skip running it and continue resuming to wait on the Watcher for changes and process dependency updates