### PR TITLE
Add watcher registration check to initTaskTemplate

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -536,9 +536,12 @@ func (tf *Terraform) initTaskTemplate() error {
 		tf.template = tmpl
 	}
 
-	err = tf.watcher.Register(tf.template)
-	if err != nil {
-		return err
+	if !tf.watcher.Watching(tf.template.ID()) {
+		err = tf.watcher.Register(tf.template)
+		if err != nil && err != hcat.RegistryErr {
+			tf.logger.Error("unable to register template", taskNameLogKey, tf.task.Name(), "error", err)
+			return err
+		}
 	}
 
 	return nil

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -260,6 +260,7 @@ func TestUpdateTask(t *testing.T) {
 			}
 
 			w := new(mocksTmpl.Watcher)
+			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 			tf := &Terraform{
 				mu: &sync.RWMutex{},
@@ -365,6 +366,7 @@ func TestUpdateTask(t *testing.T) {
 			c.On("Apply", ctx).Return(tc.applyErr).Once()
 
 			w := new(mocksTmpl.Watcher)
+			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 
 			tf := &Terraform{
@@ -487,6 +489,7 @@ func TestInitTaskTemplates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := new(mocksTmpl.Watcher)
+			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 			tf := &Terraform{
 				fileReader: tc.fileReader,
@@ -642,6 +645,7 @@ func TestInitTask(t *testing.T) {
 			c.On("Validate", ctx).Return(tc.validateErr)
 
 			w := new(mocksTmpl.Watcher)
+			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 
 			tf := &Terraform{

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -136,3 +136,17 @@ func (_m *Watcher) WaitCh(_a0 context.Context) <-chan error {
 
 	return r0
 }
+
+// Watching provides a mock function with given fields: _a0
+func (_m *Watcher) Watching(_a0 string) bool {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -41,6 +41,7 @@ type Resolver interface {
 // https://github.com/hashicorp/hcat
 type Watcher interface {
 	WaitCh(context.Context) <-chan error
+	Watching(string) bool
 	Buffer(hcat.Notifier) bool
 	Mark(notifier hcat.IDer)
 	SetBufferPeriod(min, max time.Duration, tmplIDs ...string)


### PR DESCRIPTION
Benchmarks were failing when b.N > 1 with "duplicate watcher registry entry". `InitTask` could be called more than once and so adding the registry check would help for the benchmark and edge cases around task updates via the API in the future.

```
$ go test ./e2e/benchmarks -bench=BenchmarkTasks_t01_s01/ReadOnlyCtrl/task_setup -tags e2e -benchtime=3x
goos: darwin
goarch: amd64
pkg: github.com/hashicorp/consul-terraform-sync/e2e/benchmarks
cpu: Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
BenchmarkTasks_t01_s01/ReadOnlyCtrl/task_setup-8
--- FAIL: BenchmarkTasks_t01_s01/ReadOnlyCtrl/task_setup-8
    tasks_test.go:79: 
        	Error Trace:	tasks_test.go:79
        	            				benchmark.go:192
        	            				benchmark.go:298
        	            				asm_amd64.s:1371
        	Error:      	Received unexpected error:
        	            	duplicate watcher registry entry
        	Test:       	BenchmarkTasks_t01_s01/ReadOnlyCtrl/task_setup
--- FAIL: BenchmarkTasks_t01_s01/ReadOnlyCtrl
--- FAIL: BenchmarkTasks_t01_s01
FAIL
exit status 1
FAIL	github.com/hashicorp/consul-terraform-sync/e2e/benchmarks	8.464s
FAIL
```