### PR TITLE
add ACL configuration

### DIFF
--- a/config/acl.go
+++ b/config/acl.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"fmt"
+)
+
+const (
+	// TODO: This will be changed to true in a later release
+	defaultACLIsEnabled = false
+)
+
+// ACLConfig is the configuration for an Access Control List (ACL).
+type ACLConfig struct {
+	// Boolean if ACLs are enabled or not. True if enabled, false otherwise.
+	Enabled *bool `mapstructure:"enabled"`
+
+	// The encrypted bootstrap token to be used by CTS. If this is configured then
+	// CTS will not need to be bootstrapped on restart
+	BootstrapToken *string `mapstructure:"bootstrap_token"`
+}
+
+// DefaultACLConfig returns the default configuration struct.
+func DefaultACLConfig() *ACLConfig {
+	return &ACLConfig{
+		Enabled: Bool(defaultACLIsEnabled),
+	}
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *ACLConfig) Copy() *ACLConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o ACLConfig
+	o.Enabled = BoolCopy(c.Enabled)
+	o.BootstrapToken = StringCopy(c.BootstrapToken)
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *ACLConfig) Merge(o *ACLConfig) *ACLConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.Enabled != nil {
+		r.Enabled = BoolCopy(o.Enabled)
+	}
+
+	if o.BootstrapToken != nil {
+		r.BootstrapToken = StringCopy(o.BootstrapToken)
+	}
+
+	return r
+}
+
+// Finalize ensures there no nil pointers.
+func (c *ACLConfig) Finalize() {
+	if c == nil {
+		return
+	}
+
+	if c.Enabled == nil {
+		c.Enabled = Bool(defaultACLIsEnabled)
+	}
+
+	if c.BootstrapToken == nil {
+		c.BootstrapToken = String("")
+	}
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *ACLConfig) Validate() error {
+	if c == nil {
+		return fmt.Errorf("missing acl configuration")
+	}
+
+	if c.Enabled == nil {
+		return fmt.Errorf("enabled must not be nil")
+	}
+
+	if c.BootstrapToken == nil {
+		return fmt.Errorf("bootstrap token must not be nil")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+// Sensitive information is redacted.
+func (c *ACLConfig) GoString() string {
+	if c == nil {
+		return "(*ACLConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&ACLConfig{"+
+		"Enabled:%t, "+
+		"BootstrapToken:%s, "+
+		"}",
+		BoolVal(c.Enabled),
+		StringVal(c.BootstrapToken),
+	)
+}

--- a/config/acl.go
+++ b/config/acl.go
@@ -14,9 +14,8 @@ type ACLConfig struct {
 	// Boolean if ACLs are enabled or not. True if enabled, false otherwise.
 	Enabled *bool `mapstructure:"enabled"`
 
-	// The encrypted bootstrap token to be used by CTS. If this is configured then
-	// CTS will not need to be bootstrapped on restart
-	BootstrapToken *string `mapstructure:"bootstrap_token"`
+	// The list of tokens supported for this CTS instance
+	Tokens *TokensConfig `mapstructure:"tokens"`
 }
 
 // DefaultACLConfig returns the default configuration struct.
@@ -34,7 +33,7 @@ func (c *ACLConfig) Copy() *ACLConfig {
 
 	var o ACLConfig
 	o.Enabled = BoolCopy(c.Enabled)
-	o.BootstrapToken = StringCopy(c.BootstrapToken)
+	o.Tokens = c.Tokens.Copy()
 
 	return &o
 }
@@ -61,8 +60,8 @@ func (c *ACLConfig) Merge(o *ACLConfig) *ACLConfig {
 		r.Enabled = BoolCopy(o.Enabled)
 	}
 
-	if o.BootstrapToken != nil {
-		r.BootstrapToken = StringCopy(o.BootstrapToken)
+	if o.Tokens != nil {
+		r.Tokens = o.Tokens.Copy()
 	}
 
 	return r
@@ -78,9 +77,10 @@ func (c *ACLConfig) Finalize() {
 		c.Enabled = Bool(defaultACLIsEnabled)
 	}
 
-	if c.BootstrapToken == nil {
-		c.BootstrapToken = String("")
+	if c.Tokens == nil {
+		c.Tokens = &TokensConfig{}
 	}
+	c.Tokens.Finalize()
 }
 
 // Validate validates the values and required options. This method is recommended
@@ -94,8 +94,8 @@ func (c *ACLConfig) Validate() error {
 		return fmt.Errorf("enabled must not be nil")
 	}
 
-	if c.BootstrapToken == nil {
-		return fmt.Errorf("bootstrap token must not be nil")
+	if c.Tokens == nil {
+		return fmt.Errorf("tokens must not be nil")
 	}
 
 	return nil
@@ -110,9 +110,9 @@ func (c *ACLConfig) GoString() string {
 
 	return fmt.Sprintf("&ACLConfig{"+
 		"Enabled:%t, "+
-		"BootstrapToken:%s, "+
+		"Tokens:%v, "+
 		"}",
 		BoolVal(c.Enabled),
-		StringVal(c.BootstrapToken),
+		c.Tokens.GoString(),
 	)
 }

--- a/config/acl_test.go
+++ b/config/acl_test.go
@@ -25,8 +25,10 @@ func TestACLConfig_Copy(t *testing.T) {
 		{
 			"copy",
 			&ACLConfig{
-				Enabled:        Bool(true),
-				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+				Enabled: Bool(true),
+				Tokens: &TokensConfig{
+					Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+				},
 			},
 		},
 	}
@@ -97,28 +99,28 @@ func TestACLConfig_Merge(t *testing.T) {
 			&ACLConfig{Enabled: Bool(true)},
 		},
 		{
-			"bootstrap_token_overrides",
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
-			&ACLConfig{BootstrapToken: String("")},
-			&ACLConfig{BootstrapToken: String("")},
+			"token_overrides",
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("")}},
 		},
 		{
-			"bootstrap_token_empty_one",
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			"token_empty_one",
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
 			&ACLConfig{},
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
 		},
 		{
-			"bootstrap_token_empty_two",
-			&ACLConfig{},
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			"token_empty_two",
+			&ACLConfig{Tokens: &TokensConfig{Root: String("")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
 		},
 		{
-			"bootstrap_token_same",
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
-			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			"token_same",
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
+			&ACLConfig{Tokens: &TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")}},
 		},
 	}
 
@@ -142,8 +144,8 @@ func TestACLConfig_Finalize(t *testing.T) {
 			"empty",
 			&ACLConfig{},
 			&ACLConfig{
-				Enabled:        Bool(defaultACLIsEnabled),
-				BootstrapToken: String(""),
+				Enabled: Bool(defaultACLIsEnabled),
+				Tokens:  &TokensConfig{Root: String("")},
 			},
 		},
 		{
@@ -152,18 +154,22 @@ func TestACLConfig_Finalize(t *testing.T) {
 				Enabled: Bool(true),
 			},
 			&ACLConfig{
-				Enabled:        Bool(true),
-				BootstrapToken: String(""),
+				Enabled: Bool(true),
+				Tokens:  &TokensConfig{Root: String("")},
 			},
 		},
 		{
-			"with_bootstrap_token",
+			"with_token",
 			&ACLConfig{
-				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+				Tokens: &TokensConfig{
+					Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+				},
 			},
 			&ACLConfig{
-				Enabled:        Bool(defaultACLIsEnabled),
-				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+				Enabled: Bool(defaultACLIsEnabled),
+				Tokens: &TokensConfig{
+					Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+				},
 			},
 		},
 	}
@@ -188,19 +194,23 @@ func TestACLConfig_Validate(t *testing.T) {
 			"happy_path",
 			false,
 			&ACLConfig{
-				Enabled:        Bool(defaultACLIsEnabled),
-				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+				Enabled: Bool(defaultACLIsEnabled),
+				Tokens: &TokensConfig{
+					Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+				},
 			},
 		},
 		{
 			"invalid_enabled",
 			true,
 			&ACLConfig{
-				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+				Tokens: &TokensConfig{
+					Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+				},
 			},
 		},
 		{
-			"invalid_bootstrap_token",
+			"invalid_token",
 			true,
 			&ACLConfig{
 				Enabled: Bool(defaultACLIsEnabled),

--- a/config/acl_test.go
+++ b/config/acl_test.go
@@ -1,0 +1,221 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestACLConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ACLConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&ACLConfig{},
+		},
+		{
+			"copy",
+			&ACLConfig{
+				Enabled:        Bool(true),
+				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
+func TestACLConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ACLConfig
+		b    *ACLConfig
+		r    *ACLConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&ACLConfig{},
+			&ACLConfig{},
+		},
+		{
+			"nil_b",
+			&ACLConfig{},
+			nil,
+			&ACLConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ACLConfig{},
+			&ACLConfig{},
+			&ACLConfig{},
+		},
+		{
+			"enabled_overrides",
+			&ACLConfig{Enabled: Bool(true)},
+			&ACLConfig{Enabled: Bool(false)},
+			&ACLConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_empty_one",
+			&ACLConfig{Enabled: Bool(true)},
+			&ACLConfig{},
+			&ACLConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_empty_two",
+			&ACLConfig{},
+			&ACLConfig{Enabled: Bool(true)},
+			&ACLConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_same",
+			&ACLConfig{Enabled: Bool(true)},
+			&ACLConfig{Enabled: Bool(true)},
+			&ACLConfig{Enabled: Bool(true)},
+		},
+		{
+			"bootstrap_token_overrides",
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{BootstrapToken: String("")},
+			&ACLConfig{BootstrapToken: String("")},
+		},
+		{
+			"bootstrap_token_empty_one",
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{},
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+		},
+		{
+			"bootstrap_token_empty_two",
+			&ACLConfig{},
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+		},
+		{
+			"bootstrap_token_same",
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+			&ACLConfig{BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestACLConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    *ACLConfig
+		r    *ACLConfig
+	}{
+		{
+			"empty",
+			&ACLConfig{},
+			&ACLConfig{
+				Enabled:        Bool(defaultACLIsEnabled),
+				BootstrapToken: String(""),
+			},
+		},
+		{
+			"with_enabled",
+			&ACLConfig{
+				Enabled: Bool(true),
+			},
+			&ACLConfig{
+				Enabled:        Bool(true),
+				BootstrapToken: String(""),
+			},
+		},
+		{
+			"with_bootstrap_token",
+			&ACLConfig{
+				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			},
+			&ACLConfig{
+				Enabled:        Bool(defaultACLIsEnabled),
+				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestACLConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *ACLConfig
+	}{
+		{
+			"happy_path",
+			false,
+			&ACLConfig{
+				Enabled:        Bool(defaultACLIsEnabled),
+				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			},
+		},
+		{
+			"invalid_enabled",
+			true,
+			&ACLConfig{
+				BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			},
+		},
+		{
+			"invalid_bootstrap_token",
+			true,
+			&ACLConfig{
+				Enabled: Bool(defaultACLIsEnabled),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,8 +27,10 @@ var (
 		Port:       Int(8502),
 		WorkingDir: String("working"),
 		ACL: &ACLConfig{
-			Enabled:        Bool(true),
-			BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+			Enabled: Bool(true),
+			Tokens: &TokensConfig{
+				Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+			},
 		},
 		Syslog: &SyslogConfig{
 			Enabled: Bool(true),
@@ -289,7 +291,8 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.ClientType = String("")
 	expected.Port = Int(8502)
 	expected.WorkingDir = String("working")
-	expected.ACL.BootstrapToken = String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")
+	expected.ACL.Tokens = &TokensConfig{}
+	expected.ACL.Tokens.Root = String("da666809-98ca-0e94-a99c-893c4bf5f9eb")
 	expected.Syslog.Facility = String("LOCAL0")
 	expected.BufferPeriod.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,10 @@ var (
 		LogLevel:   String("ERR"),
 		Port:       Int(8502),
 		WorkingDir: String("working"),
+		ACL: &ACLConfig{
+			Enabled:        Bool(true),
+			BootstrapToken: String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"),
+		},
 		Syslog: &SyslogConfig{
 			Enabled: Bool(true),
 			Name:    String("syslog"),
@@ -285,6 +289,7 @@ func TestConfig_Finalize(t *testing.T) {
 	expected.ClientType = String("")
 	expected.Port = Int(8502)
 	expected.WorkingDir = String("working")
+	expected.ACL.BootstrapToken = String("+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q")
 	expected.Syslog.Facility = String("LOCAL0")
 	expected.BufferPeriod.Enabled = Bool(true)
 	expected.Consul.KVNamespace = String("")

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -1,10 +1,17 @@
 log_level = "ERR"
+
 port = 8502
+
 working_dir = "working"
+
+acl {
+  enabled         = true
+  bootstrap_token = "+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"
+}
 
 syslog {
   enabled = true
-  name = "syslog"
+  name    = "syslog"
 }
 
 buffer_period {
@@ -14,77 +21,88 @@ buffer_period {
 
 consul {
   address = "consul-example.com"
+
   auth {
-    enabled = true
+    enabled  = true
     username = "username"
     password = "password"
   }
+
   kv_path = "kv_path"
+
   tls {
-    ca_cert = "ca_cert"
-    ca_path = "ca_path"
-    enabled = true
-    key = "key"
+    ca_cert     = "ca_cert"
+    ca_path     = "ca_path"
+    enabled     = true
+    key         = "key"
     server_name = "server_name"
-    verify = false
+    verify      = false
   }
+
   token = "token"
+
   transport {
-    dial_keep_alive = "5s"
-    dial_timeout = "10s"
-    disable_keep_alives = false
-    idle_conn_timeout = "1m"
+    dial_keep_alive         = "5s"
+    dial_timeout            = "10s"
+    disable_keep_alives     = false
+    idle_conn_timeout       = "1m"
     max_idle_conns_per_host = 100
-    tls_handshake_timeout = "10s"
+    tls_handshake_timeout   = "10s"
   }
 }
 
 driver "terraform" {
-  log = true
+  log  = true
   path = "path"
+
   backend "consul" {
     address = "consul-example.com"
-    path = "kv-path/terraform"
-    gzip = true
+    path    = "kv-path/terraform"
+    gzip    = true
   }
+
   required_providers {
     pName1 = "v0.0.0"
+
     pName2 = {
-      version = "v0.0.1",
-      source = "namespace/pName2"
+      version = "v0.0.1"
+      source  = "namespace/pName2"
     }
   }
 }
 
 service {
-  name = "serviceA"
+  name        = "serviceA"
   description = "descriptionA"
 }
 
 service {
-  name = "serviceB"
-  namespace = "teamB"
+  name        = "serviceB"
+  namespace   = "teamB"
   description = "descriptionB"
 }
 
 terraform_provider "X" {}
 
 task {
-  name = "task"
+  name        = "task"
   description = "automate services for X to do Y"
-  services = ["serviceA", "serviceB", "serviceC"]
-  providers = ["X"]
-  source = "Y"
+  services    = ["serviceA", "serviceB", "serviceC"]
+  providers   = ["X"]
+  source      = "Y"
+
   condition "catalog-services" {
-    regexp = ".*"
+    regexp              = ".*"
     source_includes_var = true
-    namespace = "ns2"
-    datacenter = "dc2"
+    namespace           = "ns2"
+    datacenter          = "dc2"
+
     node_meta {
       "key1" = "value1"
       "key2" = "value2"
     }
   }
+
   source_input "services" {
     regexp = ""
   }

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -5,8 +5,11 @@ port = 8502
 working_dir = "working"
 
 acl {
-  enabled         = true
-  bootstrap_token = "+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"
+  enabled = true
+
+  tokens = {
+    root = "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+  }
 }
 
 syslog {

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -10,6 +10,10 @@
     "min": "20s",
     "max": "60s"
   },
+  "acl": {
+    "enabled": true,
+    "bootstrap_token": "+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"
+  },
   "consul": {
     "address": "consul-example.com",
     "auth": {

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -12,7 +12,9 @@
   },
   "acl": {
     "enabled": true,
-    "bootstrap_token": "+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"
+    "tokens": {
+      "root": "da666809-98ca-0e94-a99c-893c4bf5f9eb"
+    }
   },
   "consul": {
     "address": "consul-example.com",

--- a/config/tokens.go
+++ b/config/tokens.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"fmt"
+)
+
+// TokensConfig is the configuration for the CTS tokens.
+type TokensConfig struct {
+
+	// Master allows operators to bootstrap the ACL system with a token Secret ID that is well-known.
+	Root *string `mapstructure:"root"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *TokensConfig) Copy() *TokensConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o TokensConfig
+	o.Root = StringCopy(c.Root)
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *TokensConfig) Merge(o *TokensConfig) *TokensConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.Root != nil {
+		r.Root = StringCopy(o.Root)
+	}
+
+	return r
+}
+
+// Finalize ensures there no nil pointers.
+func (c *TokensConfig) Finalize() {
+	if c == nil {
+		return
+	}
+
+	if c.Root == nil {
+		c.Root = String("")
+	}
+}
+
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *TokensConfig) Validate() error {
+	if c == nil {
+		return fmt.Errorf("missing acl configuration")
+	}
+
+	if c.Root == nil {
+		return fmt.Errorf("root token must not be nil")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+// Sensitive information is redacted.
+func (c *TokensConfig) GoString() string {
+	if c == nil {
+		return "(*TokensConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&TokensConfig{"+
+		"Root:%s, "+
+		"}",
+		StringVal(c.Root),
+	)
+}

--- a/config/tokens_test.go
+++ b/config/tokens_test.go
@@ -1,0 +1,172 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokensConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *TokensConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&TokensConfig{},
+		},
+		{
+			"copy",
+			&TokensConfig{
+				Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
+func TestTokensConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *TokensConfig
+		b    *TokensConfig
+		r    *TokensConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&TokensConfig{},
+			&TokensConfig{},
+		},
+		{
+			"nil_b",
+			&TokensConfig{},
+			nil,
+			&TokensConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&TokensConfig{},
+			&TokensConfig{},
+			&TokensConfig{},
+		},
+		{
+			"root_token_overrides",
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+			&TokensConfig{Root: String("")},
+			&TokensConfig{Root: String("")},
+		},
+		{
+			"root_token_empty_one",
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+			&TokensConfig{},
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+		},
+		{
+			"root_token_empty_two",
+			&TokensConfig{},
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+		},
+		{
+			"root_token_same",
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+			&TokensConfig{Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb")},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestTokensConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    *TokensConfig
+		r    *TokensConfig
+	}{
+		{
+			"empty",
+			&TokensConfig{},
+			&TokensConfig{Root: String("")},
+		},
+		{
+			"with_root_token",
+			&TokensConfig{
+				Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+			},
+			&TokensConfig{
+				Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestTokensConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *TokensConfig
+	}{
+		{
+			"happy_path",
+			false,
+			&TokensConfig{
+				Root: String("da666809-98ca-0e94-a99c-893c4bf5f9eb"),
+			},
+		},
+		{
+			"invalid_root_token",
+			true,
+			&TokensConfig{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
To configure CTS to support ACL tokens I've added a new ACL block. This first version of this block contains two fields:

```hcl
acl {
  enabled         = true
  bootstrap_token = "+aHuWFH0bNzERaJpwdAPteD5EYzEQSWWNUxFsiVWt4ADIbHDU95ytJoYfHd/M22Q"
}
```

```Go
// ACLConfig is the configuration for an Access Control List (ACL).
type ACLConfig struct {
	// Boolean if ACLs are enabled or not. True if enabled, false otherwise.
	Enabled *bool `mapstructure:"enabled"`

	// The encrypted bootstrap token to be used by CTS. If this is configured then
	// CTS will not need to be bootstrapped on restart
	BootstrapToken *string `mapstructure:"bootstrap_token"`
}
```

The intent for the BootstrapToken is that if this field is present and non-empty, this token will be used on restart, requiring no further bootstrapping. Enabled by default is currently set to `false` this will change in the future to `true` once this is officially supported by CTS.

EDIT***

Remodelled the block to be closer to consul, bootstrap_token is now called `master` and the block looks like this instead:

```hcl
acl {
  enabled = true

  tokens = {
    master = "da666809-98ca-0e94-a99c-893c4bf5f9eb"
  }
}
```

```Go
// ACLConfig is the configuration for an Access Control List (ACL).
type ACLConfig struct {
	// Boolean if ACLs are enabled or not. True if enabled, false otherwise.
	Enabled *bool `mapstructure:"enabled"`

	// The list of tokens supported for this CTS instance
	Tokens *TokensConfig `mapstructure:"tokens"`
}
```
