### PR TITLE
Add VersionMetadata field

### DIFF
--- a/build-scripts/version.sh
+++ b/build-scripts/version.sh
@@ -3,9 +3,18 @@
 version_file=$1
 version=$(awk '$1 == "Version" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "${version_file}")
 prerelease=$(awk '$1 == "VersionPrerelease" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "${version_file}")
+metadata=$(awk '$1 == "VersionMetadata" && $2 == "=" { gsub(/"/, "", $3); print $3 }' < "${version_file}")
 
 if [ -n "$prerelease" ]; then
-    echo "${version}-${prerelease}"
+    version="${version}-${prerelease}"
 else
-    echo "${version}"
+    version="${version}"
 fi
+
+if [ -n "$metadata" ]; then
+    version="${version}+${metadata}"
+else
+    version="${version}"
+fi
+
+echo "${version}"

--- a/version/version.go
+++ b/version/version.go
@@ -27,6 +27,8 @@ var (
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
 	VersionPrerelease = ""
+
+	VersionMetadata = ""
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable
@@ -43,6 +45,11 @@ func GetHumanVersion() string {
 	}
 	if release != "" {
 		version += fmt.Sprintf("-%s", release)
+	}
+
+	metadata := VersionMetadata
+	if metadata != "" {
+		version += fmt.Sprintf("+%s", metadata)
 	}
 
 	if GitCommit != "" && GitDirty != "" {


### PR DESCRIPTION
So that we can set this to `ent` in the ENT repo's version_ent.go file.

This allows us more easily to construct true semver version numbers when doing pre-releases (version-prerelease+metadata) both for the human readable version and also for our build artifact versioning.