### PR TITLE
Fix and enable benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,9 +116,19 @@ jobs:
           no_output_timeout: << parameters.no_output_timeout >>
           command:
             make test-benchmarks | /usr/bin/tee /tmp/benchmarks.json
+      - run:
+          name: Output benchmark results
+          command: |
+            mkdir /tmp/benchmark_results
+            grep 'ns/op' /tmp/benchmarks.json | awk -F '"Output":"'  '{print $2}' | sort \
+             > /tmp/benchmark_results/results-${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}.txt
+            cat /tmp/benchmark_results/results-${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}.txt
       - store_artifacts:
           path: /tmp/benchmarks.json
           destination: benchmarks.json
+      - store_artifacts:
+          path: /tmp/benchmark_results
+          destination: benchmark_results
 
 workflows:
   version: 2
@@ -129,7 +139,7 @@ workflows:
   weekly-benchmarks:
     jobs:
       - vault_integration_tests
-      # - benchmarks (disabling temporarily)
+      - benchmarks
     triggers:
       - schedule:
           # 02:10 UTC every Wednesday

--- a/e2e/benchmarks/services_test.go
+++ b/e2e/benchmarks/services_test.go
@@ -125,13 +125,13 @@ func makeConfig(t testing.TB, services []string, addr string, tls bool,
 	cleanup := testutils.MakeTempDir(t, tmpDir)
 
 	configPath := filepath.Join(tmpDir, configFile)
-	testutils.WriteFile(t, configPath, configContents(addr, tls, services))
+	testutils.WriteFile(t, configPath, configContents(addr, tls, services, tmpDir))
 
 	return configPath, cleanup
 }
 
 // returns templated contents of config file
