### PR TITLE
Update Makefile dev build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GOVERSION := 1.16
 PROJECT := $(shell go list -m)
 NAME := $(notdir $(PROJECT))
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
-GIT_DESCRIBE ?= $(shell git describe --tags `git rev-list --tags --max-count=1`)
+GIT_DESCRIBE ?=
 GIT_DIRTY ?= $(shell git diff --stat)
 VERSION := $(shell awk -F\" '/Version =/ { print $2; exit }' "${CURRENT_DIR}/version/version.go")
 


### PR DESCRIPTION
GitDescribe is no longer useful in the dev build because of how
the version prerelease and metadata are generated in conjunction
with different remotes. It pulls the latest tag across remotes even
though it's not relevant

```
% git remote -v
<remote>	git@github.com:hashicorp/<remote>.git (fetch)
<remote>	git@github.com:hashicorp/<remote>.git (push)
origin		git@github.com:hashicorp/consul-terraform-sync.git (fetch)
origin		git@github.com:hashicorp/consul-terraform-sync.git (push)
% git describe --tags `git rev-list --tags --max-count=1`
v0.4.1+ent
% consul-terraform-sync -version
consul-terraform-sync v0.4.1+ent (3e5a7ed)
```

With changes
```
% consul-terraform-sync -version
consul-terraform-sync 0.5.0-dev (3e5a7ed dirty)
Compatible with Terraform >= 0.13.0, < 1.1.0
```