### PR TITLE
Add unit test running Once and Run to test Watcher semantics

### DIFF
--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -67,6 +67,12 @@ func (d *Drivers) Reset() {
 	}
 }
 
+func (d *Drivers) Len() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.drivers)
+}
+
 // Map returns a copy of the map containing the drivers
 func (d *Drivers) Map() map[string]Driver {
 	d.mu.RLock()

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -77,13 +77,10 @@ func benchmarkTasksConcurrent(b *testing.B, numTasks, numServices int) {
 			ctx, ctxCancel := context.WithCancel(context.Background())
 			defer ctxCancel()
 			ctrlStopped := make(chan error)
-			rwCtrl.EnableTestMode()
-			completedTasksCh, err := rwCtrl.TaskNotifyChannel()
-			require.NoError(b, err)
+			completedTasksCh := rwCtrl.EnableTestMode()
 
 			go func() {
-				err = rwCtrl.Run(ctx)
-				ctrlStopped <- err
+				ctrlStopped <- rwCtrl.Run(ctx)
 			}()
 
 			// Benchmark setup is done, reset the timer


### PR DESCRIPTION
Once mode should not call an extra Watcher.WaitCh() which could
inadvertantly mute the first trigger after Once mode has completed
from when Run expects it.

Also improve taskNotify by simplifying how to enable for tests