### PR TITLE
Fix Makefile dev version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ GOVERSION := 1.16
 PROJECT := $(shell go list -m)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
-GIT_DESCRIBE ?= $(shell git describe --tags --always)
+GIT_DESCRIBE ?= $(shell git describe --tags `git rev-list --tags --max-count=1`)
 GIT_DIRTY ?= $(shell git diff --stat)
-VERSION := $(shell awk -F\" '/Version/ { print $$2; exit }' "${CURRENT_DIR}/version/version.go")
+VERSION := $(shell awk -F\" '/Version =/ { print $2; exit }' "${CURRENT_DIR}/version/version.go")
 
 # Tags specific for building
 GOTAGS ?=


### PR DESCRIPTION
`git describe` fetches the latest tag based on the current branch.
The release process creates a tag off of release branches, which
are not associated with development branches like main or feature
branches. Running `make dev` would end up referencing an old tag
that predates the current release process.

The update to `GIT_DESCRIBE` now fetches the latest tag across all
branches.

Fixes `GIT_DESCRIBE` variable in Makefile
```
$ make dev
==> Installing consul-terraform-sync for darwin/amd64
$ consul-terraform-sync -version
consul-terraform-sync v0.1.0-345-g5ab7731 (4ca4743)
Compatible with Terraform >= 0.13.0, < 1.1.0
```

```
$ make dev
==> Installing consul-terraform-sync for darwin/amd64
$ consul-terraform-sync -version
consul-terraform-sync v0.4.0-beta1 (4ca4743 dirty)
Compatible with Terraform >= 0.13.0, < 1.1.0
```

Fixes `VERSION` variable in Makefile
```
$ awk -F\" '/Version/ { print $$2; exit }' "./version/version.go"
awk: illegal field $(), name "2"
 input record number 22, file ./version/version.go
 source line number 1
$ awk -F\" '/Version =/ { print $2; exit }' "./version/version.go"
0.4.0
```