### PR TITLE
Fix weekly ci

### DIFF
--- a/e2e/benchmarks/benchmarks_test.go
+++ b/e2e/benchmarks/benchmarks_test.go
@@ -1,0 +1,16 @@
+// +build e2e
+
+package benchmarks
+
+import (
+	"io/ioutil"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+func init() {
+	// Mutes CTS logging when run directly via CLI or controller
+	hclog.SetDefault(hclog.New(&hclog.LoggerOptions{
+		Output: ioutil.Discard,
+	}))
+}

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -83,7 +83,7 @@ func TestCompatibility_Consul(t *testing.T) {
 			execPath := downloadConsul(t, tempDir, cv)
 
 			// Output the Consul version
-			consulVersion, err := exec.Command(execPath, "-version").Output()
+			consulVersion, err := exec.Command(execPath, "version").Output()
 			require.NoError(t, err)
 			t.Logf("%s\n%s", t.Name(), consulVersion)
 


### PR DESCRIPTION
Consul versions 1.5, 1.6 and 1.7 do not support the `-version` flag,
whereas all tested versions support the `version` subcommand

CTS is run directly via CLI or controller for benchmarks. It
does not properly setup log level and the logging is verbose and
pollutes the benchmark outputs that are stored as artifacts