### PR TITLE
Not all diagnostics include context

### DIFF
--- a/client/terraform_cli.go
+++ b/client/terraform_cli.go
@@ -224,7 +224,12 @@ func (t *TerraformCLI) Validate(ctx context.Context) error {
 		default:
 			fmt.Fprintf(&sb, "%s: %s\n", d.Severity, d.Summary)
 			if d.Range != nil && d.Snippet != nil {
-				fmt.Fprintf(&sb, "\non %s line %d, in %s\n", d.Range.Filename, d.Range.Start.Line, *d.Snippet.Context)
+				if d.Snippet.Context != nil {
+					fmt.Fprintf(&sb, "\non %s line %d, in %s\n",
+						d.Range.Filename, d.Range.Start.Line, *d.Snippet.Context)
+				} else {
+					fmt.Fprintf(&sb, "\non %s line %d\n", d.Range.Filename, d.Range.Start.Line)
+				}
 				fmt.Fprintf(&sb, "%d:%s\n\n", d.Snippet.StartLine, d.Snippet.Code)
 			}
 			sb.WriteString(d.Detail)


### PR DESCRIPTION
Resolves #473

The `Snippet` object for this edge case revealed that not all diags include a context.
```
&{Context:<nil> Code:provider "null" {} StartLine:1 HighlightStartOffset:0 HighlightEndOffset:15 Values:[]}
```

```
2021-11-01T12:20:53.814-0500 [WARN]  client.terraformcli: Terraform validate returned warnings:
  warnings=
  | 
  | warning: Empty provider configuration blocks are not required
  | 
  | on .terraform/modules/tf_validate_panic/main.tf line 1
  | 1:provider "null" {}
  | 
  | Remove the null provider block from module.tf_validate_panic.
  | To ensure the correct provider configuration is used, add null to the required_providers configuration
  
2021-11-01T12:20:53.814-0500 [INFO]  ctrl: driver initialized
2021-11-01T12:20:53.814-0500 [INFO]  ctrl: executing all tasks once through
```