### PR TITLE
Add upstream assistant trigger as GH action

### DIFF
--- a/.github/workflows/upstream-trigger.yml
+++ b/.github/workflows/upstream-trigger.yml
@@ -1,0 +1,27 @@
+---
+  name: Upstream Assistant Trigger
+
+  on:
+    push:
+      branches:
+        - main
+        - 'release/**'
+
+  jobs:
+    trigger-oss-merge:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Trigger Upstream Assistant
+          run: |
+            GITHUB_BRANCH=${GITHUB_REF#refs/heads/}
+            STATUS_CODE=$(curl --write-out '%{http_code}' --silent --output /dev/null \
+              -XPOST https://api.github.com/repos/${{ github.repository }}-enterprise/dispatches \
+              -H "Authorization: token ${{ secrets.ELEVATED_GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Content-Type: application/json" \
+              --data '{"event_type": "trigger_oss_merge", "client_payload": {"repository": "${{ github.repository }}", "branch": "'$GITHUB_BRANCH'"}}'
+            )
+            echo "$STATUS_CODE"
+            if [ "$STATUS_CODE" != "204" ]; then
+              exit 1
+            fi


### PR DESCRIPTION
This GH Action triggers on all pushes to `main` and `release/**` branches. It dispatches a payload to another GHA on the enterprise repo which runs an auto-merge from OSS to the corresponding enterprise branch.

Example [success](https://github.com/hashicorp/consul-terraform-sync/runs/3794105574?check_suite_focus=true) and [failure](https://github.com/hashicorp/consul-terraform-sync/runs/3794130825?check_suite_focus=true) (missing auth token)