### PR TITLE
enabling CRT for consul-terraform-sync

### DIFF
--- a/.github/scripts/generate_metadata.sh
+++ b/.github/scripts/generate_metadata.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare -r org="hashicorp"
+declare -r product="consul-terraform-sync"
+
+if ! product_version="$(make version)"; then
+  echo "Error running 'make version'"
+  echo "${product_version}"
+  exit 1
+fi
+
+if ! git_sha="$(git rev-parse HEAD)"; then
+  echo "Unable to determine git sha for this commit"
+  exit 1
+fi
+
+cat <<-EOM
+{
+  "org": "${org}",
+  "product": "${product}",
+  "sha": "${git_sha}",
+  "version": "${product_version}",
+  "buildworkflowid" : "${GITHUB_RUN_ID}",
+  "branch": "${GITHUB_REF#refs/heads/}"
+}
+EOM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,371 @@
+name: build
+
+on:
+  push
+
+jobs:
+  get-product-version:
+    runs-on: ubuntu-latest
+    outputs:
+      product-version: ${{ steps.get-product-version.outputs.product-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: get product version
+        id: get-product-version
+        run: |
+          make version
+          echo "::set-output name=product-version::$(make version)"
+
+  build-386:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [ linux, freebsd, windows ]
+        goarch: [ "386" ]
+        go: [ "1.16" ]
+      fail-fast: true
+
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      DOCKER_CLI_EXPERIMENTAL: enabled
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/ .
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/package@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/consul-terraform-sync"
+          license: "MPL-2.0"
+          binary: "dist/${{ github.event.repository.name }}"
+          deb_depends: "openssl"
+          rpm_depends: "openssl"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_i386.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_i386.deb
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.i386.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.i386.rpm
+
+  build-amd64:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, freebsd, solaris, windows]
+        goarch: ["amd64"]
+        go: ["1.16"]
+      fail-fast: true
+
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      DOCKER_CLI_EXPERIMENTAL: enabled
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/package@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/consul-terraform-sync"
+          license: "MPL-2.0"
+          binary: "dist/${{ github.event.repository.name }}"
+          deb_depends: "openssl"
+          rpm_depends: "openssl"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
+
+  build-arm:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [arm]
+        go: ["1.16"]
+        goarm: [5, 6]
+      fail-fast: true
+
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.goarm }} build
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      DOCKER_CLI_EXPERIMENTAL: enabled
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Set env NEED
+        run: |
+          if [[ ${{ matrix.goarm }} == '5' ]]; then
+              echo "FILE_SUFFIX=armelv5" >> "$GITHUB_ENV"
+          else
+              echo "FILE_SUFFIX=armhfv6" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip dist/
+
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip
+
+
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/package@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
+          arch: ${{ env.FILE_SUFFIX }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/consul-terraform-sync"
+          license: "MPL-2.0"
+          binary: "dist/${{ github.event.repository.name }}"
+          deb_depends: "openssl"
+          rpm_depends: "openssl"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ env.FILE_SUFFIX }}.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ env.FILE_SUFFIX }}.deb
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ env.FILE_SUFFIX }}.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ env.FILE_SUFFIX }}.rpm
+
+  build-arm64:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux]
+        goarch: [arm64]
+        go: ["1.16"]
+      fail-fast: true
+
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+      DOCKER_CLI_EXPERIMENTAL: enabled
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+      - name: Package
+        if: ${{ matrix.goos == 'linux' }}
+        uses: hashicorp/package@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
+          arch: ${{ matrix.goarch }}
+          version: ${{ needs.get-product-version.outputs.product-version }}
+          maintainer: "HashiCorp"
+          homepage: "https://github.com/hashicorp/consul-terraform-sync"
+          license: "MPL-2.0"
+          binary: "dist/${{ github.event.repository.name }}"
+          deb_depends: "openssl"
+          rpm_depends: "openssl"
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_arm*.deb
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ matrix.goos == 'linux' }}
+        with:
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.*.rpm
+
+
+  build-darwin:
+    needs: get-product-version
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        goos: [ darwin ]
+        goarch: [ "amd64" ]
+        go: [ "1.16" ]
+      fail-fast: true
+
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
+
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build
+        run: |
+          mkdir dist out
+          go build -o dist/
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+
+  build-docker:
+    needs:
+      - get-product-version
+      - build-arm64
+      - build-386
+      - build-amd64
+      - build-arm
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["arm", "arm64", "386", "amd64"]
+    name: Docker ${{ matrix.arch }} build
+
+    steps:
+      - name: Set env NEED
+        run: |
+          if [[ ${{ matrix.arch }} == 'arm' ]]; then
+              echo "FILE_SUFFIX=armhfv6" >> "$GITHUB_ENV"
+          else
+              echo "FILE_SUFFIX=${{ matrix.arch }}" >> "$GITHUB_ENV"
+          fi
+      - uses: actions/checkout@v2
+
+      # download arm/arm64/386/amd64 binaries from build jobs
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ env.FILE_SUFFIX }}.zip
+
+      # build docker image
+      - name: Docker build
+        working-directory: ./.release/docker
+        run: |
+          docker version
+          unzip -j ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ env.FILE_SUFFIX }}.zip
+          # arm32 bit docker images are set with --platform=linux/arm/v6
+          if [ "${{ matrix.arch }}" = "arm" ]; then
+            make docker ARCH=${{ matrix.arch }} GOARM_DOCKER="/v6"
+          else
+            make docker ARCH=${{ matrix.arch }}
+          fi
+      # upload image tarball
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_docker_linux_${{ matrix.arch }}.tar
+          path: .release/docker/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_docker_linux_${{ matrix.arch }}.tar
+  
+  
+  generate_metadata:
+    needs: get-product-version
+    runs-on: ubuntu-latest
+    name: Generate Metadata
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Generate Metadata
+        run: .github/scripts/generate_metadata.sh | tee metadata.json
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: metadata.json
+          path: metadata.json

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -1,0 +1,110 @@
+schema = "1"
+
+project "consul-terraform-sync" {
+  team = "consul api tooling"
+  slack {
+    notification_channel = "#feed-releng" #TODO update slack channel
+  }
+  github {
+    organization = "hashicorp"
+    repository = "consul-terraform-sync"
+    release_branches = ["master"]
+  }
+}
+
+event "build" {
+  depends = ["merge"]
+  action "build" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "build"
+  }
+}
+
+event "upload-dev" {
+  depends = ["build"]
+  action "upload-dev" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "upload-dev"
+    depends = ["build"]
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} failed with {{stage_output}}"
+  }
+}
+
+event "notarize-darwin-amd64" {
+  depends = ["upload-dev"]
+  action "notarize-darwin-amd64" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-darwin-amd64"
+
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} {{version}} failed with {{stage_output}}"
+  }
+}
+
+event "notarize-windows-386" {
+  depends = ["notarize-darwin-amd64"]
+  action "notarize-windows-386" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-windows-386"
+
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} {{version}} failed with {{stage_output}}"
+  }
+}
+
+event "notarize-windows-amd64" {
+  depends = ["notarize-windows-386"]
+  action "notarize-windows-amd64" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "notarize-windows-amd64"
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} {{version}} failed with {{stage_output}}"
+  }
+}
+
+event "sign" {
+  depends = ["notarize-windows-amd64"]
+  action "sign" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "sign"
+
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} {{version}} failed with {{stage_output}}"
+  }
+}
+
+event "verify" {
+  depends = ["sign"]
+  action "verify" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "verify"
+  }
+
+  notification {
+    on = "fail"
+    message_template = "{{stage_name}} {{version}} failed with {{stage_output}}"
+  }
+}

