### PR TITLE
Optimize ServicesRegex and CatalogServices to use hashicat blocking queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20211018135533-a5044b0c572e
+	github.com/hashicorp/hcat v0.0.0-20211025210343-28996dc70d6a
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20211018135533-a5044b0c572e h1:+1HWypMqJLEXr8MHauc9Pp86kLugl3qRZI0a/J0CzBc=
-github.com/hashicorp/hcat v0.0.0-20211018135533-a5044b0c572e/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20211025210343-28996dc70d6a h1:CegTD05VpWAub5F9O4MCYDcVVjQKgCNoWxX5jGfpRXk=
+github.com/hashicorp/hcat v0.0.0-20211025210343-28996dc70d6a/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/templates/tftmpl/monitor_consul_kv.go
+++ b/templates/tftmpl/monitor_consul_kv.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/logging"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 )

--- a/templates/tftmpl/tmplfunc/hcat.go
+++ b/templates/tftmpl/tmplfunc/hcat.go
@@ -6,7 +6,16 @@ package tmplfunc
 
 import (
 	"sort"
+
+	"github.com/hashicorp/hcat"
+	"github.com/hashicorp/hcat/dep"
 )
+
+type hcatQuery interface {
+	hcat.QueryOptionsSetter
+	dep.Dependency
+	Consul()
+}
 
 // isConsul satisfies the hcat dependency interface to denote Consul type for
 // managing the Consul retry function.


### PR DESCRIPTION
Relevant:
https://github.com/hashicorp/hcat/issues/71
https://github.com/hashicorp/hcat/pull/73

Tasks that use the conditions `services`+regex and `catalog-services` were not efficiently using blocking queries and would continuously query the Consul API for updates.

This PR pulls in hcat changes that now allow custom dependencies to utilize the built-in template support for blocking queries with the `QueryOptionsSetter` interface.