### PR TITLE
Add e2e mtls tests

### DIFF
--- a/e2e/config.go
+++ b/e2e/config.go
@@ -6,6 +6,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -75,6 +76,11 @@ tls {
 	if config.caCert != "" {
 		s = fmt.Sprintf(s+`
   ca_cert = "%s"`, config.clientCert)
+	}
+
+	if config.verifyIncoming != nil {
+		s = fmt.Sprintf(s+`
+  verify_incoming = %s`, strconv.FormatBool(*config.verifyIncoming))
 	}
 
 	s = s + `

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -49,15 +49,26 @@ const (
 )
 
 type tlsConfig struct {
-	clientCert string
-	clientKey  string
-	caCert     string
+	clientCert     string
+	clientKey      string
+	caCert         string
+	verifyIncoming *bool
 }
 
 func defaultTLSConfig() tlsConfig {
 	return tlsConfig{
 		clientCert: defaultCTSClientCert,
 		clientKey:  defaultCTSClientKey,
+	}
+}
+
+func defaultMTLSConfig() tlsConfig {
+	verifyIncoming := true
+	return tlsConfig{
+		clientCert:     defaultCTSClientCert,
+		clientKey:      defaultCTSClientKey,
+		caCert:         defaultCTSCACert,
+		verifyIncoming: &verifyIncoming,
 	}
 }
 
@@ -132,7 +143,12 @@ func ctsSetupTLS(t *testing.T, srv *testutil.TestServer, tempDir string, taskCon
 	configPath := filepath.Join(tempDir, configFile)
 	config.write(t, configPath)
 
-	cts, stop := api.StartCTSSecure(t, configPath)
+	cts, stop := api.StartCTSSecure(t, configPath, api.TLSConfig{
+		CACert:     tlsConfig.caCert,
+		ClientCert: tlsConfig.clientCert,
+		ClientKey:  tlsConfig.clientKey,
+		SSLVerify:  false,
+	})
 	t.Cleanup(func() {
 		stop(t)
 	})


### PR DESCRIPTION
Added e2e testing for commands using mutual TLS (mTLS)

- TLS/mTLS flags are passed via command line flags, or by environment variable
- command line flag values take precedence over corresponding environment variable values

Example CTS Configuration:
```
tls {
  enabled = true
  cert = "/path/to/certs/localhost_cert.pem"
  key = "/path/to/certs/localhost_key.pem" 
  verify_incoming = true
  ca_cert = "/path/to/certs/localhost_cert.pem"
}
```

Example CTS mTLS client using flags:
```
consul-terraform-sync task enable \
    -http-addr="https://localhost:8501" \
    -ca-cert="/path/to/certs/localhost_cert.pem" \
    -client-cert="/path/to/certs/localhost_cert.pem" \
    -client-key="/path/to/certs/localhost_key.pem"  \ 
    example-task
```

Same example, this time using some environment variables
```
export CTS_CACERT="/path/to/certs/localhost_cert.pem"
export CTS_CLIENT_CERT="/path/to/certs/localhost_cert.pem"
export CTS_CLIENT_KEY="/path/to/certs/localhost_key.pem"
export CTS_ADDRESS="https://localhost:8501"

consul-terraform-sync task enable example-task
```

Part of #466