### PR TITLE
Log warning if both ca_cert and ca_path are configured

### DIFF
--- a/config/tls_cts_test.go
+++ b/config/tls_cts_test.go
@@ -335,15 +335,12 @@ func TestCTSTLSConfig_Validate(t *testing.T) {
 			&CTSTLSConfig{},
 		},
 		{
-			"valid_fully_configured",
+			"valid_tls",
 			true,
 			&CTSTLSConfig{
-				Enabled:        Bool(true),
-				Cert:           String("../testutils/certs/consul_cert.pem"),
-				CACert:         String("ca_cert.pem"),
-				CAPath:         String("ca_path"),
-				Key:            String("../testutils/certs/consul_key.pem"),
-				VerifyIncoming: Bool(true),
+				Enabled: Bool(true),
+				Cert:    String("../testutils/certs/localhost_cert.pem"),
+				Key:     String("../testutils/certs/localhost_key.pem"),
 			},
 		},
 		{
@@ -364,8 +361,48 @@ func TestCTSTLSConfig_Validate(t *testing.T) {
 			"key_and_cert_swapped",
 			false,
 			&CTSTLSConfig{
-				Cert: String("../testutils/certs/consul_key.pem"),
-				Key:  String("../testutils/certs/consul_cert.pem"),
+				Cert: String("../testutils/certs/localhost_key.pem"),
+				Key:  String("../testutils/certs/localhost_cert.pem"),
+			},
+		},
+		{
+			"verify_incoming_ca_cert",
+			true,
+			&CTSTLSConfig{
+				Cert:           String("../testutils/certs/localhost_cert.pem"),
+				Key:            String("../testutils/certs/localhost_key.pem"),
+				VerifyIncoming: Bool(true),
+				CACert:         String("ca_cert.pem"),
+			},
+		},
+		{
+			"verify_incoming_ca_path",
+			true,
+			&CTSTLSConfig{
+				Cert:           String("../testutils/certs/localhost_cert.pem"),
+				Key:            String("../testutils/certs/localhost_key.pem"),
+				VerifyIncoming: Bool(true),
+				CAPath:         String("ca"),
+			},
+		},
+		{
+			"verify_incoming_both_ca",
+			true, // logs a warning, but is valid
+			&CTSTLSConfig{
+				Cert:           String("../testutils/certs/localhost_cert.pem"),
+				Key:            String("../testutils/certs/localhost_key.pem"),
+				VerifyIncoming: Bool(true),
+				CACert:         String("ca_cert.pem"),
+				CAPath:         String("ca"),
+			},
+		},
+		{
+			"verify_incoming_no_ca",
+			false,
+			&CTSTLSConfig{
+				Cert:           String("../testutils/certs/localhost_cert.pem"),
+				Key:            String("../testutils/certs/localhost_key.pem"),
+				VerifyIncoming: Bool(true),
 			},
 		},
 	}


### PR DESCRIPTION
The go-rootcerts library has ca_cert take precedence over ca_path, so
calling out this behavior in a warning. Also fixes the mTLS check to look
for either ca_path or ca_cert, which was the original intent.


The diff isn't great to look at, but I moved one TLS check up further, modified the mTLS check to care about the CA options and not cert/key, and added the check that warns if both CA options are configured.

Warning will look like the following:
```
$ consul-terraform-sync --config-file=config.hcl
2021-11-10T11:57:44.155-0600 [WARN]  config: ca_cert and ca_path are both configured, but only ca_cert will be used
2021-11-10T11:57:44.156-0600 [INFO]  cli: v0.4.1 (5ff7739)
2021-11-10T11:57:44.156-0600 [INFO]  cli: running controller in daemon mode
```