### PR TITLE
Set CGO_ENABLED=0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
 env:
   PKG_NAME: "consul-terraform-sync"
   GO_TAGS: ""
+  CGO_ENABLED: 0
 
 jobs:
   get-product-version:


### PR DESCRIPTION
Fixes build for docker images flagged in #474. This doesn't fix the 0.4.0 docker images yet though.