### PR TITLE
Add git to new Dockerfile for Terraform to fetch modules from GitHub

### DIFF
--- a/.release/docker/Dockerfile
+++ b/.release/docker/Dockerfile
@@ -12,7 +12,7 @@ LABEL version=$VERSION
 ENV NAME=$NAME
 ENV VERSION=$VERSION
 
-RUN apk add --no-cache dumb-init
+RUN apk add --no-cache dumb-init git
 
 # Create a non-root user to run the software.
 RUN addgroup ${NAME} && adduser -S -G ${NAME} ${NAME}


### PR DESCRIPTION
https://github.com/hashicorp/consul-terraform-sync/blob/main/docker/Dockerfile#L31

```
2021-11-03T19:27:01.716Z [ERROR] driver.terraform: error initializing worksapce for task: task_name=test-docker
2021-11-03T19:27:01.716Z [ERROR] ctrl: error initializing task: task_name=test-docker
2021-11-03T19:27:01.716Z [ERROR] cli: error initializing controller:
  error=
  | error tf-init for 'test-docker': exit status 1
  | 
  | Error: Failed to download module
  | 
  | Could not download module "test-docker" (main.tf:21) source code from
  | "git::https://github.com/mkam/terraform-cts-hello?ref=v0.1.0": error
  | downloading 'https://github.com/mkam/terraform-cts-hello?ref=v0.1.0': git
  | must be available and on the PATH.
  | 
  | 
  | Error: Failed to download module
  | 
  | Could not download module "test-docker" (main.tf:21) source code from
  | "git::https://github.com/mkam/terraform-cts-hello?ref=v0.1.0": error
  | downloading 'https://github.com/mkam/terraform-cts-hello?ref=v0.1.0': git
  | must be available and on the PATH.
```