### PR TITLE
feat: Enforce GET requests only for /v1/status/tasks endpoint

### DIFF
--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -79,12 +79,14 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 	cases := []struct {
 		name       string
 		path       string
+		method     string
 		statusCode int
 		expected   map[string]TaskStatus
 	}{
 		{
 			"all task statuses",
 			"/v1/status/tasks",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
@@ -124,6 +126,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"all task statuses with events",
 			"/v1/status/tasks?include=events",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_a": TaskStatus{
@@ -167,6 +170,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"all task statuses filtered by status critical",
 			"/v1/status/tasks?status=critical",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_b": TaskStatus{
@@ -182,6 +186,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"all task statuses filtered by status unknown",
 			"/v1/status/tasks?status=unknown",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_d": TaskStatus{
@@ -197,6 +202,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"single task",
 			"/v1/status/tasks/task_b",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_b": TaskStatus{
@@ -212,6 +218,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"single task with events",
 			"/v1/status/tasks/task_b?include=events",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_b": TaskStatus{
@@ -228,6 +235,7 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"single task that has no event data",
 			"/v1/status/tasks/task_d",
+			http.MethodGet,
 			http.StatusOK,
 			map[string]TaskStatus{
 				"task_d": TaskStatus{
@@ -243,38 +251,50 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 		{
 			"non-existent task",
 			"/v1/status/tasks/task_nonexistent",
+			http.MethodGet,
 			http.StatusNotFound,
 			map[string]TaskStatus{},
 		},
 		{
 			"non-existent task with events",
 			"/v1/status/tasks/task_nonexistent?include=events",
+			http.MethodGet,
 			http.StatusNotFound,
 			map[string]TaskStatus{},
 		},
 		{
 			"bad include parameter",
 			"/v1/status/tasks?include=wrongparam",
+			http.MethodGet,
 			http.StatusBadRequest,
 			map[string]TaskStatus{},
 		},
 		{
 			"bad status parameter",
 			"/v1/status/tasks?status=invalidparam",
+			http.MethodGet,
 			http.StatusBadRequest,
 			map[string]TaskStatus{},
 		},
 		{
 			"bad url path",
 			"/v1/status/tasks/task_b/events",
+			http.MethodGet,
 			http.StatusBadRequest,
+			map[string]TaskStatus{},
+		},
+		{
+			"bad http method",
+			"/v1/status/tasks",
+			http.MethodPut,
+			http.StatusMethodNotAllowed,
 			map[string]TaskStatus{},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", tc.path, nil)
+			req, err := http.NewRequest(tc.method, tc.path, nil)
 			require.NoError(t, err)
 			resp := httptest.NewRecorder()
 


### PR DESCRIPTION
Hi!

I added a `switch case` for enforce GET request in the status of the tasks and added a test case for that. This is the case of the `switch case` to filter the GET method.

```go
// ServeHTTP serves the task status endpoint
func (h *taskStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
	logger := logging.FromContext(r.Context()).Named(taskStatusSubsystemName)
	logger.Trace("request task status", "url_path", r.URL.Path)

	switch r.Method {
	case http.MethodGet:
		h.getTaskStatus(w, r)
	default:
		err := fmt.Errorf("'%s' in an unsupported method. The task status API "+
			"currently supports the method(s): '%s'", r.Method, http.MethodGet)
		logger.Trace("unsupported method: %s", err)
		jsonErrorResponse(r.Context(), w, http.StatusMethodNotAllowed, err)
	}
}
```

Link to Issue: https://github.com/hashicorp/consul-terraform-sync/issues/360