### PR TITLE
Add slack notification for failed CircleCI jobs on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,10 @@ jobs:
           sudo cp consul /usr/local/bin/
       - run: |
           make test-integration
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: main,release/.+
       - save_cache:
           key: ct-modcache-v1-{{ checksum "go.mod" }}
           paths:
@@ -74,6 +78,10 @@ jobs:
           sudo cp consul /usr/local/bin/
       - run: |
           make test-e2e-cirecleci
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+          branch_pattern: main,release/.+
       - save_cache:
           key: ct-modcache-v1-{{ checksum "go.mod" }}
           paths:


### PR DESCRIPTION
Adds slack notification for `unit_integration_tests` and `e2e_tests` when it fails on `main` and release branches.

https://circleci.com/developer/orbs/orb/circleci/slack
> `branch_pattern` - A comma separated list of regex matchable branch names. Notifications will only be sent if sent from a job from these branches. By default ".+" will be used to match all branches. Pattern must match the full string, no partial matches.

I don't know how to test this :(, so hopefully the format is correct for including the release branch regex