### PR TITLE
Issue 332 http request logging

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/go-uuid"
+)
+
+const (
+	timeFormat = "2006-01-02T15:04:05.000Z0700"
+)
+
+func withLogging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Generate a UUID to be included with all log messages for an incoming request
+		reqID, err := uuid.GenerateUUID()
+
+		logger := logging.Global().Named(logSystemName)
+		if err != nil {
+			logging.Global().Named(logSystemName).Error("error generating uuid", "error", err)
+			return
+		}
+
+		// UUID was successfully created, so add it now
+		logger = logger.With("reqID", reqID)
+		ts := time.Now()
+
+		// Log info before calling the next handler
+		logger.Info("received request",
+			"time", ts.Format(timeFormat),
+			"remote_ip", r.RemoteAddr,
+			"uri", r.RequestURI,
+			"method", r.Method,
+			"host", r.Host)
+
+		r = r.WithContext(logging.WithContext(r.Context(), logger))
+		next.ServeHTTP(w, r)
+
+		// Log info on exit
+		logger.Info("request complete",
+			"duration", fmt.Sprintf("%dus", time.Since(ts).Microseconds()))
+	})
+}

--- a/api/task_test.go
+++ b/api/task_test.go
@@ -253,7 +253,8 @@ func TestTask_updateTask(t *testing.T) {
 			}).
 			Return(driver.InspectPlan{}, context.Canceled).Once()
 		d.On("Task").Return(&driver.Task{}).Once()
-		handler.drivers.Add("task_a", d)
+		err = handler.drivers.Add("task_a", d)
+		require.NoError(t, err)
 
 		resp := httptest.NewRecorder()
 		go func() {

--- a/client/printer.go
+++ b/client/printer.go
@@ -5,12 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 
 	"github.com/hashicorp/consul-terraform-sync/logging"
 )
 
 var _ Client = (*Printer)(nil)
+
+const (
+	printerSubsystemName = "printer"
+	loggingSystemName    = "client"
+)
 
 // Printer is a fake client that only logs out actions. Intended to mirror
 // TerraformCLI client and to be used for development only
@@ -18,7 +22,7 @@ type Printer struct {
 	logLevel   string
 	workingDir string
 	workspace  string
-	logger     *log.Logger
+	logger     logging.Logger
 }
 
 // PrinterConfig configures the log client
@@ -35,7 +39,8 @@ func NewPrinter(config *PrinterConfig) (*Printer, error) {
 		return nil, errors.New("PrinterConfig cannot be nil - mirror Terraform CLI error")
 	}
 
-	logger, err := logging.SetupLocal(config.Writer)
+	logger, err := logging.SetupLocal(config.Writer, loggingSystemName, printerSubsystemName,
+		"workspace", config.Workspace, "working_dir", config.WorkingDir)
 	if err != nil {
 		return &Printer{}, fmt.Errorf("error creating new logger: %s", err)
 	}