-func configContents(address string, tls bool, services []string) string {
+func configContents(address string, tls bool, services []string, workingDir string) string {
 	sservices := `["` + strings.Join(services, `","`) + `"]`
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -139,7 +139,7 @@ func configContents(address string, tls bool, services []string) string {
 	}
 	return fmt.Sprintf(`
 log_level = "WARN"
-
+working_dir = "%s/sync-tasks"
 consul {
   address = "%s"
   tls {
@@ -162,5 +162,5 @@ task {
   services = %s
 }
 
-`, address, tls, pwd, sservices)
+`, workingDir, address, tls, pwd, sservices)
 }

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -76,8 +76,8 @@ func BenchmarkTaskTrigger(b *testing.B) {
 		// Make a Consul catalog change for a monitored service
 		go func() {
 			service := testutil.TestService{
-				ID:      fmt.Sprintf("service_000_%s_%d", b.Name(), n),
-				Name:    "service_000",
+				ID:      fmt.Sprintf("service-000-%s%d", b.Name(), n),
+				Name:    "service-000",
 				Address: "5.6.7.8",
 				Port:    8080,
 			}

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -67,14 +67,8 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 		}
 	})
 
-	b.Run("once mode", func(b *testing.B) {
-		// Run through once to initialize Terraform workspaces to isolate the
-		// concurrent execution to only Terraform applies.
-		for n := 0; n < b.N; n++ {
-			err = rwCtrl.Once(ctx)
-			require.NoError(b, err)
-		}
-	})
+	err = rwCtrl.Once(ctx)
+	require.NoError(b, err)
 
 	b.Run("task concurrent execution", func(b *testing.B) {
 		// This is the crux of the benchmark which evaluates the performance of

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -8,6 +8,7 @@ package benchmarks
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -48,7 +49,6 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 	cleanup := testutils.MakeTempDir(b, tempDir)
 	defer cleanup()
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
 	conf := generateConf(benchmarkConfig{
 		consul:      srv,
 		tempDir:     tempDir,
@@ -62,18 +62,20 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 
 	b.Run("task setup", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			err = rwCtrl.Init(ctx)
+			err = rwCtrl.Init(context.Background())
 			require.NoError(b, err)
 		}
 	})
 
-	err = rwCtrl.Once(ctx)
+	err = rwCtrl.Once(context.Background())
 	require.NoError(b, err)
 
 	b.Run("task concurrent execution", func(b *testing.B) {
 		// This is the crux of the benchmark which evaluates the performance of
 		// tasks triggered and executing concurrently.
 		for n := 0; n < b.N; n++ {
+			ctx, ctxCancel := context.WithCancel(context.Background())
+			defer ctxCancel()
 			ctrlStopped := make(chan error)
 			rwCtrl.EnableTestMode()
 			completedTasksCh, err := rwCtrl.TaskNotifyChannel()
@@ -89,8 +91,9 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 
 			// Register service instance to Consul catalog. This triggers task execution
 			// for all tasks watching service-000
+			random := rand.New(rand.NewSource(time.Now().UnixNano()))
 			service := testutil.TestService{
-				ID:      fmt.Sprintf("service-000-%s-%d", b.Name(), n),
+				ID:      fmt.Sprintf("service-000-%s-%d-%d", b.Name(), n, random.Intn(99999)),
 				Name:    "service-000",
 				Address: "5.6.7.8",
 				Port:    8080,
@@ -99,6 +102,7 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 
 			ctxTimeout, _ := context.WithTimeout(context.Background(), 30*time.Second)
 			completedTasks := make(map[string]bool, len(*conf.Tasks))
+		RunLoop:
 			for {
 				select {
 				case taskName := <-completedTasksCh:
@@ -114,7 +118,7 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 				case err := <-ctrlStopped:
 					assert.Equal(b, err, context.Canceled)
 					assert.Len(b, completedTasks, numTasks, "%s timed out before tasks were triggered and had executed", b.Name())
-					return
+					break RunLoop
 				}
 			}
 		}

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -94,10 +94,10 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 			b.ResetTimer()
 
 			// Register service instance to Consul catalog. This triggers task execution
-			// for all tasks watching service_000
+			// for all tasks watching service-000
 			service := testutil.TestService{
-				ID:      fmt.Sprintf("service_000_%s_%d", b.Name(), n),
-				Name:    "service_000",
+				ID:      fmt.Sprintf("service-000-%s-%d", b.Name(), n),
+				Name:    "service-000",
 				Address: "5.6.7.8",
 				Port:    8080,
 			}

--- a/e2e/benchmarks/tasks_test.go
+++ b/e2e/benchmarks/tasks_test.go
@@ -73,7 +73,7 @@ func benchmarkTasks(b *testing.B, numTasks int, numServices int) {
 
 		b.Run("task setup", func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				_, err = ctrl.Init(ctx)
+				err = ctrl.Init(ctx)
 				require.NoError(b, err)
 			}
 		})
@@ -110,6 +110,7 @@ func generateConf(bConf benchmarkConfig) *config.Config {
 	}
 
 	conf := config.DefaultConfig()
+	conf.WorkingDir = &bConf.tempDir
 	conf.BufferPeriod.Enabled = config.Bool(false)
 	conf.Tasks = &taskConfigs
 	conf.Consul.Address = config.String(bConf.consul.HTTPSAddr)

--- a/e2e/benchmarks/tasks_test.go
+++ b/e2e/benchmarks/tasks_test.go
@@ -97,7 +97,7 @@ type benchmarkConfig struct {
 func generateConf(bConf benchmarkConfig) *config.Config {
 	serviceNames := make([]string, bConf.numServices)
 	for i := 0; i < bConf.numServices; i++ {
-		serviceNames[i] = fmt.Sprintf("service_%03d", i)
+		serviceNames[i] = fmt.Sprintf("service-%03d", i)
 	}
 
 	taskConfigs := make(config.TaskConfigs, bConf.numTasks)

--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -75,7 +75,7 @@ func TestServicesRenderRace(t *testing.T) {
 	tfvarsFile := filepath.Join(tempDir, "terraform.tfvars")
 	data, err := os.ReadFile(tfvarsFile)
 	require.NoError(t, err)
-	// 'svc_name_' is unique per service and much easier to count than
+	// 'svc-name-' is unique per service and much easier to count than
 	// parsing the file and counting the real entries
-	require.Equal(t, NumberOfServices, bytes.Count(data, []byte("svc_name_")))
+	require.Equal(t, NumberOfServices, bytes.Count(data, []byte("svc-name-")))
 }

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -128,10 +128,10 @@ func AddServices(t testing.TB, srv *testutil.TestServer, svcs []testutil.TestSer
 func TestServices(n int) []testutil.TestService {
 	return generateServices(n,
 		func(i int) string {
-			return fmt.Sprintf("svc_name_%d", i)
+			return fmt.Sprintf("svc-name-%d", i)
 		},
 		func(i int) string {
-			return fmt.Sprintf("svc_id_%d", i)
+			return fmt.Sprintf("svc-id-%d", i)
 		})
 }
 
@@ -140,10 +140,10 @@ func TestServices(n int) []testutil.TestService {
 func TestInstances(n int) []testutil.TestService {
 	return generateServices(n,
 		func(i int) string {
-			return fmt.Sprintf("svc_name_common")
+			return fmt.Sprintf("svc-name-common")
 		},
 		func(i int) string {
-			return fmt.Sprintf("svc_id_%d", i)
+			return fmt.Sprintf("svc-id-%d", i)
 		})
 }
 


### PR DESCRIPTION
- Fixes issues for when parts of tests are run multiple times
  - Add a dependency change before a run
  - Reinitialize the controller context per run
  - Remove the multiple calls of the Once method
- Enables benchmarks and adds a CircleCI step to print out just the results of the benchmarks without other logs
- Fixes some instances where the temporary directory wasn't being used for the tasks 
- Updates Consul services names to prevent warning log

For context, benchmarks were failing because of issues when parts of the tests were run multiple times. For example, a run might pass the first time because previously there was a change in a dependency, but on the second run, there would have been no change. The tests would then hang indefinitely on that second run, waiting for a dependency change.

These fixes take into account that there are not just `for n := 0; n < b.N; n++` loops that will run multiple times but also that the entire sub-benchmarks will potentially run multiple times with different values of `b.N`.