### PR TITLE
Consul KV condition template

### DIFF
--- a/driver/task.go
+++ b/driver/task.go
@@ -322,6 +322,13 @@ func (t *Task) configureRootModuleInput(input *tftmpl.RootModuleInputData) {
 			// always set services variable
 			SourceIncludesVar: true,
 		}
+	case *config.ConsulKVConditionConfig:
+		condition = &tftmpl.ConsulKVCondition{
+			Path:              *v.Path,
+			SourceIncludesVar: *v.SourceIncludesVar,
+			Datacenter:        *v.Datacenter,
+			Recurse:           *v.Recurse,
+		}
 	default:
 		// expected only for test scenarios
 		log.Printf("[WARN] (driver.terraform) task '%s' condition config unset."+

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20210720211050-6b4bba8fb8ff
+	github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210720211050-6b4bba8fb8ff h1:oAnoXGgQMiT4om3z0zeuSVbPd6QVnqqmpaA+EOdz1Q4=
-github.com/hashicorp/hcat v0.0.0-20210720211050-6b4bba8fb8ff/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a h1:caioaNPyyslXE11z+gnaopeWLR1CznAhpP04awQiRSM=
+github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/templates/tftmpl/condition_consul_kv.go
+++ b/templates/tftmpl/condition_consul_kv.go
@@ -1,0 +1,140 @@
+package tftmpl
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+)
+
+var (
+	_ Condition = (*ConsulKVCondition)(nil)
+)
+
+// ConsulKVCondition handles appending templating for the consul-kv
+// run condition
+type ConsulKVCondition struct {
+	Path              string
+	SourceIncludesVar bool
+	Recurse           bool
+	Datacenter        string
+	Namespace         string
+}
+
+func (c ConsulKVCondition) SourceIncludesVariable() bool {
+	return c.SourceIncludesVar
+}
+
+func (c ConsulKVCondition) ServicesAppended() bool {
+	return false
+}
+
+func (c ConsulKVCondition) appendModuleAttribute(body *hclwrite.Body) {
+	body.SetAttributeTraversal("consul_kv", hcl.Traversal{
+		hcl.TraverseRoot{Name: "var"},
+		hcl.TraverseAttr{Name: "consul_kv"},
+	})
+}
+
+func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
+	q := c.hcatQuery()
+
+	if c.SourceIncludesVar {
+		var baseTmpl string
+		if c.Recurse {
+			baseTmpl = fmt.Sprintf(consulKVRecurseBaseTmpl, q)
+		} else {
+			baseTmpl = fmt.Sprintf(consulKVBaseTmpl, q, c.Path)
+		}
+		_, err := fmt.Fprintf(w, consulKVConditionIncludesVarTmpl, baseTmpl)
+		if err != nil {
+			log.Printf("[ERR] (templates.tftmpl) unable to write consul-kv" +
+				" template to include variable")
+			return err
+		}
+		return nil
+	}
+
+	var conditionTmpl string
+	if c.Recurse {
+		conditionTmpl = consulKVRecurseConditionTmpl
+	} else {
+		conditionTmpl = consulKVConditionTmpl
+	}
+	_, err := fmt.Fprintf(w, conditionTmpl, q)
+	if err != nil {
+		log.Printf("[ERR] (templates.tftmpl) unable to write consul-kv" +
+			" empty template")
+		return err
+	}
+	return nil
+}
+
+func (c ConsulKVCondition) appendVariable(w io.Writer) error {
+	_, err := w.Write(variableConsulKV)
+	return err
+}
+
+func (c ConsulKVCondition) hcatQuery() string {
+	var opts []string
+
+	opts = append(opts, c.Path)
+
+	if c.Datacenter != "" {
+		opts = append(opts, fmt.Sprintf("dc=%s", c.Datacenter))
+	}
+
+	if c.Namespace != "" {
+		opts = append(opts, fmt.Sprintf("ns=%s", c.Namespace))
+	}
+
+	if len(opts) > 0 {
+		return `"` + strings.Join(opts, `" "`) + `" ` // deliberate space at end
+	}
+	return ""
+}
+
+const consulKVConditionTmpl = `
+{{- with $kv := key %s }}
+	{{- /* Empty template. Detects changes in Consul KV */ -}}
+{{- end}}
+`
+const consulKVRecurseConditionTmpl = `
+{{- with $kv := keys %s }}
+	{{- range $k, $v := $kv }}
+		{{- /* Empty template. Detects changes in Consul KV */ -}}
+	{{- end}}
+{{- end}}
+`
+
+var consulKVConditionIncludesVarTmpl = `
+consul_kv = {%s}
+`
+
+const consulKVBaseTmpl = `
+{{- with $kv := key %s }}
+	"%s" = "{{ $kv }}"
+{{- end}}
+`
+
+const consulKVRecurseBaseTmpl = `
+{{- with $kv := keys %s }}
+	{{- range $k := $kv }}
+	"{{ .Path }}" = "{{ .Value }}"
+	{{- end}}
+{{- end}}
+`
+
+// variableConsulKV is required for modules that include Consul KV
+// information. It is versioned to track compatibility between the generated
+// root module and modules that include Consul KV.
+var variableConsulKV = []byte(`
+# Consul KV definition protocol v0
+variable "consul_kv" {
+	description = "Consul KV pair"
+	type = map(string)
+}
+`)

