### PR TITLE
Add configuration for consul-kv condition

### DIFF
--- a/config/condition.go
+++ b/config/condition.go
@@ -41,6 +41,8 @@ func isConditionNil(c ConditionConfig) bool {
 		result = v == nil
 	case *CatalogServicesConditionConfig:
 		result = v == nil
+	case *ConsulKVConditionConfig:
+		result = v == nil
 	default:
 		return c == nil || reflect.ValueOf(c).IsNil()
 	}
@@ -82,6 +84,10 @@ func conditionToTypeFunc() mapstructure.DecodeHookFunc {
 		}
 		if c, ok := conditions[servicesConditionType]; ok {
 			var config ServicesConditionConfig
+			return decodeConditionToType(c, &config)
+		}
+		if c, ok := conditions[consulKVConditionType]; ok {
+			var config ConsulKVConditionConfig
 			return decodeConditionToType(c, &config)
 		}
 

--- a/config/condition_consul_kv.go
+++ b/config/condition_consul_kv.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"fmt"
+)
+
+const consulKVConditionType = "consul-kv"
+
+var _ ConditionConfig = (*ConsulKVConditionConfig)(nil)
+
+type ConsulKVConditionConfig struct {
+	Path              *string `mapstructure:"path"`
+	SourceIncludesVar *bool   `mapstructure:"source_includes_var"`
+	Recurse           *bool   `mapstructure:"recurse"`
+	Datacenter        *string `mapstructure:"datacenter"`
+	Namespace         *string `mapstructure:"namespace"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *ConsulKVConditionConfig) Copy() ConditionConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o ConsulKVConditionConfig
+	o.Path = StringCopy(c.Path)
+	o.Recurse = BoolCopy(c.Recurse)
+	o.SourceIncludesVar = BoolCopy(c.SourceIncludesVar)
+	o.Datacenter = StringCopy(c.Datacenter)
+	o.Namespace = StringCopy(c.Namespace)
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+func (c *ConsulKVConditionConfig) Merge(o ConditionConfig) ConditionConfig {
+	if c == nil {
+		if isConditionNil(o) { // o is interface, use isConditionNil()
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if isConditionNil(o) {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+	o2, ok := o.(*ConsulKVConditionConfig)
+	if !ok {
+		return r
+	}
+
+	r2 := r.(*ConsulKVConditionConfig)
+
+	if o2.Path != nil {
+		r2.Path = StringCopy(o2.Path)
+	}
+
+	if o2.SourceIncludesVar != nil {
+		r2.SourceIncludesVar = BoolCopy(o2.SourceIncludesVar)
+	}
+
+	if o2.Recurse != nil {
+		r2.Recurse = BoolCopy(o2.Recurse)
+	}
+
+	if o2.Datacenter != nil {
+		r2.Datacenter = StringCopy(o2.Datacenter)
+	}
+
+	if o2.Namespace != nil {
+		r2.Namespace = StringCopy(o2.Namespace)
+	}
+
+	return r2
+}
+
+// Finalize ensures there no nil pointers.
+func (c *ConsulKVConditionConfig) Finalize(consulkv []string) {
+	if c == nil { // config not required, return early
+		return
+	}
+
+	if c.Path == nil {
+		c.Path = String("")
+	}
+
+	if c.SourceIncludesVar == nil {
+		c.SourceIncludesVar = Bool(false)
+	}
+
+	if c.Recurse == nil {
+		c.Recurse = Bool(false)
+	}
+
+	if c.Datacenter == nil {
+		c.Datacenter = String("")
+	}
+
+	if c.Namespace == nil {
+		c.Namespace = String("")
+	}
+
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *ConsulKVConditionConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if c.Path == nil || *c.Path == "" {
+		return fmt.Errorf("path is required for consul-kv condition")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *ConsulKVConditionConfig) GoString() string {
+	if c == nil {
+		return "(*ConsulKVConditionConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&ConsulKVConditionConfig{"+
+		"Path:%s, "+
+		"SourceIncludesVar:%v, "+
+		"Recurse:%v, "+
+		"Datacenter:%v, "+
+		"Namespace:%v, "+
+		"}",
+		StringVal(c.Path),
+		BoolVal(c.SourceIncludesVar),
+		BoolVal(c.Recurse),
+		StringVal(c.Datacenter),
+		StringVal(c.Namespace),
+	)
+}

--- a/config/condition_consul_kv_test.go
+++ b/config/condition_consul_kv_test.go
@@ -1,0 +1,296 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsulKVConditionConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ConsulKVConditionConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&ConsulKVConditionConfig{},
+		},
+		{
+			"fully_configured",
+			&ConsulKVConditionConfig{
+				Path:              String("key-path"),
+				Recurse:           Bool(true),
+				SourceIncludesVar: Bool(true),
+				Datacenter:        String("dc2"),
+				Namespace:         String("ns2"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			if tc.a == nil {
+				// returned nil interface has nil type, which is unequal to tc.a
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.a, r)
+			}
+		})
+	}
+}
+
+func TestConsulKVConditionConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ConsulKVConditionConfig
+		b    *ConsulKVConditionConfig
+		r    *ConsulKVConditionConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{},
+		},
+		{
+			"nil_b",
+			&ConsulKVConditionConfig{},
+			nil,
+			&ConsulKVConditionConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{},
+		},
+		{
+			"path_overrides",
+			&ConsulKVConditionConfig{Path: String("same")},
+			&ConsulKVConditionConfig{Path: String("different")},
+			&ConsulKVConditionConfig{Path: String("different")},
+		},
+		{
+			"path_empty_one",
+			&ConsulKVConditionConfig{Path: String("same")},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Path: String("same")},
+		},
+		{
+			"path_empty_two",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Path: String("same")},
+			&ConsulKVConditionConfig{Path: String("same")},
+		},
+		{
+			"path_empty_same",
+			&ConsulKVConditionConfig{Path: String("same")},
+			&ConsulKVConditionConfig{Path: String("same")},
+			&ConsulKVConditionConfig{Path: String("same")},
+		},
+		{
+			"recurse_overrides",
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+			&ConsulKVConditionConfig{Recurse: Bool(false)},
+			&ConsulKVConditionConfig{Recurse: Bool(false)},
+		},
+		{
+			"recurse_empty_one",
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+		},
+		{
+			"recurse_empty_two",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+		},
+		{
+			"recurse_empty_same",
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+			&ConsulKVConditionConfig{Recurse: Bool(true)},
+		},
+		{
+			"source_includes_var_overrides",
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(false)},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(false)},
+		},
+		{
+			"source_includes_var_empty_one",
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+		},
+		{
+			"source_includes_var_empty_two",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+		},
+		{
+			"source_includes_var_empty_same",
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+			&ConsulKVConditionConfig{SourceIncludesVar: Bool(true)},
+		},
+		{
+			"datacenter_overrides",
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+			&ConsulKVConditionConfig{Datacenter: String("different")},
+			&ConsulKVConditionConfig{Datacenter: String("different")},
+		},
+		{
+			"datacenter_empty_one",
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"datacenter_empty_two",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"datacenter_empty_same",
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+			&ConsulKVConditionConfig{Datacenter: String("same")},
+		},
+		{
+			"namespace_overrides",
+			&ConsulKVConditionConfig{Namespace: String("same")},
+			&ConsulKVConditionConfig{Namespace: String("different")},
+			&ConsulKVConditionConfig{Namespace: String("different")},
+		},
+		{
+			"namespace_empty_one",
+			&ConsulKVConditionConfig{Namespace: String("same")},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Namespace: String("same")},
+		},
+		{
+			"namespace_empty_two",
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{Namespace: String("same")},
+			&ConsulKVConditionConfig{Namespace: String("same")},
+		},
+		{
+			"namespace_empty_same",
+			&ConsulKVConditionConfig{Namespace: String("same")},
+			&ConsulKVConditionConfig{Namespace: String("same")},
+			&ConsulKVConditionConfig{Namespace: String("same")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				// returned nil interface has nil type, which is unequal to tc.r
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.r, r)
+			}
+		})
+	}
+}
+
+func TestConsulKVConditionConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		s    []string
+		i    *ConsulKVConditionConfig
+		r    *ConsulKVConditionConfig
+	}{
+		{
+			"empty",
+			[]string{},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{
+				Path:              String(""),
+				Recurse:           Bool(false),
+				SourceIncludesVar: Bool(false),
+				Datacenter:        String(""),
+				Namespace:         String(""),
+			},
+		},
+		{
+			"services_ignored",
+			[]string{"api"},
+			&ConsulKVConditionConfig{},
+			&ConsulKVConditionConfig{
+				Path:              String(""),
+				Recurse:           Bool(false),
+				SourceIncludesVar: Bool(false),
+				Datacenter:        String(""),
+				Namespace:         String(""),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize(tc.s)
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestConsulKVConditionConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *ConsulKVConditionConfig
+	}{
+		{
+			"happy_path",
+			false,
+			&ConsulKVConditionConfig{
+				Path:              String("key-path"),
+				Recurse:           Bool(true),
+				SourceIncludesVar: Bool(true),
+				Datacenter:        String("dc2"),
+				Namespace:         String("ns2"),
+			},
+		},
+		{
+			"nil_path",
+			true,
+			&ConsulKVConditionConfig{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -161,6 +161,31 @@ task {
 }`,
 		},
 		{
+			"consul-kv: happy path",
+			false,
+			&ConsulKVConditionConfig{
+				Path:              String("key-path"),
+				SourceIncludesVar: Bool(true),
+				Datacenter:        String("dc2"),
+				Namespace:         String("ns2"),
+				Recurse:           Bool(true),
+			},
+			"config.hcl",
+			`
+task {
+	name = "condition_task"
+	source = "..."
+	services = ["api"]
+	condition "consul-kv" {
+		path = "key-path"
+		source_includes_var = true
+		namespace = "ns2"
+		datacenter = "dc2"
+		recurse = true
+	}
+}`,
+		},
+		{
 			"error: nonexistent condition type",
 			true,
 			nil,

--- a/config/task.go
+++ b/config/task.go
@@ -281,6 +281,9 @@ func (c *TaskConfig) Validate() error {
 					"task.condition.regexp or at least one service in " +
 					"task.services to be configured")
 			}
+		case *ConsulKVConditionConfig:
+			return fmt.Errorf("consul-kv condition requires at least one service to " +
+				"be configured in task.services")
 		}
 	} else {
 		switch cond := c.Condition.(type) {

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -539,6 +539,17 @@ func TestTaskConfig_Validate(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"missing services with consul-kv condition",
+			&TaskConfig{
+				Name:   String("task"),
+				Source: String("source"),
+				Condition: &ConsulKVConditionConfig{
+					Path: String("path"),
+				},
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Supports consul-kv condition in task block, where path is
a required attribute for the condition.

**Example Configuration:**
```
task {
...
  condition "consul-kv" {
    path = "test"
    source_includes_var = true
    recurse = true
    datacenter = "dc1"
    namespace = "test-namespace"
  }
...
}
```

This PR only has the configuration changes. Follow up PR will have the template and notifier changes that use the configuration.

Part of https://github.com/hashicorp/consul-terraform-sync/issues/150