### PR TITLE
Refactor services condition to more standard pattern

### DIFF
--- a/driver/task.go
+++ b/driver/task.go
@@ -319,6 +319,8 @@ func (t *Task) configureRootModuleInput(input *tftmpl.RootModuleInputData) {
 	case *config.ServicesConditionConfig:
 		condition = &tftmpl.ServicesCondition{
 			Regexp: *v.Regexp,
+			// always set services variable
+			SourceIncludesVar: true,
 		}
 	default:
 		// expected only for test scenarios

--- a/e2e/condition_test.go
+++ b/e2e/condition_test.go
@@ -611,8 +611,9 @@ func TestCondition_Services_Regexp(t *testing.T) {
 	//    (one new event) and its data exists in the services variable.
 	// 3. Add a check to the api-web service instance. Confirm that task was triggered
 	//    (one new event) and its data exists in the services variable.
-	// 4.Add a check to the api-web service instance. Confirm that task was triggered
-	//    (one new event) and its the check status is updated in the services variable.
+	// 4. Set the check of the api-web service instance to Critical. Confirm that
+	//    task was triggered (one new event) and the status is updated in the
+	//    services variable.
 
 	// 0. Confirm only one event. Confirm empty var catalog_services
 	eventCountBase := eventCount(t, taskName, cts.Port())


### PR DESCRIPTION
Updated services condition to use SourceIncludesVar to determine whether
to set the template as the services variable, similar to how catalog
condition sets the catalog_services variable. For the Terraform driver,
this is always going to be set to true.

Related to https://github.com/hashicorp/consul-terraform-sync/issues/299