--- a/.release/docker/Dockerfile
+++ b/.release/docker/Dockerfile
@@ -1,0 +1,30 @@
+FROM alpine:3.13
+
+# NAME and VERSION are the name of the software in releases.hashicorp.com
+# and the version to download. Example: NAME=consul VERSION=1.2.3.
+ARG NAME=consul-terraform-sync
+ARG VERSION
+
+LABEL maintainer="Consul Team <consul@hashicorp.com>"
+LABEL version=$VERSION
+
+# Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
+ENV NAME=$NAME
+ENV VERSION=$VERSION
+
+# Create a non-root user to run the software.
+RUN addgroup ${NAME} && adduser -S -G ${NAME} ${NAME}
+
+COPY consul-terraform-sync /bin/consul-terraform-sync
+
+### Added for CTS
+RUN mkdir -p /consul-terraform-sync/config \
+	&& chown -R ${NAME}:${NAME} /consul-terraform-sync
+VOLUME /consul-terraform-sync/config
+COPY docker-entrypoint.sh /bin/docker-entrypoint.sh
+WORKDIR /consul-terraform-sync
+ENTRYPOINT ["/bin/docker-entrypoint.sh"]
+###
+
+USER ${NAME}
+CMD /bin/${NAME}

--- a/.release/docker/Makefile
+++ b/.release/docker/Makefile
@@ -1,0 +1,23 @@
+SHELL := /usr/bin/env bash -euo pipefail -c
+export PROJECT_NAME=consul-terraform-sync
+
+.PHONY: build download docker
+
+build: download docker
+
+download: export RELEASE_DIST=https://releases.hashicorp.com
+download: export VERSION=$$(./../../build-scripts/version.sh ../../version/version.go)
+download: 
+	curl -o $(PROJECT_NAME).zip $(RELEASE_DIST)/$(PROJECT_NAME)/$(VERSION)/$(PROJECT_NAME)_$(VERSION)_linux_$(ARCH).zip
+	unzip $(PROJECT_NAME).zip
+	rm $(PROJECT_NAME).zip
+
+# GITHUB_SHA is an environment variable from GitHub Actions
+# save images tagged as $GITHUB_SHA-$VERSION-$ARCH since we will need to combine distinct tags
+# together with docker manifest
+docker: export VERSION=$$(./../../build-scripts/version.sh ../../version/version.go)
+docker:
+	echo "Building image for $(PROJECT_NAME):$(GITHUB_SHA)-$(VERSION)-$(ARCH)"
+	docker buildx create --use
+	docker buildx build --load --build-arg VERSION=$(VERSION) --build-arg NAME=$(PROJECT_NAME) --platform=linux/$(ARCH)$(GOARM_DOCKER) -t $(PROJECT_NAME):$(GITHUB_SHA)-$(VERSION)-$(ARCH) .
+	docker save --output $(PROJECT_NAME)_$(VERSION)_docker_linux_$(ARCH).tar $(PROJECT_NAME):$(GITHUB_SHA)-$(VERSION)-$(ARCH)

