### PR TITLE
Add config error for driver.terraform-cloud when using CTS OSS

### DIFF
--- a/config/decode.go
+++ b/config/decode.go
@@ -20,12 +20,20 @@ func processUnusedConfigKeys(md mapstructure.Metadata, file string) error {
 	err := fmt.Errorf("'%s' has invalid keys: %s", file, strings.Join(md.Unused, ", "))
 
 	for _, key := range md.Unused {
-		if key == "provider" {
-			err = fmt.Errorf(`%s
-	'provider' is an invalid key for Consul Terraform Sync configuration, try 'terraform_provider'.
-	terraform_provider configuration blocks are similar to provider blocks in Terraform but have additional features supported only by Consul Terraform Sync.
+		switch key {
+		case "provider":
+			return fmt.Errorf(`%s
 
-`, err)
+'provider' is an invalid key for Consul-Terraform-Sync (CTS) configuration,
+try 'terraform_provider'. The terraform_provider configuration blocks are
+similar to provider blocks in Terraform but have additional features
+supported only by CTS.`, err)
+
+		case "driver.terraform-cloud":
+			return fmt.Errorf(`%s
+
+Terraform Cloud is a Consul-Terraform-Sync (CTS) Enterprise feature.
+Upgrade to Consul Enterprise to enable CTS Enterprise features.`, err)
 		}
 	}
 	return err

--- a/config/task.go
+++ b/config/task.go
@@ -309,7 +309,7 @@ func (c *TaskConfig) Validate() error {
 
 	if c.TFVersion != nil && *c.TFVersion != "" {
 		return fmt.Errorf("unsupported configuration 'terraform_version' for "+
-			"task %q. This option is available for Consul-Terraform-Sync enterprise "+
+			"task %q. This option is available for Consul-Terraform-Sync Enterprise "+
 			"when using the Terraform Cloud driver, or configure the Terraform client "+
 			"version within the Terraform driver block", *c.Name)
 	}


### PR DESCRIPTION
Update error line length to fit <80 chars

```
2021-11-17T11:17:55.413-0600 [ERROR] cli: error building configuration:
  error=
  | 'config.hcl' has invalid keys: driver.terraform-cloud
  | 
  | Terraform Cloud is a Consul-Terraform-Sync (CTS) Enterprise feature.
  | Upgrade to Consul Enterprise to enable CTS Enterprise features.
```