### PR TITLE
Weekly Consul compat tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,28 @@ jobs:
           paths:
             - /go/pkg/mod
 
+  consul_compatibility_tests:
+    environment:
+      GO111MODULE: "on"
+      GO_VERSION: "1.16"
+    docker:
+      - image: docker.mirror.hashicorp.services/circleci/golang:${GO_VERSION}
+    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - ct-modcache-v1-{{ checksum "go.mod" }}
+      - run: |
+          make test-compat
+      # - slack/notify:
+      #     event: fail
+      #     template: basic_fail_1
+      - save_cache:
+          key: ct-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+
   benchmarks:
     parameters:
       no_output_timeout:
@@ -141,12 +163,14 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - unit_integration_tests
-      - e2e_tests
+      # - unit_integration_tests
+      # - e2e_tests
+      - consul_compatibility_tests # Temp to test CI job, remove before merge
   weekly-benchmarks:
     jobs:
       - vault_integration_tests
       - benchmarks
+      - consul_compatibility_tests
     triggers:
       - schedule:
           # 02:10 UTC every Wednesday

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,9 @@ jobs:
             - ct-modcache-v1-{{ checksum "go.mod" }}
       - run: |
           make test-compat
-      # - slack/notify:
-      #     event: fail
-      #     template: basic_fail_1
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
       - save_cache:
           key: ct-modcache-v1-{{ checksum "go.mod" }}
           paths:
@@ -163,9 +163,8 @@ workflows:
   version: 2
   build-test:
     jobs:
-      # - unit_integration_tests
-      # - e2e_tests
-      - consul_compatibility_tests # Temp to test CI job, remove before merge
+      - unit_integration_tests
+      - e2e_tests
   weekly-benchmarks:
     jobs:
       - vault_integration_tests

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ test-setup-e2e: dev
 test-e2e-cirecleci: test-setup-e2e test-e2e
 .PHONY: test-e2e-cirecleci
 
+# test-compat sets up the CTS binary and then runs the compatibility tests
+test-compat: test-setup-e2e
+	@echo "==> Testing ${NAME} compatiblity with Consul"
+	@go test ./e2e/compatibility -timeout 1h -tags=e2e -v -run TestCompatibility_Consul
+.PHONY: test-compat
+
 # test-benchmarks requires Terraform in the path of execution and Consul in $PATH.
 test-benchmarks:
 	@echo "==> Running benchmarks for ${NAME}"

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-e2e-cirecleci: test-setup-e2e test-e2e
 # test-compat sets up the CTS binary and then runs the compatibility tests
 test-compat: test-setup-e2e
 	@echo "==> Testing ${NAME} compatiblity with Consul"
-	@go test ./e2e/compatibility -timeout 1h -tags=e2e -v -run TestCompatibility_Consul
+	@go test ./e2e/compatibility -timeout 30m -tags=e2e -v -run TestCompatibility_Consul
 .PHONY: test-compat
 
 # test-benchmarks requires Terraform in the path of execution and Consul in $PATH.

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -82,6 +82,11 @@ func TestCompatibility_Consul(t *testing.T) {
 			cleanup := testutils.MakeTempDir(t, tempDir)
 			execPath := downloadConsul(t, tempDir, cv)
 
+			// Output the Consul version
+			consulVersion, err := exec.Command(execPath, "-version").Output()
+			require.NoError(t, err)
+			t.Logf("%s\n%s", t.Name(), consulVersion)
+
 			for _, tc := range cases {
 				t.Run(tc.name, func(t *testing.T) {
 					port := testutils.FreePort(t)

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -272,7 +272,6 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 	registerService(t, serviceInstance, port)
 	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
 	assert.Contains(t, content, "critical")
-
 }
 
 // testTagQueryCompatibility tests the compatibility of Consul's Health Service
@@ -317,7 +316,6 @@ func testTagQueryCompatibility(t *testing.T, tempDir string, port int) {
 	registerService(t, &capi.AgentServiceRegistration{ID: "redis_v2",
 		Name: "redis", Tags: []string{"v2"}}, port)
 	testutils.CheckFile(t, false, resourcesPath, "redis_v2.txt")
-
 }
 
 // testNodeValuesCompatibility tests the compatibility of Consul's Health


### PR DESCRIPTION
Runs compatibility tests with Consul in parallel and adds it to weekly CI jobs.
* Fix tests looking for artifacts in old paths (missing task subdir)
* Refactor tests to run in parallel by version
  * Reworked temp directories to not overlap across versions

Tests passing https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/1858/workflows/7185eedf-177e-4c37-9b61-0bb8a4690876/jobs/3655

TODO follow up and add Consul 1.11 when released.

I tried using hc-install library to fetch the latest version within minor releases, but it requires adding an internal dependency which would break builds for OSS users locally.