### PR TITLE
Add schedule task condition configuration

### DIFF
--- a/config/condition.go
+++ b/config/condition.go
@@ -43,6 +43,8 @@ func isConditionNil(c ConditionConfig) bool {
 		result = v == nil
 	case *ConsulKVConditionConfig:
 		result = v == nil
+	case *ScheduleConditionConfig:
+		result = v == nil
 	default:
 		return c == nil || reflect.ValueOf(c).IsNil()
 	}
@@ -88,6 +90,10 @@ func conditionToTypeFunc() mapstructure.DecodeHookFunc {
 		}
 		if c, ok := conditions[consulKVConditionType]; ok {
 			var config ConsulKVConditionConfig
+			return decodeConditionToType(c, &config)
+		}
+		if c, ok := conditions[scheduleConditionType]; ok {
+			var config ScheduleConditionConfig
 			return decodeConditionToType(c, &config)
 		}
 

--- a/config/condition_schedule.go
+++ b/config/condition_schedule.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/cronexpr"
+)
+
+const scheduleConditionType = "schedule"
+
+var _ ConditionConfig = (*ScheduleConditionConfig)(nil)
+
+// ScheduleConditionConfig configures a condition configuration block of type
+// 'schedule'. A schedule condition is triggered by a configured cron schedule
+type ScheduleConditionConfig struct {
+	Cron *string `mapstructure:"cron"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *ScheduleConditionConfig) Copy() ConditionConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o ScheduleConditionConfig
+	o.Cron = StringCopy(c.Cron)
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+func (c *ScheduleConditionConfig) Merge(o ConditionConfig) ConditionConfig {
+	if c == nil {
+		if isConditionNil(o) { // o is interface, use isConditionNil()
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if isConditionNil(o) {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+	o2, ok := o.(*ScheduleConditionConfig)
+	if !ok {
+		return r
+	}
+
+	r2 := r.(*ScheduleConditionConfig)
+
+	if o2.Cron != nil {
+		r2.Cron = StringCopy(o2.Cron)
+	}
+
+	return r2
+}
+
+// Finalize ensures there no nil pointers.
+func (c *ScheduleConditionConfig) Finalize([]string) {
+	if c == nil { // config not required, return early
+		return
+	}
+
+	if c.Cron == nil {
+		c.Cron = String("")
+	}
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *ScheduleConditionConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if c.Cron == nil || len(*c.Cron) == 0 {
+		return fmt.Errorf("cron config is required for schedule condition")
+	}
+
+	if _, err := cronexpr.Parse(*c.Cron); err != nil {
+		return fmt.Errorf("unable to parse schedule condition's cron config "+
+			"%q: %s. for more information on writing cron expressions, see %s",
+			StringVal(c.Cron), err, "https://github.com/hashicorp/cronexpr")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *ScheduleConditionConfig) GoString() string {
+	if c == nil {
+		return "(*ScheduleConditionConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&ScheduleConditionConfig{"+
+		"Cron:%s, "+
+		"}",
+		StringVal(c.Cron),
+	)
+}

--- a/config/condition_schedule_test.go
+++ b/config/condition_schedule_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduleConditionConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ScheduleConditionConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&ScheduleConditionConfig{},
+		},
+		{
+			"fully_configured",
+			&ScheduleConditionConfig{
+				Cron: String("* * * * * * *"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			if tc.a == nil {
+				// returned nil interface has nil type, which is unequal to tc.a
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.a, r)
+			}
+		})
+	}
+}
+
+func TestScheduleConditionConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ScheduleConditionConfig
+		b    *ScheduleConditionConfig
+		r    *ScheduleConditionConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{},
+		},
+		{
+			"nil_b",
+			&ScheduleConditionConfig{},
+			nil,
+			&ScheduleConditionConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{},
+		},
+		{
+			"cron_overrides",
+			&ScheduleConditionConfig{Cron: String("same")},
+			&ScheduleConditionConfig{Cron: String("different")},
+			&ScheduleConditionConfig{Cron: String("different")},
+		},
+		{
+			"cron_empty_one",
+			&ScheduleConditionConfig{Cron: String("same")},
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{Cron: String("same")},
+		},
+		{
+			"cron_empty_two",
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{Cron: String("same")},
+			&ScheduleConditionConfig{Cron: String("same")},
+		},
+		{
+			"cron_empty_same",
+			&ScheduleConditionConfig{Cron: String("same")},
+			&ScheduleConditionConfig{Cron: String("same")},
+			&ScheduleConditionConfig{Cron: String("same")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				// returned nil interface has nil type, which is unequal to tc.r
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.r, r)
+			}
+		})
+	}
+}
+
+func TestScheduleConditionConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		s    []string
+		i    *ScheduleConditionConfig
+		r    *ScheduleConditionConfig
+	}{
+		{
+			"nil",
+			[]string{},
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			[]string{},
+			&ScheduleConditionConfig{},
+			&ScheduleConditionConfig{
+				Cron: String(""),
+			},
+		},
+		{
+			"cron_configured",
+			[]string{},
+			&ScheduleConditionConfig{
+				Cron: String("* * * * *"),
+			},
+			&ScheduleConditionConfig{
+				Cron: String("* * * * *"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize(tc.s)
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestScheduleConditionConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *ScheduleConditionConfig
+	}{
+		{
+			"nil",
+			false,
+			nil,
+		},
+		{
+			"valid_cron",
+			false,
+			&ScheduleConditionConfig{
+				Cron: String("* * * * * * *"),
+			},
+		},
+		{
+			"nil_cron",
+			true,
+			&ScheduleConditionConfig{},
+		},
+		{
+			"invalid_cron",
+			true,
+			&ScheduleConditionConfig{
+				Cron: String("invalid"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -128,6 +128,23 @@ task {
 }`,
 		},
 		{
+			"schedule: happy path",
+			false,
+			&ScheduleConditionConfig{
+				Cron: String("* * * * * * *"),
+			},
+			"config.hcl",
+			`
+task {
+	name = "schedule_condition_task"
+	source = "..."
+	services = ["api"]
+	condition "schedule" {
+		cron = "* * * * * * *"
+	}
+}`,
+		},
+		{
 			"catalog-services: unsupported field",
 			true,
 			nil,

--- a/config/task.go
+++ b/config/task.go
@@ -235,9 +235,10 @@ func (c *TaskConfig) Finalize(globalBp *BufferPeriodConfig, wd string) {
 	if _, ok := c.Condition.(*ScheduleConditionConfig); ok {
 		// disable buffer_period for schedule condition
 		if c.BufferPeriod != nil {
-			log.Printf("[WARN] (config.task) disabling buffer_period for "+
-				"schedule condition. overriding buffer_period configured for "+
-				"this task: %s", c.BufferPeriod.GoString())
+			logging.Global().Named(logSystemName).Named(taskSubsystemName).Warn(
+				"disabling buffer_period for schedule condition. overriding "+
+					"buffer_period configured for this task",
+				"task_name", StringVal(c.Name), "buffer_period", c.BufferPeriod.GoString())
 		}
 		bp = &BufferPeriodConfig{
 			Enabled: Bool(false),
@@ -313,9 +314,11 @@ func (c *TaskConfig) Validate() error {
 			if cond.Regexp != nil && *cond.Regexp != "" {
 				err := fmt.Errorf("task.services is not allowed if task.condition.regexp " +
 					"is configured for a services condition")
-				logging.Global().Named(logSystemName+taskSubsystemName).Error("[ERR] (config.task) list of "+
-					"services and service condition regex both provided. If both are needed, consider "+
-					"including the list in the regex or creating separate tasks.", "error", err)
+				logging.Global().Named(logSystemName).Named(taskSubsystemName).
+					Error("list of services and service condition regex both "+
+						"provided. If both are needed, consider including the "+
+						"list in the regex or creating separate tasks",
+						"task_name", StringVal(c.Name), "error", err)
 				return err
 			}
 		}

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -366,6 +367,31 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				WorkingDir:   String("sync-tasks/task"),
 			},
 		},
+		{
+			"with_schedule_condition",
+			&TaskConfig{
+				Name:      String("task"),
+				Condition: &ScheduleConditionConfig{},
+			},
+			&TaskConfig{
+				Description: String(""),
+				Name:        String("task"),
+				Providers:   []string{},
+				Services:    []string{},
+				Source:      String(""),
+				VarFiles:    []string{},
+				Version:     String(""),
+				TFVersion:   String(""),
+				BufferPeriod: &BufferPeriodConfig{
+					Enabled: Bool(false),
+					Min:     TimeDuration(0 * time.Second),
+					Max:     TimeDuration(0 * time.Second),
+				},
+				Enabled:    Bool(true),
+				Condition:  &ScheduleConditionConfig{String("")},
+				WorkingDir: String("sync-tasks/task"),
+			},
+		},
 	}
 
 	for i, tc := range cases {
@@ -438,6 +464,16 @@ func TestTaskConfig_Validate(t *testing.T) {
 			true,
 		},
 		{
+			"valid (service with schedule condition)",
+			&TaskConfig{
+				Name:      String("task"),
+				Source:    String("source"),
+				Services:  []string{"serviceA", "serviceB"},
+				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
+			},
+			true,
+		},
+		{
 			"missing name",
 			&TaskConfig{Services: []string{"service"}, Source: String("source")},
 			false,
@@ -473,6 +509,15 @@ func TestTaskConfig_Validate(t *testing.T) {
 				Name:      String("task"),
 				Source:    String("source"),
 				Condition: &CatalogServicesConditionConfig{},
+			},
+			false,
+		},
+		{
+			"missing service with schedule condition",
+			&TaskConfig{
+				Name:      String("task"),
+				Source:    String("source"),
+				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
 			},
 			false,
 		},

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/consul v1.9.3
 	github.com/hashicorp/consul/api v1.8.1
 	github.com/hashicorp/consul/sdk v0.7.0
+	github.com/hashicorp/cronexpr v1.1.1
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-bexpr v0.1.4
 	github.com/hashicorp/go-checkpoint v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/hashicorp/consul/api v1.8.1/go.mod h1:sDjTOq0yUyv5G4h+BqSea7Fn6BU+Xbo
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/consul/sdk v0.7.0 h1:H6R9d008jDcHPQPAqPNuydAshJ4v5/8URdFnUvK/+sc=
 github.com/hashicorp/consul/sdk v0.7.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
+github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=
+github.com/hashicorp/cronexpr v1.1.1/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
Supports configuring a task with a schedule condition allowing users to
configure a task that monitors services in task.services but only execute
on a configured schedule rather than be dynamically triggered on changes.

Details:
 - schedule condition's cron field is required
 - uses the hashicorp fork of `cronexpr` to validate cron expression
 - disables buffer_period and logs a warning if task's buffer_period is
 configured. buffer_period does not make sense to be enabled for a scheduled
 task

Example config:
```
task {
  name = "scheduled_task"
  description = "run task every 10 seconds"
  services = ["web", "db"]
  source = "path/to/module"
  condition "schedule" {
    cron = "*/10 * * * * * *"
  }
}
```
Part of: https://github.com/hashicorp/consul-terraform-sync/issues/308

Subsequent prs
 - Consume schedule condition configuration to trigger task on schedule
 - Support configuring monitoring services by regexp
 - Support configuring monitoring kv