### PR TITLE
Reorganize TLS finalize config

### DIFF
--- a/config/consul.go
+++ b/config/consul.go
@@ -156,7 +156,7 @@ func (c *ConsulConfig) Finalize() {
 	if c.TLS == nil {
 		c.TLS = DefaultTLSConfig()
 	}
-	c.TLS.Finalize()
+	c.TLS.FinalizeConsul()
 
 	if c.Token == nil {
 		c.Token = stringFromEnv([]string{

--- a/config/vault.go
+++ b/config/vault.go
@@ -174,29 +174,7 @@ func (c *VaultConfig) Finalize() {
 	if c.TLS == nil {
 		c.TLS = DefaultTLSConfig()
 	}
-	if c.TLS.Enabled == nil {
-		c.TLS.Enabled = Bool(true)
-	}
-	if c.TLS.CACert == nil {
-		c.TLS.CACert = stringFromEnv([]string{api.EnvVaultCACert}, "")
-	}
-	if c.TLS.CAPath == nil {
-		c.TLS.CAPath = stringFromEnv([]string{api.EnvVaultCAPath}, "")
-	}
-	if c.TLS.Cert == nil {
-		c.TLS.Cert = stringFromEnv([]string{api.EnvVaultClientCert}, "")
-	}
-	if c.TLS.Key == nil {
-		c.TLS.Key = stringFromEnv([]string{api.EnvVaultClientKey}, "")
-	}
-	if c.TLS.ServerName == nil {
-		c.TLS.ServerName = stringFromEnv([]string{api.EnvVaultTLSServerName}, "")
-	}
-	if c.TLS.Verify == nil {
-		c.TLS.Verify = antiboolFromEnv([]string{
-			api.EnvVaultSkipVerify, api.EnvVaultInsecure}, true)
-	}
-	c.TLS.Finalize()
+	c.TLS.FinalizeVault()
 
 	// Order of precedence
 	// 1. `vault_agent_token_file` configuration value


### PR DESCRIPTION
TLS config loaded from env vars are different for Consul and Vault.
This reorganizes it to more easily be found in one place