### PR TITLE
Replace keyExists/key combination with keyExistsGet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a
+	github.com/hashicorp/hcat v0.0.0-20210930170120-25001581ba31
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a h1:caioaNPyyslXE11z+gnaopeWLR1CznAhpP04awQiRSM=
-github.com/hashicorp/hcat v0.0.0-20210831190427-7ef04e9d801a/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20210930170120-25001581ba31 h1:h+1JPhzVf6nVyq6G+ePD5MmPuVZoojGgSeAXRiz8vJ0=
+github.com/hashicorp/hcat v0.0.0-20210930170120-25001581ba31/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/templates/tftmpl/condition_consul_kv.go
+++ b/templates/tftmpl/condition_consul_kv.go
@@ -41,7 +41,7 @@ func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
 		if c.Recurse {
 			conditionTmpl = fmt.Sprintf(consulKVRecurseConditionTmpl, q)
 		} else {
-			conditionTmpl = fmt.Sprintf(consulKVConditionTmpl, q, q)
+			conditionTmpl = fmt.Sprintf(consulKVConditionTmpl, q)
 		}
 		_, err = w.Write([]byte(conditionTmpl))
 		if err != nil {
@@ -56,10 +56,8 @@ func (c ConsulKVCondition) appendTemplate(w io.Writer) error {
 }
 
 const consulKVConditionTmpl = `
-{{- if keyExists %s }}
-	{{- with $kv := key %s }}
-		{{- /* Empty template. Detects changes in Consul KV */ -}}
-	{{- end}}
+{{- with $kv := keyExistsGet %s }}
+  {{- /* Empty template. Detects changes in Consul KV */ -}}
 {{- end}}
 `
 const consulKVRecurseConditionTmpl = `

--- a/templates/tftmpl/condition_consul_kv_test.go
+++ b/templates/tftmpl/condition_consul_kv_test.go
@@ -64,10 +64,8 @@ func TestConsulKVCondition_appendTemplate(t *testing.T) {
 				SourceIncludesVar: false,
 			},
 			`
-{{- if keyExists "path" "dc=dc1" "ns=test-ns"  }}
-	{{- with $kv := key "path" "dc=dc1" "ns=test-ns"  }}
-		{{- /* Empty template. Detects changes in Consul KV */ -}}
-	{{- end}}
+{{- with $kv := keyExistsGet "path" "dc=dc1" "ns=test-ns"  }}
+  {{- /* Empty template. Detects changes in Consul KV */ -}}
 {{- end}}
 `,
 		},
@@ -84,10 +82,10 @@ func TestConsulKVCondition_appendTemplate(t *testing.T) {
 			},
 			`
 consul_kv = {
-{{- if keyExists "path" "dc=dc1" "ns=test-ns"  }}
-	{{- with $kv := key "path" "dc=dc1" "ns=test-ns"  }}
-		"path" = "{{ $kv }}"
-	{{- end}}
+{{- with $kv := keyExistsGet "path" "dc=dc1" "ns=test-ns"  }}
+  {{- if .Exists }}
+  "{{ .Path }}" = "{{ .Value }}"
+  {{- end}}
 {{- end}}
 }
 `,

--- a/templates/tftmpl/monitor_consul_kv.go
+++ b/templates/tftmpl/monitor_consul_kv.go
@@ -49,7 +49,7 @@ func (m ConsulKVMonitor) appendTemplate(w io.Writer) error {
 	if m.Recurse {
 		baseTmpl = fmt.Sprintf(consulKVRecurseBaseTmpl, q)
 	} else {
-		baseTmpl = fmt.Sprintf(consulKVBaseTmpl, q, q, m.Path)
+		baseTmpl = fmt.Sprintf(consulKVBaseTmpl, q)
 	}
 	_, err := fmt.Fprintf(w, consulKVIncludesVarTmpl, baseTmpl)
 	if err != nil {
@@ -88,10 +88,10 @@ consul_kv = {%s}
 `
 
 const consulKVBaseTmpl = `
-{{- if keyExists %s }}
-	{{- with $kv := key %s }}
-		"%s" = "{{ $kv }}"
-	{{- end}}
+{{- with $kv := keyExistsGet %s }}
+  {{- if .Exists }}
+  "{{ .Path }}" = "{{ .Value }}"
+  {{- end}}
 {{- end}}
 `
 

--- a/templates/tftmpl/notifier/consul_kv_test.go
+++ b/templates/tftmpl/notifier/consul_kv_test.go
@@ -24,13 +24,8 @@ func Test_ConsulKV_Notify(t *testing.T) {
 			false,
 		},
 		{
-			"notify: key value",
-			dep.KvValue("value"),
-			true,
-		},
-		{
-			"notify: key value exists",
-			dep.KVExists(true),
+			"notify: single key pair",
+			&dep.KeyPair{Key: "key", Value: "value", Exists: true},
 			true,
 		},
 		{
@@ -120,58 +115,15 @@ func Test_ConsulKV_Notify_Once_Mode_Key_Pairs(t *testing.T) {
 
 func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 
-	t.Run("services-last-with-existing-key", func(t *testing.T) {
+	t.Run("services-last", func(t *testing.T) {
 		// Test that notifier notifies at the end of once-mode, particularly
 		// for the race-condition when the services dependency (which normally
 		// does not notify) is received after consul-kv dependency.
 
-		// Notifier has 4 dependencies: 2 services, 1 Consul KV exists, 1 Consul KV value
+		// Notifier has 3 dependencies: 2 services, 1 Consul KV pair
 		// 1. receive first services dependency, no notification
-		// 2. receive Consul KV exists (true) dependency, notify for consul-kv
-		// 3. receive Consul KV value dependency, notify for consul-kv
+		// 2. receive Consul KV pair dependency, notify for consul-kv
 		// 4. receive second services dependency, notify for once-mode
-
-		tmpl := new(mocks.Template)
-		tmpl.On("Notify", mock.Anything).Return(true).Times(3)
-		n := NewConsulKV(tmpl, 2)
-
-		// 1. first services dependency does not notify
-		notify := n.Notify([]*dep.HealthService{})
-		assert.False(t, notify, "first services dep should not have notified")
-		assert.False(t, n.once, "got 1/4 deps. once-mode should not be completed")
-		assert.Equal(t, 1, n.counter, "first services dep should be 1st dep")
-
-		// 2. consul-kv exists notifies
-		notify = n.Notify(dep.KVExists(true))
-		assert.True(t, notify, "consul-kv dep should have notified")
-		assert.False(t, n.once, "got 2/4 deps. once-mode should not be completed")
-		assert.Equal(t, 2, n.counter, "consul-kv dep should be 2nd dep")
-
-		// 3. consul-kv value change notifies
-		notify = n.Notify(dep.KvValue("test"))
-		assert.True(t, notify, "consul-kv dep should have notified")
-		assert.False(t, n.once, "got 3/4 deps. once-mode should not be completed")
-		assert.Equal(t, 3, n.counter, "consul-kv dep should be 3rd dep")
-
-		// 4. second services notifies
-		notify = n.Notify([]*dep.HealthService{})
-		assert.True(t, notify, "second services dep should have notified")
-		assert.True(t, n.once, "got 4/4 deps. once-mode should be completed")
-		assert.Equal(t, 4, n.counter, "second services should be 4th dep")
-
-		// check mock template was called three times
-		tmpl.AssertExpectations(t)
-	})
-
-	t.Run("services-last-with-nonexistent-key", func(t *testing.T) {
-		// Test that notifier notifies at the end of once-mode, particularly
-		// for the race-condition when the services dependency (which normally
-		// does not notify) is received after consul-kv dependency.
-
-		// Notifier has 3 dependencies: 2 services, 1 Consul KV exists
-		// 1. receive first services dependency, no notification
-		// 2. receive Consul KV exists (false) dependency, notify for consul-kv
-		// 3. receive second services dependency, notify for once-mode
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Times(2)
@@ -183,8 +135,8 @@ func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 		assert.False(t, n.once, "got 1/3 deps. once-mode should not be completed")
 		assert.Equal(t, 1, n.counter, "first services dep should be 1st dep")
 
-		// 2. consul-kv exists notifies
-		notify = n.Notify(dep.KVExists(false))
+		// 2. consul-kv notifies
+		notify = n.Notify(&dep.KeyPair{Key: "key", Value: "value", Exists: true})
 		assert.True(t, notify, "consul-kv dep should have notified")
 		assert.False(t, n.once, "got 2/3 deps. once-mode should not be completed")
 		assert.Equal(t, 2, n.counter, "consul-kv dep should be 2nd dep")
@@ -195,51 +147,17 @@ func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 		assert.True(t, n.once, "got 3/3 deps. once-mode should be completed")
 		assert.Equal(t, 3, n.counter, "second services should be 3rd dep")
 
-		// check mock template was called twice
+		// check mock template was called three times
 		tmpl.AssertExpectations(t)
 	})
 
-	t.Run("consul-kv-last-with-existing-key", func(t *testing.T) {
+	t.Run("consul-kv-last", func(t *testing.T) {
 		// Test that notifier notifies at the end of once-mode, particularly for
 		// the case when the consul-kv dependency is received last.
 
-		// Notifier in test has 3 dependencies: 1 services, 1 Consul KV exists, 1 Consul KV value
+		// Notifier in test has 2 dependencies: 1 services, 1 Consul KV pair
 		// 1. receive services dependency, no notification
-		// 2. receive consul-kv exists (true) dependency, notify
-		// 3. receive consul-kv value dependency, notify
-
-		tmpl := new(mocks.Template)
-		tmpl.On("Notify", mock.Anything).Return(true).Twice()
-		n := NewConsulKV(tmpl, 1)
-
-		// 1. services dependency does not notify
-		notify := n.Notify([]*dep.HealthService{})
-		assert.False(t, notify, "services dep should not have notified")
-		assert.False(t, n.once, "got 1/3 deps. once-mode should not be completed")
-		assert.Equal(t, 1, n.counter, "services dep should be 1st dep")
-
-		// 2. consul-kv exists notifies
-		notify = n.Notify(dep.KVExists(true))
-		assert.True(t, notify, "consul-kv dep should have notified")
-		assert.False(t, n.once, "got 2/3 deps. once-mode should not be completed")
-		assert.Equal(t, 2, n.counter, "consul-kv dep should be 2nd dep")
-
-		notify = n.Notify(dep.KvValue("test"))
-		assert.True(t, notify, "consul-kv dep should have notified")
-		assert.True(t, n.once, "got 3/3 deps. once-mode should be completed")
-		assert.Equal(t, 3, n.counter, "consul-kv dep should be 3rd dep")
-
-		// check mock template was called once
-		tmpl.AssertExpectations(t)
-	})
-
-	t.Run("consul-kv-last-with-nonexistent-key", func(t *testing.T) {
-		// Test that notifier notifies at the end of once-mode, particularly for
-		// the case when the consul-kv dependency is received last.
-
-		// Notifier in test has 2 dependencies: 1 services and 1 Consul KV exists
-		// 1. receive services dependency, no notification
-		// 2. receive consul-kv exists (false) dependency, notify
+		// 2. receive consul-kv dependency, notify
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Once()
@@ -251,8 +169,8 @@ func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 		assert.False(t, n.once, "got 1/2 deps. once-mode should not be completed")
 		assert.Equal(t, 1, n.counter, "services dep should be 1st dep")
 
-		// 2. consul-kv exists notifies
-		notify = n.Notify(dep.KVExists(false))
+		// 2. consul-kv pair notifies
+		notify = n.Notify(&dep.KeyPair{Key: "key", Value: "value", Exists: true})
 		assert.True(t, notify, "consul-kv dep should have notified")
 		assert.True(t, n.once, "got 2/2 deps. once-mode should be completed")
 		assert.Equal(t, 2, n.counter, "consul-kv dep should be 2nd dep")


### PR DESCRIPTION
Having the two dependencies where the second dependency (the get) depends on the
value of the first dependency (if it exists) has made this too much of a special
case and adds too much complexity. Replacing with a single dependency keeps it
more in line with all our other templates.