### PR TITLE
Update CHANGELOG.md with 0.4.0 beta1 date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## UNRELEASED
+## 0.4.0-beta1 (September 29, 2021)
 BREAKING CHANGES:
 * Remove deprecated `tag` filtering option from `service` configuration, which has been replaced by the more general `filter` option. [[GH-312](https://github.com/hashicorp/consul-terraform-sync/issues/312)]
 * The logging timestamps are now reported using the timezone of the system CTS is running on, instead of defaulting to UTC time. [[GH-332](https://github.com/hashicorp/consul-terraform-sync/issues/332)]


### PR DESCRIPTION
Our new release process does not add the changelog date automatically. Manually changing afterwards.

For future release processes, we will need to change the date before the release if the process stays the same