### PR TITLE
Revert "Fix consul compat test expecting critical service"

### DIFF
--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -37,15 +37,7 @@ func TestCompatibility_Consul(t *testing.T) {
 	// Tested only OSS GA releases for the highest patch version given a
 	// major minor version. v1.4.5 starts losing compatibility, details in
 	// comments. Theoretical compatible versions 0.1.0 GA:
-	consulVersions := []string{
-		"1.11.0-beta1",
-		"1.10.3",
-		"1.9.10",
-		"1.8.16",
-		"1.7.14",
-		"1.6.10",
-		"1.5.3",
-	}
+	consulVersions := []string{"1.10.3", "1.9.10", "1.8.16", "1.7.14", "1.6.10", "1.5.3"}
 
 	cases := []struct {
 		name              string
@@ -275,7 +267,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 	assert.Contains(t, content, "tag3")
 
 	// 2. change health status. when no health check, 'passing' by default.
-	// add a 'critical' health check. Critical services do not render by default.
+	// add a 'critical' health check
 	serviceInstance.Check = &capi.AgentServiceCheck{
 		CheckID:  "db1_check",
 		HTTP:     "fake_url",
@@ -284,7 +276,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 	}
 	registerService(t, serviceInstance, port)
 	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
-	assert.NotContains(t, content, "critical")
+	assert.Contains(t, content, "critical")
 }
 
 // testTagQueryCompatibility tests the compatibility of Consul's Health Service


### PR DESCRIPTION
Reverts hashicorp/consul-terraform-sync#455

Reverting this change since the fix for this is reverted for the 0.4.1 release. Will include for 0.5