--- a/templates/tftmpl/condition_consul_kv_test.go
+++ b/templates/tftmpl/condition_consul_kv_test.go
@@ -1,0 +1,125 @@
+package tftmpl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsulKVCondition_hcatQuery(t *testing.T) {
+	testcase := []struct {
+		name string
+		c    *ConsulKVCondition
+		exp  string
+	}{
+		{
+			"path only",
+			&ConsulKVCondition{
+				Path: "key-path",
+			},
+			"\"key-path\" ",
+		},
+		{
+			"all_parameters",
+			&ConsulKVCondition{
+				Path:       "key-path",
+				Datacenter: "dc2",
+				Namespace:  "test-ns",
+			},
+			"\"key-path\" \"dc=dc2\" \"ns=test-ns\" ",
+		},
+	}
+
+	for _, tc := range testcase {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.c.hcatQuery()
+			assert.Equal(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestConsulKVCondition_appendTemplate(t *testing.T) {
+	testcases := []struct {
+		name string
+		c    *ConsulKVCondition
+		exp  string
+	}{
+		{
+			"recurse false includes var false",
+			&ConsulKVCondition{
+				Path:              "path",
+				Recurse:           false,
+				SourceIncludesVar: false,
+				Datacenter:        "dc1",
+				Namespace:         "test-ns",
+			},
+			`
+{{- with $kv := key "path" "dc=dc1" "ns=test-ns"  }}
+	{{- /* Empty template. Detects changes in Consul KV */ -}}
+{{- end}}
+`,
+		},
+		{
+			"recurse false includes var true",
+			&ConsulKVCondition{
+				Path:              "path",
+				Recurse:           false,
+				SourceIncludesVar: true,
+				Datacenter:        "dc1",
+				Namespace:         "test-ns",
+			},
+			`
+consul_kv = {
+{{- with $kv := key "path" "dc=dc1" "ns=test-ns"  }}
+	"path" = "{{ $kv }}"
+{{- end}}
+}
+`,
+		},
+		{
+			"recurse true includes var false",
+			&ConsulKVCondition{
+				Path:              "path",
+				Recurse:           true,
+				SourceIncludesVar: false,
+				Datacenter:        "dc1",
+				Namespace:         "test-ns",
+			},
+			`
+{{- with $kv := keys "path" "dc=dc1" "ns=test-ns"  }}
+	{{- range $k, $v := $kv }}
+		{{- /* Empty template. Detects changes in Consul KV */ -}}
+	{{- end}}
+{{- end}}
+`,
+		},
+		{
+			"recurse true includes var true",
+			&ConsulKVCondition{
+				Path:              "path",
+				Recurse:           true,
+				SourceIncludesVar: true,
+				Datacenter:        "dc1",
+				Namespace:         "test-ns",
+			},
+			`
+consul_kv = {
+{{- with $kv := keys "path" "dc=dc1" "ns=test-ns"  }}
+	{{- range $k := $kv }}
+	"{{ .Path }}" = "{{ .Value }}"
+	{{- end}}
+{{- end}}
+}
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := new(strings.Builder)
+			tc.c.appendTemplate(w)
+			assert.Equal(t, tc.exp, w.String())
+		})
+	}
+}


### PR DESCRIPTION
Adds the templating work for Consul KV triggers, using the latest hcat changes for `key`, `keyExists`, and `keys`. The recurse option determines whether to use `keys` or `keyExists` + `key`. This is because of the Consul client used by hcat has a get method for `recurse=false` and a separate list method for `recurse=true`.

Follow up PR will have the notifier changes so that only KV dependencies trigger tasks and the end-to-end tests.

Part of https://github.com/hashicorp/consul-terraform-sync/issues/150