### PR TITLE
Update CRT configuration to build on release branches

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,7 +9,12 @@ project "consul-terraform-sync" {
   github {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
-    release_branches = ["main"]
+    release_branches = [
+      "main",
+      "release/0.2.x",
+      "release/0.3.x",
+      "release/0.4.x"
+    ]
   }
 }
 


### PR DESCRIPTION
Regex support is not supported yet, so listing n-2 release branches.