--- a/.release/docker/docker-entrypoint.sh
+++ b/.release/docker/docker-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/dumb-init /bin/sh
+set -e
+
+# Note above that we run dumb-init as PID 1 in order to reap zombie processes
+# as well as forward signals to all processes in its session. Normally, sh
+# wouldn't do either of these functions so we'd leak zombies as well as do
+# unclean termination of all our sub-processes.
+
+# If the user is trying to run consul-terraform-sync directly with some arguments,
+# then pass them to consul-terraform-sync.
+# On alpine /bin/sh is busybox which supports the bashism below.
+if [ "${1:0:1}" = '-' ]; then
+	set -- /bin/consul-terraform-sync "$@"
+fi
+
+# If user is trying to run consul-terraform-sync with no arguments (daemon-mode),
+# docker will run '/bin/sh -c /bin/${NAME}'. Check for the full command since
+# running 'bin/sh' is a common pattern
+if [ "$*" = '/bin/sh -c /bin/${NAME}' ]; then
+	set -- /bin/consul-terraform-sync
+fi
+
+# Matches VOLUME in the Dockerfile, for importing config files into image
+CTS_CONFIG_DIR=/consul-terraform-sync/config
+
+# Set the configuration directory
+if [ "$1" = '/bin/consul-terraform-sync' ]; then
+	shift
+	set -- /bin/consul-terraform-sync -config-dir="$CTS_CONFIG_DIR" "$@"
+fi
+
+exec "$@"

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,11 @@ dev-tree:
 	@true
 .PHONY: dev-tree
 
+version:
+ifneq (,$(wildcard version/version_ent.go))
+	@$(CURDIR)/build-scripts/version.sh version/version_ent.go
+else
+	@$(CURDIR)/build-scripts/version.sh version/version.go
+endif
+
+.PHONY: version

--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+version_file=$1
+version=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "${version_file}")
+prerelease=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "${version_file}")
+
+if [ -n "$prerelease" ]; then
+    echo "${version}-${prerelease}"
+else
+    echo "${version}"
+fi

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
-	Version = "0.2.0"
+	Version = "0.4.0"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
**Enabling the CRT CD pipeline for CTS.**

Final "green" pipeline is [here](https://github.com/hashicorp/consul-terraform-sync/actions/runs/1186508858) 

This includes files and logic to build all binaries, docker images and rpms/debs and attach to the GitHub workflow.

The [promotion](https://github.com/hashicorp/crt-workflows-common/actions) pipeline will then kick off to sign/notarize and move these artifacts to the [stable](https://artifactory.hashicorp.engineering/ui/repos/tree/General/hashicorp-crt-stable-local%2Fconsul-terraform-sync%2F0.3.0%2Fc6c834563b4db401645738d7b4a3023a26a158bd) repo in Artifactory ready to be released.

We should have 25 artifacts in total:

consul-terraform-sync-0.3.0.arm64.rpm
consul-terraform-sync-0.3.0.x86_64.rpm
consul-terraform-sync-0.3.0.armelv5.rpm
consul-terraform-sync-0.3.0.armhfv6.rpm
consul-terraform-sync-0.3.0.i386.rpm

consul-terraform-sync_0.3.0_amd64.deb
consul-terraform-sync_0.3.0_armelv5.deb
consul-terraform-sync_0.3.0_armhfv6.deb
consul-terraform-sync_0.3.0_arm64.deb
consul-terraform-sync_0.3.0_i386.deb

consul-terraform-sync_0.3.0_docker_linux_386.tar
consul-terraform-sync_0.3.0_docker_linux_amd64.tar
consul-terraform-sync_0.3.0_docker_linux_arm.tar 
consul-terraform-sync_0.3.0_docker_linux_arm64.tar

consul-terraform-sync_0.3.0_freebsd_386.zip
consul-terraform-sync_0.3.0_linux_386.zip
consul-terraform-sync_0.3.0_windows_386.zip
consul-terraform-sync_0.3.0_darwin_amd64.zip
consul-terraform-sync_0.3.0_freebsd_amd64.zip
consul-terraform-sync_0.3.0_linux_amd64.zip
consul-terraform-sync_0.3.0_linux_arm64.zip
consul-terraform-sync_0.3.0_linux_armelv5.zip
consul-terraform-sync_0.3.0_linux_armhfv6.zip
consul-terraform-sync_0.3.0_solaris_amd64.zip
consul-terraform-sync_0.3.0_windows_amd64.zip