### PR TITLE
Update backport assistant for 0.4.2 custom release

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,3 +20,10 @@
             BACKPORT_LABEL_REGEXP: "backport/(?P<target>\\d+\\.\\d+)"
             BACKPORT_TARGET_TEMPLATE: "release/{{.target}}.x"
             GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+        - name: Run Backport Assistant (custom for 0.4.2)
+          run: |
+            backport-assistant backport -automerge
+          env:
+            BACKPORT_LABEL_REGEXP: "backport/0.4.2"
+            BACKPORT_TARGET_TEMPLATE: "release/0.4.2"
+            GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
The current backporting assistant supports a label like `backport/0.4` to backport to a branch like `release/0.4.x`.

For 0.4.2 release we deviated from our typical release process and are planning to release from a branch like `release/0.4.2`. If want an associated label like `backport/0.4.2`, this requires different backporting logic.

Solution in PR is the most readable (and easy to delete) solution I could think of that didn't change our existing release process. Welcome other solutions. Opening a PR was the easiest way to share context on this problem.