### PR TITLE
Added wrapper message around EOF error returned by CTS client when co…

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -18,8 +18,8 @@ import (
 //go:generate mockery --name=httpClient  --structname=HttpClient --output=../mocks/api
 
 const (
-	httpScheme  = "http"
-	httpsScheme = "https"
+	HTTPScheme  = "http"
+	HTTPSScheme = "https"
 
 	DefaultAddress   = "http://localhost:8558"
 	DefaultSSLVerify = true
@@ -172,12 +172,19 @@ func setupTLSConfig(c *ClientConfig) (*tls.Config, error) {
 	return tlsClientConfig, nil
 }
 
+// Port returns the port being used by the client
 func (c *Client) Port() int {
 	return c.port
 }
 
+// FullAddress returns the client address including the scheme. eg. http://localhost:8558
 func (c *Client) FullAddress() string {
 	return fmt.Sprintf("%s://%s", c.scheme, c.addr)
+}
+
+// Scheme returns the scheme being used by the client
+func (c *Client) Scheme() string {
+	return fmt.Sprintf(c.scheme)
 }
 
 // WaitForAPI polls the /v1/status endpoint to check when the CTS API is
@@ -395,14 +402,14 @@ func (t *Task) Update(name string, config UpdateTaskConfig, q *QueryParam) (Upda
 
 func parseAddress(addr string) (addressComposite, error) {
 	ac := addressComposite{}
-	ac.scheme = httpScheme
+	ac.scheme = HTTPScheme
 	parts := strings.SplitN(addr, "://", 2)
 	if len(parts) == 2 {
 		switch parts[0] {
-		case httpScheme:
-			ac.scheme = httpScheme
-		case httpsScheme:
-			ac.scheme = httpsScheme
+		case HTTPScheme:
+			ac.scheme = HTTPScheme
+		case HTTPSScheme:
+			ac.scheme = HTTPSScheme
 		default:
 			return addressComposite{}, fmt.Errorf("unknown protocol scheme: %s", parts[0])
 		}

--- a/api/test.go
+++ b/api/test.go
@@ -24,14 +24,14 @@ const (
 // running once-mode, the function will block until complete so no need to use
 // stop function
 func StartCTS(t *testing.T, configPath string, opts ...string) (*Client, func(t *testing.T)) {
-	return configureCTS(t, httpScheme, configPath, TLSConfig{}, opts...)
+	return configureCTS(t, HTTPScheme, configPath, TLSConfig{}, opts...)
 }
 
 // StartCTSSecure starts the CTS from binary using the https scheme for connections and returns a function to stop CTS. If
 // running once-mode, the function will block until complete so no need to use
 // stop function
 func StartCTSSecure(t *testing.T, configPath string, tlsConfig TLSConfig, opts ...string) (*Client, func(t *testing.T)) {
-	return configureCTS(t, httpsScheme, configPath, tlsConfig, opts...)
+	return configureCTS(t, HTTPSScheme, configPath, tlsConfig, opts...)
 }
 
 func configureCTS(t *testing.T, scheme string, configPath string, tlsConfig TLSConfig, opts ...string) (*Client, func(t *testing.T)) {

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -90,6 +90,7 @@ func (c *taskDisableCommand) Run(args []string) int {
 	}, nil)
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error: unable to disable '%s'", taskName))
+		err = processEOFError(client.Scheme(), err)
 
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
@@ -100,4 +101,14 @@ func (c *taskDisableCommand) Run(args []string) int {
 	c.UI.Info(fmt.Sprintf("'%s' disable complete!", taskName))
 
 	return ExitCodeOK
+}
+
+func processEOFError(scheme string, err error) error {
+	if strings.Contains(err.Error(), "EOF") && scheme == api.HTTPScheme {
+		err = fmt.Errorf("%s. Scheme %s was used, "+
+			"this error can be caused by a client using http to connect to a CTS server with TLS enabled, "+
+			"consider using %s scheme instead", err, scheme, api.HTTPSScheme)
+	}
+
+	return err
 }

--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -105,6 +105,8 @@ func (c *taskEnableCommand) Run(args []string) int {
 	}, &api.QueryParam{Run: driver.RunOptionInspect})
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error: unable to generate plan for '%s'", taskName))
+		err = processEOFError(client.Scheme(), err)
+
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
 

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -135,7 +135,7 @@ func TestE2E_CommandTLSErrors(t *testing.T) {
 				dbTaskName,
 			},
 			[]string{},
-			"EOF",
+			"consider using https scheme",
 		},
 		{
 			"connect using wrong scheme override right scheme from environment",
@@ -148,7 +148,7 @@ func TestE2E_CommandTLSErrors(t *testing.T) {
 			[]string{
 				fmt.Sprintf("%s-%s", api.EnvAddress, address),
 			},
-			"EOF",
+			"consider using https scheme",
 		},
 		{
 			"connect with invalid cert",


### PR DESCRIPTION
#### Background
The purpose of this PR is to have more meaningful TLS errors returned from our CTS CLI when connecting using an http scheme with a CTS instance using https.

From research:

- **GET/PUT** receives a nice response from the CTS server: `Client sent an HTTP request to an HTTPS server.`
- **PATCH/DELETE/POST** however get a nil response and an EOF error.
- These errors do not happen when connecting using an https client to an http server. In that case we get the nice `Client sent an HTTPS request to an HTTP server.`

Investigating how Consul handles things, it looks like they have similar behaviour. It also looks like they just return the EOF response as is. For example:
```
consul kv put -http-addr="http://localhost:8501" key-value "blue"
Error! Failed writing data: Unexpected response code: 400 (Client sent an HTTP request to an HTTPS server.)

consul kv delete -http-addr="http://localhost:8501" "blue"
Error deleting key blue: Delete "http://localhost:8501/v1/kv/blue": EOF
```

#### Solution
EOF seems to be a common error returned in this scenario, and there isn't much we can do about what is returned from the server. What we can improve however is the information the CLI provides. Therefore, I've added a check that `if strings.Contains(err.Error(), "EOF") && scheme == api.HttpScheme` then a more detailed message will be returned from the CLI:

```
==> Error: unable to disable 'example-task'
    Patch "http://localhost:8558/v1/tasks/example-task": EOF. Scheme http was
used, this error can be caused by using http to connect to an https CTS
instance, consider using https scheme instead
```