### PR TITLE
update alpine version used in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@
 # We don't rebuild the software because we want the exact checksums and
 # binary signatures to match the software and our builds aren't fully
 # reproducible currently.
-FROM alpine:3.13
+FROM alpine:3
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.


### PR DESCRIPTION
3.13 had open security issues.
Changing to use the latest alpine:3 to better stay up to date.
Note alpine:3 is currently an alias for 3.14, which fixes the security issues.