### PR TITLE
Add build flags for CRT for detailed version output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           sha="$(git rev-parse --short HEAD)"
           echo "::set-output name=ldflags::"-s -w -X \'$project/version.Name=${{ env.PKG_NAME }}\' \
           -X \'$project/version.GitCommit=$sha\' \
-          -X \'$project/version.GitDescribe=${{ needs.get-product-version.outputs.product-version }}\'""
+          -X \'$project/version.GitDescribe=v${{ needs.get-product-version.outputs.product-version }}\'""
     
   build-386:
     needs: [get-product-version, set-ld-flags]


### PR DESCRIPTION
When variables in [`version/version.go`](https://github.com/hashicorp/consul-terraform-sync/blob/main/version/version.go#L9-L29) are unset, the compiled version is considered a dev prerelease, for example running go build w/o any linker flags:

```
$ go build
$ ./consul-terraform-sync -version
consul-terraform-sync v0.X.Y-dev
Compatible with Terraform >= 0.13.0, < 1.1.0
```

PR adds `ldflags` to the go build commands with values to the variables
* `version.Name=consul-terraform-sync`
* `version.GitCommit` to the [GHA environment variable `GITHUB_SHA`](https://docs.github.com/en/actions/learn-github-actions/environment-variables)
* `version.GitDescribe` to the release version. This differs than the [Makefile](https://github.com/hashicorp/consul-terraform-sync/blob/main/Makefile#L16) since the new tag has not been created yet to be fetched with `git`.

The desired output

```
consul-terraform-sync v0.X.Y (<commit_sha>)
Compatible with Terraform >= 0.13.0, < 1.1.0
```

## Context
For the 0.4.0 GA release with CRT, we had to temporarily remove the `-dev` prerelease logic (https://github.com/hashicorp/consul-terraform-sync/commit/7a0775fdd6e75aca8fb7fd890f8e20c5fa64ee0f). This wasn't an issue with 0.4.0-beta1 release because it contained the `beta1` prerelease information. The resulting compiled version for 0.4.0 GA is without the commit detail.

```
consul-terraform-sync 0.4.0
Compatible with Terraform >= 0.13.0, < 1.1.0
```

I was careful with the quotes and shell variable expansion, but it has not been tested/verified in the GH Action environment because I don't know how to test this w/o attempting a release. 🙃 