### PR TITLE
Remove arm/v5/v6 from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,6 @@ jobs:
           go build -o dist/
 
           zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-          ls -lah out
 
       - uses: actions/upload-artifact@v2
         with:
@@ -182,7 +181,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}
           description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
-          arch: ${{ env.FILE_SUFFIX }}
+          arch: ${{ matrix.goarch }}
           version: ${{ needs.get-product-version.outputs.product-version }}
           maintainer: "HashiCorp"
           homepage: "https://github.com/hashicorp/consul-terraform-sync"
@@ -311,9 +310,6 @@ jobs:
     name: Docker ${{ matrix.arch }} build
 
     steps:
-      #- name: Set env NEED
-      # run: |
-      #    echo "FILE_SUFFIX=${{ matrix.arch }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
 
       # download arm/arm64/386/amd64 binaries from build jobs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_amd64.deb
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_armhf.deb
           path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_amd64.deb
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,10 +146,9 @@ jobs:
         goos: [linux]
         goarch: [arm]
         go: ["1.16"]
-        goarm: [5, 6]
       fail-fast: true
 
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} ${{ matrix.goarm }} build
+    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
 
     env:
       GOOS: ${{ matrix.goos }}
@@ -164,26 +163,18 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Set env NEED
-        run: |
-          if [[ ${{ matrix.goarm }} == '5' ]]; then
-              echo "FILE_SUFFIX=armelv5" >> "$GITHUB_ENV"
-          else
-              echo "FILE_SUFFIX=armhfv6" >> "$GITHUB_ENV"
-          fi
-
       - name: Build
         run: |
           mkdir dist out
           go build -o dist/
-          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip dist/
 
+          zip -r -j out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
+          ls -lah out
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ env.FILE_SUFFIX }}.zip
-
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
       - name: Package
         if: ${{ matrix.goos == 'linux' }}
@@ -202,13 +193,13 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ env.FILE_SUFFIX }}.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ env.FILE_SUFFIX }}.deb
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_amd64.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_amd64.deb
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ env.FILE_SUFFIX }}.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ env.FILE_SUFFIX }}.rpm
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
 
   build-arm64:
     needs: get-product-version
@@ -272,7 +263,6 @@ jobs:
           name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
           path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.*.rpm
 
-
   build-darwin:
     needs: get-product-version
     runs-on: macos-latest
@@ -321,26 +311,22 @@ jobs:
     name: Docker ${{ matrix.arch }} build
 
     steps:
-      - name: Set env NEED
-        run: |
-          if [[ ${{ matrix.arch }} == 'arm' ]]; then
-              echo "FILE_SUFFIX=armhfv6" >> "$GITHUB_ENV"
-          else
-              echo "FILE_SUFFIX=${{ matrix.arch }}" >> "$GITHUB_ENV"
-          fi
+      #- name: Set env NEED
+      # run: |
+      #    echo "FILE_SUFFIX=${{ matrix.arch }}" >> "$GITHUB_ENV"
       - uses: actions/checkout@v2
 
       # download arm/arm64/386/amd64 binaries from build jobs
       - uses: actions/download-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ env.FILE_SUFFIX }}.zip
+          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
 
       # build docker image
       - name: Docker build
         working-directory: ./.release/docker
         run: |
           docker version
-          unzip -j ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ env.FILE_SUFFIX }}.zip
+          unzip -j ${GITHUB_WORKSPACE}/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
           # arm32 bit docker images are set with --platform=linux/arm/v6
           if [ "${{ matrix.arch }}" = "arm" ]; then
             make docker ARCH=${{ matrix.arch }} GOARM_DOCKER="/v6"
@@ -352,8 +338,7 @@ jobs:
         with:
           name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_docker_linux_${{ matrix.arch }}.tar
           path: .release/docker/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_docker_linux_${{ matrix.arch }}.tar
-  
-  
+
   generate_metadata:
     needs: get-product-version
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
+          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
 
   build-arm64:
     needs: get-product-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
 
       - uses: actions/upload-artifact@v2
         with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
+          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
           path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
 
   build-arm64:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_armhf.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_amd64.deb
+          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_armhf.deb
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Removing arm/v5/v6 support from build.yml
Succesful run[ is here ](https://github.com/hashicorp/consul-terraform-sync/actions/runs/1211431864)