### PR TITLE
Method for validating files created by modules

### DIFF
--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -190,15 +190,13 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 				checkScheduledRun(t, taskName, registerTime, taskSchedule, port)
 
 				// confirm key-value resources created, and that the values are as expected
-				val := testutils.CheckFile(t, true, resourcesPath, "key-path.txt")
-				assert.Equal(t, expectedKV, val)
+				validateModuleFile(t, true, true, resourcesPath, "key-path", expectedKV)
 
 				if tc.isRecurse {
-					val = testutils.CheckFile(t, true, resourcesPath, "key-path/recursive.txt")
-					assert.Equal(t, expectedRecurseKV, val)
+					validateModuleFile(t, true, true, resourcesPath, "key-path/recursive", expectedRecurseKV)
 				} else {
 					// if recurse is disabled, then the recursive key should not be present
-					testutils.CheckFile(t, false, resourcesPath, "key-path/recursive.txt")
+					validateModuleFile(t, true, false, resourcesPath, "key-path/recursive", "")
 				}
 			}
 		})

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -130,3 +130,21 @@ func validateServices(t *testing.T, expected bool, services []string, servicesPa
 		testutils.CheckFile(t, expected, servicesPath, fmt.Sprintf("%s.txt", service))
 	}
 }
+
+// validateModuleFile checks whether a file dependent on a source input variable was created or not by the module.
+// If the file exists, then the content of the file is checked as well. If source_includes_var is set to false,
+// then no file is expected to be created so no checks will be made. Assumes the file has a .txt extension.
+//
+// e.g., checking that the module created a file for a Consul KV entry where the filename is the key and the
+// content is the value
+func validateModuleFile(t *testing.T, srcIncludesVar, expected bool, resourcesPath, name, expectedContent string) {
+	if !srcIncludesVar {
+		// module will not generate files based on the source input variables,
+		// nothing to validate
+		return
+	}
+	content := testutils.CheckFile(t, expected, resourcesPath, fmt.Sprintf("%s.txt", name))
+	if expected {
+		assert.Equal(t, expectedContent, content)
+	}
+}


### PR DESCRIPTION
Used to test modules that expect source_includes_var=true and
create files based on the source input variable. Does not check
anything if source_includes_var=false, so can be used in data-driven
tests.

Part of my effort to abstract local file checks! See https://github.com/hashicorp/consul-terraform-sync/pull/469 for more context. Only thing after this should be checking tfvars.