### PR TITLE
Added new tests for CA path

### DIFF
--- a/e2e/config.go
+++ b/e2e/config.go
@@ -75,7 +75,12 @@ tls {
 
 	if config.caCert != "" {
 		s = fmt.Sprintf(s+`
-  ca_cert = "%s"`, config.clientCert)
+  ca_cert = "%s"`, config.caCert)
+	}
+
+	if config.caPath != "" {
+		s = fmt.Sprintf(s+`
+  ca_path = "%s"`, config.caPath)
 	}
 
 	if config.verifyIncoming != nil {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -6,6 +6,7 @@ package testutils
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -48,6 +49,66 @@ func MakeTempDir(t testing.TB, tempDir string) func() error {
 	return func() error {
 		return os.RemoveAll(tempDir)
 	}
+}
+
+// FindFileMatches walks a root directory and returns a list of all files that match
+// a particular pattern string.
+// eg. If you want to find all files that end with .txt, pattern=*.txt
+func FindFileMatches(t testing.TB, rootDir, pattern string) []string {
+	var matches []string
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, err)
+		if info.IsDir() {
+			return nil
+		}
+		if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {
+			require.NoError(t, err)
+		} else if matched {
+			matches = append(matches, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return matches
+}
+
+// CopyFiles copies a list of files to a destination (dst) directory
+func CopyFiles(t testing.TB, srcFiles []string, dst string) {
+	for _, src := range srcFiles {
+		file := filepath.Base(src)
+		dst := filepath.Join(dst, file)
+		CopyFile(t, src, dst)
+	}
+}
+
+// CopyFile copies a file from src to dst.
+func CopyFile(t testing.TB, src, dst string) {
+	sourceFI, err := os.Stat(src)
+	require.NoError(t, err)
+	if !sourceFI.Mode().IsRegular() {
+		// cannot copy non-regular files (e.g., directories,
+		// symlinks, devices, etc.)
+		err = fmt.Errorf("non-regular source file %s (%q)", sourceFI.Name(), sourceFI.Mode().String())
+		require.NoError(t, err)
+	}
+
+	destFI, err := os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+	} else {
+		if !(destFI.Mode().IsRegular()) {
+			err = fmt.Errorf("non-regular destination file %s (%q)", destFI.Name(), destFI.Mode().String())
+			require.NoError(t, err)
+		}
+		if os.SameFile(sourceFI, destFI) {
+			return
+		}
+	}
+
+	err = copyFileContents(src, dst)
+	require.NoError(t, err)
 }
 
 // CheckDir checks whether or not a directory exists. If it exists, returns the
@@ -158,4 +219,28 @@ func (t *TestingTB) Cleanup(f func()) {
 			prev()
 		}
 	}
+}
+
+// copyFileContents copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+func copyFileContents(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	err = out.Sync()
+	return err
 }


### PR DESCRIPTION
- Added test cases for both TLS and MTLS using CAPath instead of CACert. CAPath allows for a directory of certs to be passed to server and client instead of just a single file. Then the server and/or client is able to authenticate using the correct cert.
- Modified test cases so that they don't use self-signed certificates (CA and Cert being the same file). Instead using a CA, `localhost_cert.pem` and a cert signed by the CA, `localhost_leaf_cert.pem` which would be a more realistic scenario.
- Added testutil functions for copying test files to test directories. This was needed since CAPath requires that only certs (no keys, readmes, etc.) be in the provided directory.

Example CTS Configuration:
```
tls {
  enabled = true
  cert = "/path/to/certs/localhost_cert.pem"
  key = "/path/to/certs/localhost_key.pem" 
  verify_incoming = true
  ca_path = "/path/to/certs"
}
```

Example CTS mTLS client using flags:
```
consul-terraform-sync task enable \
    -http-addr="https://localhost:8501" \
    -ca-path="/path/to/certs" \
    -client-cert="/path/to/certs/localhost_cert.pem" \
    -client-key="/path/to/certs/localhost_key.pem"  \ 
    example-task
```

Same example, this time using some environment variables
```
export CTS_CAPATH="/path/to/certs"
export CTS_CLIENT_CERT="/path/to/certs/localhost_cert.pem"
export CTS_CLIENT_KEY="/path/to/certs/localhost_key.pem"
export CTS_ADDRESS="https://localhost:8501"

consul-terraform-sync task enable example-task
```

Part of #466 