### PR TITLE
Fix issue with response header when no task exists

### DIFF
--- a/api/task_status.go
+++ b/api/task_status.go
@@ -114,6 +114,7 @@ func (h *taskStatusHandler) getTaskStatus(w http.ResponseWriter, r *http.Request
 				err := fmt.Errorf("task '%s' does not exist", taskName)
 				logger.Trace("error getting task", "error", err)
 				jsonErrorResponse(r.Context(), w, http.StatusNotFound, err)
+				return
 			}
 		}
 	}


### PR DESCRIPTION
Because we weren't returning after an error was set, the response
code was attempted to be set again later, which caused "superfluous
response.WriteHeader call" errors to be logged. It also caused an
additional '{}' to be appended at the end of the response.

Previous Response:
```
$ curl -v localhost:8558/v1/status/tasks/nonexistent-task
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8558 (#0)
> GET /v1/status/tasks/nonexistent-task HTTP/1.1
> Host: localhost:8558
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Content-Type: application/json
< Date: Fri, 12 Nov 2021 21:30:16 GMT
< Content-Length: 66
<
{"error":{"message":"task 'nonexistent-task' does not exist"}}
{}
```
```
2021-11-12T15:30:16.461-0600 [INFO]  api: received request: reqID=4b022ea7-ca9c-35c9-d685-f7b5714e6e33 time=2021-11-12T15:30:16.461-0600 remote_ip=[::1]:51856 uri=/v1/status/tasks/nonexistent-task method=GET host=localhost:8558
2021/11/12 15:30:16 http: superfluous response.WriteHeader call from github.com/hashicorp/consul-terraform-sync/api.jsonResponse (api.go:189)
2021-11-12T15:30:16.462-0600 [INFO]  api: request complete: reqID=4b022ea7-ca9c-35c9-d685-f7b5714e6e33 duration=434us
```
With Fix:
```
$ curl -v localhost:8558/v1/status/tasks/nonexistent-task
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8558 (#0)
> GET /v1/status/tasks/nonexistent-task HTTP/1.1
> Host: localhost:8558
> User-Agent: curl/7.64.1
> Accept: */*
>
< HTTP/1.1 404 Not Found
< Content-Type: application/json
< Date: Fri, 12 Nov 2021 21:28:57 GMT
< Content-Length: 63
<
{"error":{"message":"task 'nonexistent-task' does not exist"}}
```