### PR TITLE
Add tls cli client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1,15 +1,39 @@
 package api
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/go-rootcerts"
 )
 
 //go:generate mockery --name=httpClient  --structname=HttpClient --output=../mocks/api
+
+const (
+	httpScheme  = "http"
+	httpsScheme = "https"
+
+	DefaultAddress   = "http://localhost:8558"
+	DefaultSSLVerify = true
+
+	// Environment Variables
+	EnvAddress = "CTS_ADDRESS" // The address of the CTS daemon, supports http or https by specifying as part of the address (e.g. https://localhost:8558)
+
+	// TLS Environment Variables
+	EnvTLSCACert     = "CTS_CACERT"      // Path to a directory of CA certificates to use for TLS when communicating with Consul-Terraform-Sync
+	EnvTLSCAPath     = "CTS_CAPATH"      // Path to a CA file to use for TLS when communicating with Consul-Terraform-Sync
+	EnvTLSClientCert = "CTS_CLIENT_CERT" // Path to a client cert file to use for TLS when verify_incoming is enabled
+	EnvTLSClientKey  = "CTS_CLIENT_KEY"  // Path to a client key file to use for TLS when verify_incoming is enabled
+	EnvTLSSSLVerify  = "CTS_SSL_VERIFY"  // Boolean to verify SSL or not. Set to true to verify SSL. Default is true
+)
 
 // httpClient describes the interface for the client to make http calls
 type httpClient interface {
@@ -18,7 +42,8 @@ type httpClient interface {
 
 // Client to make api requests
 type Client struct {
-	port    int
+	port    int // remain for backwards compatibility but prefer addr
+	addr    string
 	version string
 	scheme  string
 	http    httpClient
@@ -26,20 +51,125 @@ type Client struct {
 
 // ClientConfig configures the client to make api requests
 type ClientConfig struct {
-	Port int
+	Port   int // Stay for now for backwards compatibility, but prefer Addr
+	Addr   string
+	Scheme string
+
+	TLSConfig TLSConfig
+}
+
+type TLSConfig struct {
+	// TLS variables
+	CAPath     string
+	CACert     string
+	ClientCert string
+	ClientKey  string
+	SSLVerify  bool
+}
+
+type addressComposite struct {
+	scheme  string
+	address string
+}
+
+// DefaultClientConfig returns a default configuration for the client
+func DefaultClientConfig() *ClientConfig {
+	c := &ClientConfig{
+		Port: config.DefaultPort,
+		Addr: DefaultAddress,
+		TLSConfig: TLSConfig{
+			SSLVerify: true,
+		},
+	}
+
+	// Read env vars
+	if v := os.Getenv(EnvAddress); v != "" {
+		c.Addr = v
+	}
+
+	// Read TLS env vars
+	if v := os.Getenv(EnvTLSCACert); v != "" {
+		c.TLSConfig.CACert = v
+	}
+	if v := os.Getenv(EnvTLSCAPath); v != "" {
+		c.TLSConfig.CAPath = v
+	}
+	if v := os.Getenv(EnvTLSClientCert); v != "" {
+		c.TLSConfig.ClientCert = v
+	}
+
+	if v := os.Getenv(EnvTLSClientKey); v != "" {
+		c.TLSConfig.ClientKey = v
+	}
+
+	if v := os.Getenv(EnvTLSSSLVerify); v != "" {
+		if verify, err := strconv.ParseBool(v); err == nil {
+			c.TLSConfig.SSLVerify = verify
+		}
+	}
+
+	return c
 }
 
 // NewClient returns a client to make api requests
-func NewClient(c *ClientConfig, httpClient httpClient) *Client {
+func NewClient(c *ClientConfig, httpClient httpClient) (*Client, error) {
 	if httpClient == nil {
-		httpClient = &http.Client{}
+		tlsConfig, err := setupTLSConfig(c)
+		if err != nil {
+			return nil, err
+		}
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		}
 	}
+
+	// Determine the scheme and address without scheme based on the address passed in
+	ac, err := parseAddress(c.Addr)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Client{
 		port:    c.Port,
+		addr:    ac.address,
 		version: defaultAPIVersion,
-		scheme:  "http",
+		scheme:  ac.scheme,
 		http:    httpClient,
+	}, nil
+}
+
+// setupTLSConfig is used to generate a TLSClientConfig that's useful for talking to
+// Consul using TLS.
+func setupTLSConfig(c *ClientConfig) (*tls.Config, error) {
+	tlsClientConfig := &tls.Config{
+		// If verify is false, then we set skip verify to true
+		// InsecureSkipVerify will always be the opposite of SSLVerify
+		InsecureSkipVerify: !c.TLSConfig.SSLVerify,
 	}
+
+	if c.TLSConfig.ClientCert != "" && c.TLSConfig.ClientKey != "" {
+		tlsCert, err := tls.LoadX509KeyPair(c.TLSConfig.ClientCert, c.TLSConfig.ClientKey)
+		if err != nil {
+			return nil, err
+		}
+		tlsClientConfig.Certificates = []tls.Certificate{tlsCert}
+	} else if c.TLSConfig.ClientCert != "" || c.TLSConfig.ClientKey != "" {
+		return nil, fmt.Errorf("both client cert and client key must be provided")
+	}
+
+	if c.TLSConfig.CACert != "" || c.TLSConfig.CAPath != "" {
+		rootConfig := &rootcerts.Config{
+			CAFile: c.TLSConfig.CACert,
+			CAPath: c.TLSConfig.CAPath,
+		}
+		if err := rootcerts.ConfigureTLS(tlsClientConfig, rootConfig); err != nil {
+			return nil, err
+		}
+	}
+
+	return tlsClientConfig, nil
 }
 
 func (c *Client) Port() int {
@@ -87,15 +217,29 @@ func (c *Client) WaitForAPI(timeout time.Duration) error {
 // path: relative path with no preceding '/' e.g. "status/tasks"
 // query: URL encoded query string with no preceding '?'. See QueryParam.Encode()
 func (c *Client) request(method, path, query, body string) (*http.Response, error) {
-	url := url.URL{
-		Scheme:   "http",
-		Host:     fmt.Sprintf("localhost:%d", c.port),
-		Path:     fmt.Sprintf("%s/%s", c.version, path),
-		RawQuery: query,
+	var serverURL url.URL
+
+	// If port is default, use the address variable instead
+	if c.port == config.DefaultPort {
+		serverURL = url.URL{
+			Scheme:   c.scheme,
+			Host:     c.addr,
+			Path:     fmt.Sprintf("%s/%s", c.version, path),
+			RawQuery: query,
+		}
+	} else {
+		// If port is set, assume using old arguments and append port to localhost
+		// assume http scheme
+		serverURL = url.URL{
+			Scheme:   c.scheme,
+			Host:     fmt.Sprintf("localhost:%d", c.port),
+			Path:     fmt.Sprintf("%s/%s", c.version, path),
+			RawQuery: query,
+		}
 	}
 
 	r := strings.NewReader(body)
-	req, err := http.NewRequest(method, url.String(), r)
+	req, err := http.NewRequest(method, serverURL.String(), r)
 	if err != nil {
 		return nil, err
 	}
@@ -243,4 +387,23 @@ func (t *Task) Update(name string, config UpdateTaskConfig, q *QueryParam) (Upda
 	}
 
 	return plan, nil
+}
+
+func parseAddress(addr string) (addressComposite, error) {
+	ac := addressComposite{}
+	ac.scheme = httpScheme
+	parts := strings.SplitN(addr, "://", 2)
+	if len(parts) == 2 {
+		switch parts[0] {
+		case httpScheme:
+			ac.scheme = httpScheme
+		case httpsScheme:
+			ac.scheme = httpsScheme
+		default:
+			return addressComposite{}, fmt.Errorf("unknown protocol scheme: %s", parts[0])
+		}
+		ac.address = parts[1]
+	}
+
+	return ac, nil
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultClientConfig_WithOSEnvSet(t *testing.T) {
+	url := "https://1.2.3.4:5678"
+	caCert := "test/path/ca.pem"
+	caPath := "test/path"
+	clientCert := "test/path/client.pem"
+	clientKey := "test/path/key.pem"
+	sslVerify := "false"
+
+	err := os.Setenv(EnvAddress, url)
+	require.NoError(t, err)
+	defer os.Setenv(EnvAddress, "")
+
+	err = os.Setenv(EnvTLSCACert, caCert)
+	require.NoError(t, err)
+	defer os.Setenv(EnvTLSCACert, "")
+
+	err = os.Setenv(EnvTLSCAPath, caPath)
+	require.NoError(t, err)
+	defer os.Setenv(EnvTLSCAPath, "")
+
+	err = os.Setenv(EnvTLSClientCert, clientCert)
+	require.NoError(t, err)
+	defer os.Setenv(EnvTLSClientCert, "")
+
+	err = os.Setenv(EnvTLSClientKey, clientKey)
+	require.NoError(t, err)
+	defer os.Setenv(EnvTLSClientKey, "")
+
+	os.Setenv(EnvTLSSSLVerify, sslVerify)
+	require.NoError(t, err)
+	defer os.Setenv(EnvTLSSSLVerify, "")
+
+	config := DefaultClientConfig()
+
+	assert.Equal(t, url, config.Addr)
+	assert.Equal(t, caCert, config.TLSConfig.CACert)
+	assert.Equal(t, caPath, config.TLSConfig.CAPath)
+	assert.Equal(t, clientCert, config.TLSConfig.ClientCert)
+	assert.Equal(t, clientKey, config.TLSConfig.ClientKey)
+
+	expectedSSLVerify, err := strconv.ParseBool(sslVerify)
+	require.NoError(t, err)
+	assert.Equal(t, expectedSSLVerify, config.TLSConfig.SSLVerify)
+}
+
+func TestDefaultClientConfig_OnlyDefaults(t *testing.T) {
+	caCert := ""
+	caPath := ""
+	clientCert := ""
+	clientKey := ""
+
+	config := DefaultClientConfig()
+
+	assert.Equal(t, DefaultAddress, config.Addr)
+	assert.Equal(t, caCert, config.TLSConfig.CACert)
+	assert.Equal(t, caPath, config.TLSConfig.CAPath)
+	assert.Equal(t, clientCert, config.TLSConfig.ClientCert)
+	assert.Equal(t, clientKey, config.TLSConfig.ClientKey)
+	assert.Equal(t, DefaultSSLVerify, config.TLSConfig.SSLVerify)
+}

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -115,9 +115,12 @@ func TestStatus(t *testing.T) {
 
 	// setup drivers
 	drivers := driver.NewDrivers()
-	drivers.Add("task_a", createDriver(t, "task_a", true))
-	drivers.Add("task_b", createDriver(t, "task_b", true))
-	drivers.Add("task_c", createDriver(t, "task_c", true))
+	err := drivers.Add("task_a", createDriver(t, "task_a", true))
+	require.NoError(t, err)
+	err = drivers.Add("task_b", createDriver(t, "task_b", true))
+	require.NoError(t, err)
+	err = drivers.Add("task_c", createDriver(t, "task_c", true))
+	require.NoError(t, err)
 
 	// start up server
 	port := testutils.FreePort(t)
@@ -168,7 +171,7 @@ func TestStatus(t *testing.T) {
 				nil,
 				false,
 				map[string]TaskStatus{
-					"task_a": TaskStatus{
+					"task_a": {
 						TaskName:  "task_a",
 						Enabled:   true,
 						Status:    StatusSuccessful,
@@ -176,7 +179,7 @@ func TestStatus(t *testing.T) {
 						Services:  []string{},
 						EventsURL: "/v1/status/tasks/task_a?include=events",
 					},
-					"task_b": TaskStatus{
+					"task_b": {
 						TaskName:  "task_b",
 						Enabled:   true,
 						Status:    StatusCritical,
@@ -184,7 +187,7 @@ func TestStatus(t *testing.T) {
 						Services:  []string{},
 						EventsURL: "/v1/status/tasks/task_b?include=events",
 					},
-					"task_c": TaskStatus{
+					"task_c": {
 						TaskName:  "task_c",
 						Enabled:   true,
 						Status:    StatusCritical,
@@ -200,7 +203,7 @@ func TestStatus(t *testing.T) {
 				nil,
 				false,
 				map[string]TaskStatus{
-					"task_a": TaskStatus{
+					"task_a": {
 						TaskName:  "task_a",
 						Enabled:   true,
 						Status:    StatusSuccessful,
@@ -216,7 +219,7 @@ func TestStatus(t *testing.T) {
 				&QueryParam{IncludeEvents: true},
 				false,
 				map[string]TaskStatus{
-					"task_b": TaskStatus{
+					"task_b": {
 						TaskName:  "task_b",
 						Status:    StatusCritical,
 						Enabled:   true,
@@ -233,7 +236,7 @@ func TestStatus(t *testing.T) {
 				&QueryParam{Status: StatusCritical},
 				false,
 				map[string]TaskStatus{
-					"task_b": TaskStatus{
+					"task_b": {
 						TaskName:  "task_b",
 						Enabled:   true,
 						Status:    StatusCritical,
@@ -241,7 +244,7 @@ func TestStatus(t *testing.T) {
 						Services:  []string{},
 						EventsURL: "/v1/status/tasks/task_b?include=events",
 					},
-					"task_c": TaskStatus{
+					"task_c": {
 						TaskName:  "task_c",
 						Enabled:   true,
 						Status:    StatusCritical,
@@ -296,8 +299,8 @@ func Test_Task_Update(t *testing.T) {
 	t.Run("disable-then-enable", func(t *testing.T) {
 		// setup temp dir
 		tempDir := "disable-enable"
-		delete := testutils.MakeTempDir(t, tempDir)
-		defer delete()
+		del := testutils.MakeTempDir(t, tempDir)
+		defer del()
 
 		task, err := driver.NewTask(driver.TaskConfig{Enabled: true, WorkingDir: tempDir})
 		require.NoError(t, err)
@@ -308,7 +311,8 @@ func Test_Task_Update(t *testing.T) {
 			ClientType: "test",
 		})
 		require.NoError(t, err)
-		drivers.Add("task_a", d)
+		err = drivers.Add("task_a", d)
+		require.NoError(t, err)
 
 		assert.True(t, d.Task().IsEnabled())
 		plan, err := c.Task().Update("task_a", UpdateTaskConfig{
@@ -334,7 +338,8 @@ func Test_Task_Update(t *testing.T) {
 		d := new(mocksD.Driver)
 		d.On("UpdateTask", mock.Anything, mock.Anything).
 			Return(expectedPlan, nil).Once()
-		drivers.Add("task_b", d)
+		err = drivers.Add("task_b", d)
+		require.NoError(t, err)
 
 		actual, err := c.Task().Update("task_b", UpdateTaskConfig{
 			Enabled: config.Bool(false),

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -84,7 +84,8 @@ func TestRequest(t *testing.T) {
 			}
 			hc.On("Do", mock.Anything).Return(mockResp, tc.httpError).Once()
 
-			c := NewClient(&ClientConfig{Port: 8558}, hc)
+			c, err := NewClient(&ClientConfig{Port: 8558}, hc)
+			require.NoError(t, err)
 			resp, err := c.request("GET", "v1/some/endpoint", "test=true", "body")
 			if tc.expectError {
 				assert.Error(t, err)
@@ -129,8 +130,9 @@ func TestStatus(t *testing.T) {
 	})
 	go api.Serve(ctx)
 
-	c := NewClient(&ClientConfig{Port: port}, nil)
-	err := c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
+	c, err := NewClient(&ClientConfig{Port: port}, nil)
+	require.NoError(t, err)
+	err = c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
 	require.NoError(t, err)
 
 	t.Run("overall-status", func(t *testing.T) {
@@ -286,8 +288,9 @@ func Test_Task_Update(t *testing.T) {
 	})
 	go api.Serve(ctx)
 
-	c := NewClient(&ClientConfig{Port: port}, nil)
-	err := c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
+	c, err := NewClient(&ClientConfig{Port: port}, nil)
+	require.NoError(t, err)
+	err = c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
 	require.NoError(t, err)
 
 	t.Run("disable-then-enable", func(t *testing.T) {
@@ -346,8 +349,9 @@ func TestWaitForAPI(t *testing.T) {
 	t.Parallel()
 
 	t.Run("timeout", func(t *testing.T) {
-		cts := NewClient(&ClientConfig{Port: 0}, nil)
-		err := cts.WaitForAPI(time.Second)
+		cts, err := NewClient(&ClientConfig{Port: 0}, nil)
+		require.NoError(t, err)
+		err = cts.WaitForAPI(time.Second)
 		assert.Error(t, err, "No CTS API server running, test is expected to timeout")
 	})
 
@@ -361,8 +365,9 @@ func TestWaitForAPI(t *testing.T) {
 		})
 		go api.Serve(ctx)
 
-		cts := NewClient(&ClientConfig{Port: port}, nil)
-		err := cts.WaitForAPI(3 * time.Second)
+		cts, err := NewClient(&ClientConfig{Port: port}, nil)
+		require.NoError(t, err)
+		err = cts.WaitForAPI(3 * time.Second)
 		assert.NoError(t, err, "CTS API server should be available")
 	})
 }

--- a/api/test.go
+++ b/api/test.go
@@ -54,7 +54,8 @@ func StartCTS(t *testing.T, configPath string, opts ...string) (*Client, func(t 
 	err = cmd.Start()
 	require.NoError(t, err)
 
-	ctsClient := NewClient(&ClientConfig{Port: port}, nil)
+	ctsClient, err := NewClient(&ClientConfig{Port: port}, nil)
+	require.NoError(t, err)
 
 	return ctsClient, func(t *testing.T) {
 		defer func() {

--- a/command/cli.go
+++ b/command/cli.go
@@ -98,8 +98,8 @@ func (cli *CLI) Run(args []string) int {
 
 	// Development only flags. Not printed with -h, -help
 	f.StringVar(&clientType, "client-type", "", "Use only when developing"+
-		"consul-terraform-sync binary. Defaults to Terraform client if empty or"+
-		"unknown value. Values can also be 'development' or 'test'.")
+		" consul-terraform-sync binary. Defaults to Terraform client if empty or"+
+		" unknown value. Values can also be 'development' or 'test'.")
 
 	err := f.Parse(args[1:])
 	if err != nil {

--- a/command/meta.go
+++ b/command/meta.go
@@ -17,18 +17,62 @@ const width = uint(78)
 
 // meta contains the meta-options and functionality for all CTS commands
 type meta struct {
-	UI cli.Ui
+	UI    cli.Ui
+	flags *flag.FlagSet
 
 	helpOptions []string
 	port        *int
+	addr        *string
+
+	tls tls
 }
 
-func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
-	flags := flag.NewFlagSet(name, flag.ContinueOnError)
-	m.port = flags.Int("port", config.DefaultPort, "The port to use for the Consul Terraform Sync API server")
-	flags.SetOutput(ioutil.Discard)
+type tls struct {
+	caPath     *string
+	caCert     *string
+	clientCert *string
+	clientKey  *string
+	sslVerify  *bool
+}
 
-	flags.VisitAll(func(f *flag.Flag) {
+const (
+	// Command line flag names
+	flagPort     = "port"
+	flagHTTPAddr = "http-addr"
+
+	flagCAPath     = "ca-path"
+	flagCaFile     = "ca-cert"
+	flagClientCert = "client-cert"
+	flagClientKey  = "client-key"
+	flagSSLVerify  = "ssl-verify"
+)
+
+func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
+	m.flags = flag.NewFlagSet(name, flag.ContinueOnError)
+
+	// Values provide both default values, and documentation for the default value when -help is used
+	m.port = m.flags.Int(flagPort, config.DefaultPort,
+		fmt.Sprintf("The port to use for the Consul Terraform Sync API server, it is preferred to use the %s field instead", flagHTTPAddr))
+	m.addr = m.flags.String(flagHTTPAddr, api.DefaultAddress, fmt.Sprintf("The `address` and port of the CTS daemon. The value can be an IP "+
+		"address or DNS address, but it must also include the port. This can "+
+		"also be specified via the %s environment variable. The "+
+		"default value is %s. The scheme can also be set to "+
+		"HTTPS by including https in the provided address (eg. https://127.0.0.1:8558)", api.EnvAddress, api.DefaultAddress))
+
+	// Initialize TLS flags
+	m.tls.caPath = m.flags.String(flagCAPath, "", fmt.Sprintf("Path to a directory of CA certificates to use for TLS when communicating with Consul-Terraform-Sync. "+
+		"This can also be specified using the %s environment variable.", api.EnvTLSCAPath))
+	m.tls.caCert = m.flags.String(flagCaFile, "", fmt.Sprintf("Path to a CA file to use for TLS when communicating with Consul-Terraform-Sync. "+
+		"This can also be specified using the %s environment variable.", api.EnvTLSCACert))
+	m.tls.clientCert = m.flags.String(flagClientCert, "", fmt.Sprintf("Path to a client cert file to use for TLS when verify_incoming is enabled. "+
+		"This can also be specified using the %s environment variable.", api.EnvTLSClientCert))
+	m.tls.clientKey = m.flags.String(flagClientKey, "", fmt.Sprintf("Path to a client key file to use for TLS when verify_incoming is enabled. "+
+		"This can also be specified using the %s environment variable.", api.EnvTLSClientKey))
+	m.tls.sslVerify = m.flags.Bool(flagSSLVerify, true, fmt.Sprintf("Boolean to verify SSL or not. Set to true to verify SSL. "+
+		"This can also be specified using the %s environment variable.", api.EnvTLSSSLVerify))
+
+	m.flags.SetOutput(ioutil.Discard)
+	m.flags.VisitAll(func(f *flag.Flag) {
 		option := fmt.Sprintf("  %s %s\n    %s\n", f.Name, f.Value, f.Usage)
 		m.helpOptions = append(m.helpOptions, option)
 	})
@@ -36,7 +80,7 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 		m.helpOptions = append(m.helpOptions, "No options are currently available")
 	}
 
-	return flags
+	return m.flags
 }
 
 func (m *meta) setFlagsUsage(flags *flag.FlagSet, args []string, help string) {
@@ -71,10 +115,45 @@ func (m *meta) oneArgCheck(name string, args []string) bool {
 	return false
 }
 
-func (m *meta) client() *api.Client {
-	return api.NewClient(&api.ClientConfig{
-		Port: *m.port,
-	}, nil)
+// clientConfig is used to initialize and return a new API ClientConfig using
+// the default command line arguments and env vars.
+func (m *meta) clientConfig() *api.ClientConfig {
+	// Let the Client determine its default first, then override with command flag values
+	c := api.DefaultClientConfig()
+	if m.isFlagParsedAndFound(flagPort) {
+		c.Port = *m.port
+	}
+	if m.addr != nil && *m.addr != "" {
+		c.Addr = *m.addr
+	}
+
+	// If we need custom TLS configuration, then set it
+	if m.tls.caCert != nil && *m.tls.caCert != "" {
+		c.TLSConfig.CACert = *m.tls.caCert
+	}
+	if m.tls.caPath != nil && *m.tls.caPath != "" {
+		c.TLSConfig.CAPath = *m.tls.caPath
+	}
+	if m.tls.clientCert != nil && *m.tls.clientCert != "" {
+		c.TLSConfig.ClientCert = *m.tls.clientCert
+	}
+	if m.tls.clientKey != nil && *m.tls.clientKey != "" {
+		c.TLSConfig.ClientKey = *m.tls.clientKey
+	}
+	if m.isFlagParsedAndFound(flagSSLVerify) {
+		c.TLSConfig.SSLVerify = *m.tls.sslVerify
+	}
+
+	return c
+}
+
+func (m *meta) client() (*api.Client, error) {
+	c, err := api.NewClient(m.clientConfig(), nil)
+
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 // requestUserApproval returns an exit code and boolean describing if the user
@@ -86,7 +165,7 @@ func (m *meta) requestUserApproval(taskName string) (int, bool) {
 	m.UI.Output(" - Consul Terraform Sync cannot guarantee Terraform will perform")
 	m.UI.Output("   these exact actions if monitored services have changed.\n")
 	m.UI.Output("Only 'yes' will be accepted to approve.\n")
-	v, err := m.UI.Ask(fmt.Sprintf("Enter a value:"))
+	v, err := m.UI.Ask("Enter a value:")
 	m.UI.Output("")
 
 	if err != nil {
@@ -99,4 +178,16 @@ func (m *meta) requestUserApproval(taskName string) (int, bool) {
 	}
 
 	return 0, true
+}
+
+// Returns true if the flags have been parsed
+// and the flag has been found in the list of provided flags, false otherwise
+func (m meta) isFlagParsedAndFound(name string) bool {
+	found := false
+	m.flags.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -76,8 +76,16 @@ func (c *taskDisableCommand) Run(args []string) int {
 	c.UI.Info(fmt.Sprintf("Waiting to disable '%s'...", taskName))
 	c.UI.Output("")
 
-	client := c.meta.client()
-	_, err := client.Task().Update(taskName, api.UpdateTaskConfig{
+	client, err := c.meta.client()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to create client for '%s'", taskName))
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	_, err = client.Task().Update(taskName, api.UpdateTaskConfig{
 		Enabled: config.Bool(false),
 	}, nil)
 	if err != nil {

--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -91,7 +91,15 @@ func (c *taskEnableCommand) Run(args []string) int {
 		taskName))
 	c.UI.Output("Generating plan that Consul Terraform Sync will use Terraform to execute\n")
 
-	client := c.meta.client()
+	client, err := c.meta.client()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to create client for '%s'", taskName))
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
 	resp, err := client.Task().Update(taskName, api.UpdateTaskConfig{
 		Enabled: config.Bool(true),
 	}, &api.QueryParam{Run: driver.RunOptionInspect})

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hashicorp/go-hclog v0.16.2
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0


### PR DESCRIPTION
Adds TLS flags to support TLS when using the CTS CLI

- TLS flags are passed via command line flags, or by environment variable
- command line flag values take precedence over corresponding environment variable values
- meta.go is responsible for handling flags set
- client.go handles environment variables and defaults required for creating the client

Example using flags:
```
consul-terraform-sync task enable \
    -http-addr="https://localhost:8501" \
    -ca-file="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/consul-agent-ca.pem" \
    -client-cert="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/dc1-server-consul-0.pem" \
    -client-key="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/dc1-server-consul-0-key.pem" \ 
    example-task
```

Example using some environment variables (same effect)
```
export CTS_CACERT="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/consul-agent-ca.pem" 
export CTS_CLIENT_CERT="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/dc1-server-consul-0.pem"
export CTS_CLIENT_KEY="/Users/mwilkerson/dev/michael-cts-example/tls_consul.d/dc1-server-consul-0-key.pem"

consul-terraform-sync task enable -http-addr="https://localhost:8501" example-task
```

*Note* the client won't work until the CTS server handles TLS, as of right now this hasn't been completed