@@ -50,42 +55,36 @@ func NewPrinter(config *PrinterConfig) (*Printer, error) {
 
 // SetEnv logs out 'setenv'
 func (p *Printer) SetEnv(map[string]string) error {
-	p.logger.Printf("[INFO] (client.printer) setting workspace environment: "+
-		"'%s', workingdir: '%s'", p.workspace, p.workingDir)
+	p.logger.Info("setting environment for workspace")
 	return nil
 }
 
 // SetStdout logs out 'set standard out'
-func (p *Printer) SetStdout(w io.Writer) {
-	p.logger.Printf("[INFO] (client.printer) setting standard out for workspace: "+
-		"'%s', workingdir: '%s'", p.workspace, p.workingDir)
+func (p *Printer) SetStdout(io.Writer) {
+	p.logger.Info("setting standard out for workspace")
 }
 
 // Init logs out 'init'
-func (p *Printer) Init(ctx context.Context) error {
-	p.logger.Printf("[INFO] (client.printer) initing workspace: '%s', workingdir: '%s'",
-		p.workspace, p.workingDir)
+func (p *Printer) Init(context.Context) error {
+	p.logger.Info("initing workspace")
 	return nil
 }
 
 // Apply logs out 'apply'
-func (p *Printer) Apply(ctx context.Context) error {
-	p.logger.Printf("[INFO] (client.printer) applying workspace: '%s', workingdir: '%s'",
-		p.workspace, p.workingDir)
+func (p *Printer) Apply(context.Context) error {
+	p.logger.Info("applying workspace")
 	return nil
 }
 
 // Plan logs out 'plan'
-func (p *Printer) Plan(ctx context.Context) (bool, error) {
-	p.logger.Printf("[INFO] (client.printer) planning workspace: '%s', workingdir: '%s'",
-		p.workspace, p.workingDir)
+func (p *Printer) Plan(context.Context) (bool, error) {
+	p.logger.Info("planning workspace")
 	return true, nil
 }
 
 // Validate logs out 'validate'
-func (p *Printer) Validate(ctx context.Context) error {
-	p.logger.Printf("[INFO] (client.printer) validating workspace: '%s', workingdir: '%s'",
-		p.workspace, p.workingDir)
+func (p *Printer) Validate(context.Context) error {
+	p.logger.Info("validating workspace")
 	return nil
 }
 

--- a/client/printer_test.go
+++ b/client/printer_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-terraform-sync/logging"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -165,7 +164,7 @@ func TestPrinterLogLevel(t *testing.T) {
 			p, err := NewTestPrinter(tc.config)
 			assert.NoError(t, err)
 
-			p.logger.Printf("[TRACE] Test Message")
+			p.logger.Trace("Test Message")
 			if tc.expectWrite {
 				assert.NotEmpty(t, buf.String())
 			} else {

--- a/config/service.go
+++ b/config/service.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
 )
 
 // ServiceConfig defines the explicit configuration for Sync to monitor
@@ -159,7 +160,7 @@ func (c *ServiceConfig) Finalize() {
 	if c.Tag == nil {
 		c.Tag = String("")
 	} else {
-		log.Println("[WARN] (config) The 'tag' attribute was marked for " +
+		logging.Global().Named(logSystemName).Warn("The 'tag' attribute was marked for " +
 			"deprecation in v0.2.0 and will be removed in v0.4.0 " +
 			"of Consul-Terraform-Sync. Please update your configuration to " +
 			"use 'filter' and provide a filter expression using the " +

--- a/config/task.go
+++ b/config/task.go
@@ -2,11 +2,15 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+const (
+	taskSubsystemName = "task"
 )
 
 // TaskConfig is the configuration for a Sync task. This block may be
@@ -289,11 +293,12 @@ func (c *TaskConfig) Validate() error {
 		switch cond := c.Condition.(type) {
 		case *ServicesConditionConfig:
 			if cond.Regexp != nil && *cond.Regexp != "" {
-				log.Printf("[ERR] (config.task) list of services and service condition regex " +
-					"both provided. If both are needed, consider including the list in the regex " +
-					"or creating separate tasks.")
-				return fmt.Errorf("task.services is not allowed if task.condition.regexp " +
+				err := fmt.Errorf("task.services is not allowed if task.condition.regexp " +
 					"is configured for a services condition")
+				logging.Global().Named(logSystemName+taskSubsystemName).Error("[ERR] (config.task) list of "+
+					"services and service condition regex both provided. If both are needed, consider "+
+					"including the list in the regex or creating separate tasks.", "error", err)
+				return err
 			}
 		}
 	}

--- a/config/terraform.go
+++ b/config/terraform.go
@@ -2,18 +2,21 @@ package config
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	ctsVersion "github.com/hashicorp/consul-terraform-sync/version"
 	goVersion "github.com/hashicorp/go-version"
 )
 
 // DefaultTFBackendKVPath is the default KV path used for configuring the
 // default backend to use Consul KV.
-const DefaultTFBackendKVPath = "consul-terraform-sync/terraform"
+const (
+	DefaultTFBackendKVPath = "consul-terraform-sync/terraform"
+	logSystemName          = "config"
+)
 
 // TerraformConfig is the configuration for the Terraform driver.
 type TerraformConfig struct {
@@ -30,9 +33,9 @@ type TerraformConfig struct {
 func DefaultTerraformConfig() *TerraformConfig {
 	wd, err := os.Getwd()
 	if err != nil {
-		log.Println("[ERR] (config) unable to retrieve current working directory " +
-			"to setup default configuration for the Terraform driver")
-		log.Panic(err)
+		logging.Global().Named(logSystemName).Error("unable to retrieve current working directory "+
+			"to setup default configuration for the Terraform driver", "error", err)
+		panic(err)
 	}
 
 	return &TerraformConfig{
@@ -201,10 +204,11 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 	}
 
 	wd, err := os.Getwd()
+	logger := logging.Global().Named(logSystemName)
 	if err != nil {
-		log.Println("[ERR] (config) unable to retrieve current working directory " +
-			"to setup default configuration for the Terraform driver")
-		log.Panic(err)
+		logger.Error("unable to retrieve current working directory "+
+			"to setup default configuration for the Terraform driver", "error", err)
+		panic(err)
 	}
 
 	if c.Version == nil {
@@ -227,7 +231,7 @@ func (c *TerraformConfig) Finalize(consul *ConsulConfig) {
 		// intentionally left as nil for the top-level config to override
 		// log a warning message if the configuration is not configured to the
 		// default location.
-		log.Println("[WARN] (config) The 'driver.working_dir' configuration " +
+		logger.Warn("The 'driver.working_dir' configuration " +
 			"option was marked for deprecation in v0.3.0 and will be removed in " +
 			"v0.5.0 of Consul-Terraform-Sync. Please update your configuration " +
 			"to use 'working_dir' or configure the working directory individually " +

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
@@ -123,10 +124,12 @@ func TestBaseControllerInit(t *testing.T) {
 				},
 				drivers: driver.NewDrivers(),
 				conf:    tc.config,
+				logger:  logging.NewNullLogger(),
 			}
-			baseCtrl.drivers.Add("task", d)
+			err := baseCtrl.drivers.Add("task", d)
+			require.NoError(t, err)
 
-			err := baseCtrl.init(ctx)
+			err = baseCtrl.init(ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -215,7 +215,8 @@ func TestOnce(t *testing.T) {
 					d.On("ApplyTask", mock.Anything).Return(nil).Once()
 					return d, nil
 				},
-				conf: multipleTaskConfig(tc.numTasks),
+				conf:   multipleTaskConfig(tc.numTasks),
+				logger: logging.NewNullLogger(),
 			}
 
 			ctx := context.Background()
@@ -270,7 +271,8 @@ func TestReadWrite_Once_error(t *testing.T) {
 			}
 			return d, nil
 		},
-		conf: multipleTaskConfig(numTasks),
+		conf:   multipleTaskConfig(numTasks),
+		logger: logging.NewNullLogger(),
 	}
 
 	ctx := context.Background()
@@ -391,6 +393,7 @@ func TestReadWrite_OnceAndRun(t *testing.T) {
 	ctrl := ReadWrite{
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
+			logger:  logging.NewNullLogger(),
 		},
 		store: event.NewStore(),
 	}

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/handler"
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates"
@@ -97,6 +98,7 @@ func TestReadWrite_CheckApply(t *testing.T) {
 			controller := ReadWrite{
 				baseController: &baseController{
 					drivers: drivers,
+					logger:  logging.NewNullLogger(),
 				},
 				store: event.NewStore(),
 			}
@@ -148,6 +150,7 @@ func TestReadWrite_CheckApply_Store(t *testing.T) {
 		controller := ReadWrite{
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
+				logger:  logging.NewNullLogger(),
 			},
 			store: event.NewStore(),
 		}
@@ -294,6 +297,7 @@ func TestReadWriteUnits(t *testing.T) {
 		controller := ReadWrite{
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
+				logger:  logging.NewNullLogger(),
 			},
 			store: event.NewStore(),
 		}
@@ -318,6 +322,7 @@ func TestReadWriteUnits(t *testing.T) {
 		controller := ReadWrite{
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
+				logger:  logging.NewNullLogger(),
 			},
 			store: event.NewStore(),
 		}
@@ -350,6 +355,7 @@ func TestReadWriteRun_context_cancel(t *testing.T) {
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			watcher: w,
+			logger:  logging.NewNullLogger(),
 		},
 		store: event.NewStore(),
 	}

--- a/event/event.go
+++ b/event/event.go
@@ -3,10 +3,14 @@ package event
 import (
 	"errors"
 	"fmt"
-	"log"
 	"time"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/go-uuid"
+)
+
+const (
+	logSystemName = "event"
 )
 
 // Event captures the series of actions that needs to happen to update network
@@ -56,7 +60,7 @@ func NewEvent(taskName string, config *Config) (*Event, error) {
 // Start sets the start time on an event. Can only be called once.
 func (e *Event) Start() {
 	if !e.StartTime.IsZero() {
-		log.Printf("[WARN] (event) event already started. unable to restart")
+		logging.Global().Named(logSystemName).Warn("event already started. unable to restart")
 		return
 	}
 	e.StartTime = time.Now()
@@ -66,7 +70,7 @@ func (e *Event) Start() {
 // Can only be called once
 func (e *Event) End(err error) {
 	if !e.EndTime.IsZero() {
-		log.Printf("[WARN] (event) event already ended. unable to re-end")
+		logging.Global().Named(logSystemName).Warn("event already ended. unable to re-end")
 		return
 	}
 

--- a/examples/runnable-example/example-module/main.tf
+++ b/examples/runnable-example/example-module/main.tf
@@ -3,7 +3,7 @@ terraform {
     # Provider source is used for Terraform discovery and installation of
     # providers. Declare source for all providers required by the module.
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
       version = ">= 2.1.0"
     }
   }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/go-bexpr v0.1.4
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-getter v1.5.3
-	github.com/hashicorp/go-hclog v0.15.0 // indirect
+	github.com/hashicorp/go-hclog v0.16.2
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-syslog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.12.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
-github.com/hashicorp/go-hclog v0.15.0 h1:qMuK0wxsoW4D0ddCCYwPSTm4KQv1X1ke3WmPWZ0Mvsk=
-github.com/hashicorp/go-hclog v0.15.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
+github.com/hashicorp/go-hclog v0.16.2 h1:K4ev2ib4LdQETX5cSZBG0DVLk1jwGqSPXBjdah3veNs=
+github.com/hashicorp/go-hclog v0.16.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.1.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=

--- a/handler/fake.go
+++ b/handler/fake.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
 )
 
 // TerraformProviderFake is the name of a fake Terraform provider
-const TerraformProviderFake = "fake-sync"
+const (
+	TerraformProviderFake = "fake-sync"
+	fakeSubsystemName     = "fake"
+)
 
 var _ Handler = (*Fake)(nil)
 
@@ -53,7 +57,9 @@ func NewFake(config map[string]interface{}) (*Fake, error) {
 		return nil, errors.New("FakeHandler: missing 'name' configuration")
 	}
 
-	log.Printf("[INFO] (handler.fake) creating handler with name: %s", h.name)
+	logging.Global().Named(logSystemName).Named(fakeSubsystemName).Info("creating handler",
+		"handler_name", h.name)
+
 	return h, nil
 }
 
@@ -68,7 +74,7 @@ func (h *Fake) Do(ctx context.Context, prevErr error) error {
 		err = fmt.Errorf("error %s", h.name)
 	}
 
-	if h.first == true {
+	if h.first {
 		h.first = false
 		if h.successFirst {
 			err = nil

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	logSystemName = "handler"
+)
+
 // Handler handles additional actions that need to be executed. These can
 // be at any level. Handlers can be chained such that they execute and continue
 // to the next handler. A chain of handlers will return an aggregate of any

--- a/handler/panos_test.go
+++ b/handler/panos_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/PaloAltoNetworks/pango"
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/handler"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
@@ -116,9 +117,9 @@ func TestPanosDo(t *testing.T) {
 				Return(nil)
 			m.On("String").Return("client string")
 
-			h := &Panos{client: m}
+			h := &Panos{client: m, logger: logging.NewNullLogger()}
 			if tc.next {
-				next := &Panos{client: m}
+				next := &Panos{client: m, logger: logging.NewNullLogger()}
 				h.SetNext(next)
 			}
 
@@ -136,7 +137,7 @@ func TestPanosDo(t *testing.T) {
 			Return(nil).Once()
 		m.On("String").Return("client string").Once()
 
-		h := &Panos{client: m, autoCommit: true, retry: retry.NewTestRetry(1)}
+		h := &Panos{client: m, autoCommit: true, retry: retry.NewTestRetry(1), logger: logging.NewNullLogger()}
 		assert.NoError(t, h.Do(context.Background(), nil))
 		h.autoCommit = false
 		assert.NoError(t, h.Do(context.Background(), nil))
@@ -211,7 +212,7 @@ func TestPanosCommit(t *testing.T) {
 				Return(tc.waitReturn)
 			m.On("String").Return("client string").Once()
 
-			h := &Panos{client: m, retry: retry.NewTestRetry(1)}
+			h := &Panos{client: m, retry: retry.NewTestRetry(1), logger: logging.NewNullLogger()}
 			err := h.commit(context.Background())
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -254,8 +255,8 @@ func TestPanosSetNext(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			h := &Panos{}
-			h.SetNext(&Panos{})
+			h := &Panos{logger: logging.NewNullLogger()}
+			h.SetNext(&Panos{logger: logging.NewNullLogger()})
 			assert.NotNil(t, h.next)
 		})
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -20,6 +21,9 @@ const (
 	defaultLogLevel = "INFO"
 )
 
+// Logger is a type alias for hclog.Logger
+type Logger hclog.Logger
+
 // Config is the configuration for this log setup.
 type Config struct {
 	// Level is the log level to use.
@@ -36,9 +40,6 @@ type Config struct {
 	// be written to writer in addition to syslog.
 	Writer io.Writer
 }
-
-// Logger is a type alias for hclog.Logger
-type Logger hclog.Logger
 
 // Setup takes as an arugment a configuration and then uses it to configure the global
 // logger. After setup logging.Global() can be used to access the global logger
@@ -84,6 +85,18 @@ func Global() Logger {
 // NewNullLogger returns the hclog.NewNullLogger() null logger as type Logger
 func NewNullLogger() Logger {
 	return hclog.NewNullLogger()
+}
+
+// WithContext stores a Logger and any provided arguments into the provided context
+// to access this logger, use the FromContext function
+func WithContext(ctx context.Context, logger Logger, args ...interface{}) context.Context {
+	return hclog.WithContext(ctx, logger, args...)
+}
+
+// FromContext returns the Logger contained with the context. If no Logger is found in the context,
+// this function returns the Global Logger
+func FromContext(ctx context.Context) Logger {
+	return hclog.FromContext(ctx)
 }
 
 // SetupLocal returns a new log.Logger which logs to a provided io.Writer

--- a/templates/hcltmpl/dynamic.go
+++ b/templates/hcltmpl/dynamic.go
@@ -3,9 +3,9 @@ package hcltmpl
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	tmpls "github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/hcat"
 	"github.com/hashicorp/hcat/tfunc"
@@ -15,6 +15,11 @@ import (
 var (
 	dynamicTmplRegexp = regexp.MustCompile(`\{\{\s*(env|key|with secret)\s+\\?\".+\\?\"\s*\}\}`)
 	vaultTmplRegexp   = regexp.MustCompile(`\{\{\s*with secret\s+\\?\".+\\?\"\s*\}\}`)
+)
+
+const (
+	logSystemName        = "template"
+	hcltmplSubsystemName = "hcltmpl"
 )
 
 // ContainsDynamicTemplate reports whether the template syntax supported by CTS
@@ -42,7 +47,8 @@ func LoadDynamicConfig(ctx context.Context, w tmpls.Watcher, r tmpls.Resolver,
 		return block, nil
 	}
 
-	log.Printf("[INFO] (templates.hcltmpl) evaluating dynamic configuration for %q", block.Name)
+	logging.Global().Named(logSystemName).Named(hcltmplSubsystemName).Info(
+		"evaluating dynamic configuration for block", "block_name", block.Name)
 
 	// Traverse all variables and nested variables to evaluate any dynamic values
 	for attrName, v := range block.Variables {

--- a/templates/tftmpl/condition_consul_kv.go
+++ b/templates/tftmpl/condition_consul_kv.go
@@ -3,8 +3,9 @@ package tftmpl
 import (
 	"fmt"
 	"io"
-	"log"
 	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
@@ -48,6 +49,7 @@ func (c ConsulKVCondition) appendModuleAttribute(body *hclwrite.Body) {
 func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
 	q := c.hcatQuery()
 
+	logger := logging.Global().Named(logSystemName).Named(tftmplSubsystemName)
 	if c.SourceIncludesVar {
 		var baseTmpl string
 		if c.Recurse {
@@ -57,8 +59,7 @@ func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
 		}
 		_, err := fmt.Fprintf(w, consulKVConditionIncludesVarTmpl, baseTmpl)
 		if err != nil {
-			log.Printf("[ERR] (templates.tftmpl) unable to write consul-kv" +
-				" template to include variable")
+			logger.Error("unable to write consul-kv template to include variable", "error", err)
 			return err
 		}
 		return nil
@@ -72,8 +73,7 @@ func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
 	}
 	_, err := w.Write([]byte(conditionTmpl))
 	if err != nil {
-		log.Printf("[ERR] (templates.tftmpl) unable to write consul-kv" +
-			" empty template")
+		logger.Error("unable to write consul-kv empty template", "error", err)
 		return err
 	}
 	return nil

--- a/templates/tftmpl/notifier/notifier_test.go
+++ b/templates/tftmpl/notifier/notifier_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"testing"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/hcat/dep"
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,7 @@ func Test_CatalogServicesRegistration_Notify(t *testing.T) {
 			tmpl := new(mocks.Template)
 			tmpl.On("Notify", mock.Anything).Return(true)
 
-			n := CatalogServicesRegistration{Template: tmpl, once: true}
+			n := CatalogServicesRegistration{Template: tmpl, once: true, logger: logging.NewNullLogger()}
 			actual := n.Notify(tc.dep)
 			assert.Equal(t, tc.expected, actual)
 		})

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -6,7 +6,6 @@ package testutils
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -37,8 +37,8 @@ func FreePort(t testing.TB) int {
 func MakeTempDir(t testing.TB, tempDir string) func() error {
 	_, err := os.Stat(tempDir)
 	if !os.IsNotExist(err) {
-		log.Printf("[WARN] temp dir %s was not cleared out after last test. "+
-			"Deleting.", tempDir)
+		logging.Global().Warn("temp dir was not cleared out after last test. "+
+			"Deleting.", "temp_dir", tempDir)
 		err = os.RemoveAll(tempDir)
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
This issue resolves #332 

In this issue I've done the following:
1) Refactored logging to be performed by [go-hclog](https://github.com/hashicorp/go-hclog) library
2) Added HTTP middleware which logs information about a request on the way in, as well as on the way out. The middleware also adds a request ID (reqID) so that logs for a particular request can be tracked.

As part of (2) I considered creating a custom wrapper around the http.ResponseWriter so that metadata such as the status of the response could be logged, but ultimately decided that this may be a task for another issue if so desired. If anyone feels strongly that this information should be logged as part of this issue, then I can do this enhancement as well.

**For comparison, New vs Old logs**
![new logs](https://user-images.githubusercontent.com/62034708/131760114-af991bcb-af0c-4e25-b006-3596d5492eec.png)

![old logs](https://user-images.githubusercontent.com/62034708/131760158-e18046cb-df34-44d7-ae10-4d8c655edb88.png)

**Sample Trace Logs with HTTP Logs at the end**
![image](https://user-images.githubusercontent.com/62034708/131760378-a12a70dd-a693-4493-aa14-eac439855f69.png)

