### PR TITLE
Add slack notification for benchmark failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  slack: circleci/slack@4.4
+
 jobs:
   unit_integration_tests:
     environment:
@@ -116,6 +120,9 @@ jobs:
           no_output_timeout: << parameters.no_output_timeout >>
           command:
             make test-benchmarks | /usr/bin/tee /tmp/benchmarks.json
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
       - run:
           name: Output benchmark results
           command: |


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/6362111/135308519-e7e92d84-a9b7-47da-9790-1c2e0c0be472.png" width=350>

Followup to resolving the benchmarks failing https://github.com/hashicorp/consul-terraform-sync/pull/384