### PR TITLE
Pull in hcat changes for kvExistsGet blocking queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20211026172945-afc76570e24d
+	github.com/hashicorp/hcat v0.0.0-20211027165433-7a391f33967d
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20211026172945-afc76570e24d h1:aKYXufwUBAMj20VUll78d5gp1G+HcSlQlQDMMgUa5xE=
-github.com/hashicorp/hcat v0.0.0-20211026172945-afc76570e24d/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.0.0-20211027165433-7a391f33967d h1:u6WNJKmAkzXe70OFzUYYf0yFheIRRTsNYzkPHgn1iac=
+github.com/hashicorp/hcat v0.0.0-20211027165433-7a391f33967d/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=


### PR DESCRIPTION
https://github.com/hashicorp/hcat/pull/75

Behavior remains the same (all current tests continue to pass), except it is more efficient with regards to the # of API requests to the Consul agent.