### PR TITLE
Add config decode error wrapper

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -414,7 +413,7 @@ func decodeConfig(content []byte, file string) (*Config, error) {
 
 	if err := decoder.Decode(raw); err != nil {
 		log.Println("[DEBUG] (config) mapstructure decode failed")
-		return nil, err
+		return nil, decodeError(err)
 	}
 
 	if err := processUnusedConfigKeys(md, file); err != nil {
@@ -520,26 +519,6 @@ func supportedFormat(format string) bool {
 	}
 
 	return false
-}
-
-func processUnusedConfigKeys(md mapstructure.Metadata, file string) error {
-	if len(md.Unused) == 0 {
-		return nil
-	}
-
-	sort.Strings(md.Unused)
-	err := fmt.Errorf("'%s' has invalid keys: %s", file, strings.Join(md.Unused, ", "))
-
-	for _, key := range md.Unused {
-		if key == "provider" {
-			err = fmt.Errorf(`%s
-	'provider' is an invalid key for Consul Terraform Sync configuration, try 'terraform_provider'.
-	terraform_provider configuration blocks are similar to provider blocks in Terraform but have additional features supported only by Consul Terraform Sync.
-
-`, err)
-		}
-	}
-	return err
 }
 
 func stringFromEnv(list []string, def string) *string {

--- a/config/decode_test.go
+++ b/config/decode_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeError(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		}, {
+			"no change",
+			errors.New("no change"),
+			errors.New("no change"),
+		}, {
+			"unchanged decode error",
+			errors.New(`'file.hcl' has invalid keys: consul.unsupported`),
+			errors.New(`'file.hcl' has invalid keys: consul.unsupported`),
+		}, {
+			"unexpected type",
+			errors.New(`* 'consul' expected a map, got 'int'`),
+			errors.New(`* 'consul' expected a map, got 'int'`),
+		}, {
+			"unsupported repeated blocks",
+			errors.New(`1 error(s) decoding:
+
+* 'driver' expected a map, got 'slice'
+`),
+			errors.New("only one 'driver' block can be configured"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := decodeError(tc.err)
+			assert.Equal(t, tc.expected, err)
+		})
+	}
+}


### PR DESCRIPTION
The mapstructure error is not intuitive to interpret when a user configures repeated blocks for a configuration that is not supported.

With the same config file `test.hcl`
```
log_level = "DEBUG"

consul {}

consul {}
```

Current error
```
$ consul-terraform-sync -inspect -config-file test.hcl
2021/07/27 16:50:02 [DEBUG] (config) mapstructure decode failed
2021/07/27 16:50:02 [ERR] (config) failed decoding content from file: test.hcl
2021/07/27 16:50:02 [ERR] (cli) error building configuration: 1 error(s) decoding:

* 'consul' expected a map, got 'slice'
```

New error
```
$ consul-terraform-sync -inspect -config-file test.hcl
2021/07/27 16:50:44 [DEBUG] (config) mapstructure decode failed
2021/07/27 16:50:44 [ERR] (config) failed decoding content from file: test.hcl
2021/07/27 16:50:44 [ERR] (cli) error building configuration: only one 'consul' block can be configured
```