### PR TITLE
Update Services Condition & Source Input configuration

### DIFF
--- a/config/condition.go
+++ b/config/condition.go
@@ -22,7 +22,11 @@ type ConditionConfig interface {
 func DefaultConditionConfig() ConditionConfig {
 	return &ServicesConditionConfig{
 		ServicesMonitorConfig{
-			Regexp: String(""),
+			Regexp:             String(""),
+			Datacenter:         String(""),
+			Namespace:          String(""),
+			Filter:             String(""),
+			CTSUserDefinedMeta: map[string]string{},
 		},
 	}
 }

--- a/config/condition_services_test.go
+++ b/config/condition_services_test.go
@@ -22,10 +22,16 @@ func TestServicesConditionConfig_Copy(t *testing.T) {
 			&ServicesConditionConfig{},
 		},
 		{
-			"fully_configured",
+			"happy_path",
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
-					Regexp: String("^web.*"),
+					Regexp:     String("^web.*"),
+					Datacenter: String("dc"),
+					Namespace:  String("namespace"),
+					Filter:     String("filter"),
+					CTSUserDefinedMeta: map[string]string{
+						"key": "value",
+					},
 				},
 			},
 		},
@@ -78,28 +84,34 @@ func TestServicesConditionConfig_Merge(t *testing.T) {
 			&ServicesConditionConfig{},
 		},
 		{
-			"regexp_overrides",
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("different")}},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("different")}},
-		},
-		{
-			"regexp_empty_one",
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-			&ServicesConditionConfig{},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-		},
-		{
-			"regexp_empty_two",
-			&ServicesConditionConfig{},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-		},
-		{
-			"regexp_empty_same",
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
-			&ServicesConditionConfig{ServicesMonitorConfig{Regexp: String("same")}},
+			"happy_path",
+			&ServicesConditionConfig{
+				ServicesMonitorConfig{
+					Regexp:             String("regexp"),
+					Datacenter:         String("datacenter_overriden"),
+					Namespace:          nil,
+					Filter:             nil,
+					CTSUserDefinedMeta: map[string]string{},
+				},
+			},
+			&ServicesConditionConfig{
+				ServicesMonitorConfig{
+					Regexp:             nil,
+					Datacenter:         String("datacenter"),
+					Namespace:          String("namespace"),
+					Filter:             nil,
+					CTSUserDefinedMeta: map[string]string{},
+				},
+			},
+			&ServicesConditionConfig{
+				ServicesMonitorConfig{
+					Regexp:             String("regexp"),
+					Datacenter:         String("datacenter"),
+					Namespace:          String("namespace"),
+					Filter:             nil,
+					CTSUserDefinedMeta: map[string]string{},
+				},
+			},
 		},
 	}
 
@@ -126,22 +138,22 @@ func TestServicesConditionConfig_Finalize(t *testing.T) {
 		r    *ServicesConditionConfig
 	}{
 		{
-			"empty",
+			"nil",
+			[]string{},
+			nil,
+			nil,
+		},
+		{
+			"happy_path",
 			[]string{},
 			&ServicesConditionConfig{},
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
-					Regexp: String(""),
-				},
-			},
-		},
-		{
-			"services_ignored",
-			[]string{"api"},
-			&ServicesConditionConfig{},
-			&ServicesConditionConfig{
-				ServicesMonitorConfig{
-					Regexp: String(""),
+					Regexp:             String(""),
+					Datacenter:         String(""),
+					Namespace:          String(""),
+					Filter:             String(""),
+					CTSUserDefinedMeta: map[string]string{},
 				},
 			},
 		},
@@ -164,7 +176,7 @@ func TestServicesConditionConfig_Validate(t *testing.T) {
 		c         *ServicesConditionConfig
 	}{
 		{
-			"happy_path",
+			"valid",
 			false,
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
@@ -173,13 +185,18 @@ func TestServicesConditionConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			"invalid_regexp",
+			"invalid",
 			true,
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
 					Regexp: String("*"),
 				},
 			},
+		},
+		{
+			"nil",
+			false,
+			nil,
 		},
 	}
 
@@ -191,6 +208,46 @@ func TestServicesConditionConfig_Validate(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestServicesCondition_GoString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		i        *ServicesConditionConfig
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*ServicesConditionConfig)(nil)",
+		},
+		{
+			"fully_configured",
+			&ServicesConditionConfig{
+				ServicesMonitorConfig{
+					Regexp:     String("^api$"),
+					Datacenter: String("dc"),
+					Namespace:  String("namespace"),
+					Filter:     String("filter"),
+					CTSUserDefinedMeta: map[string]string{
+						"key": "value",
+					},
+				},
+			},
+			"&ServicesConditionConfig{&ServicesMonitorConfig{Regexp:^api$, Datacenter:dc, " +
+				"Namespace:namespace, Filter:filter, " +
+				"CTSUserDefinedMeta:map[key:value]}}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.i.GoString()
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -73,11 +73,7 @@ task {
 		{
 			"no condition: defaults to services condition",
 			false,
-			&ServicesConditionConfig{
-				ServicesMonitorConfig{
-					Regexp: String(""),
-				},
-			},
+			DefaultConditionConfig(),
 			"config.hcl",
 			`
 task {
@@ -91,7 +87,13 @@ task {
 			false,
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
-					Regexp: String(".*"),
+					Regexp:     String(".*"),
+					Datacenter: String("dc"),
+					Namespace:  String("namespace"),
+					Filter:     String("filter"),
+					CTSUserDefinedMeta: map[string]string{
+						"key": "value",
+					},
 				},
 			},
 			"config.hcl",
@@ -101,17 +103,19 @@ task {
 	source = "..."
 	condition "services" {
 		regexp = ".*"
+		datacenter = "dc"
+		namespace = "namespace"
+		filter = "filter"
+		cts_user_defined_meta {
+			key = "value"
+		}
 	}
 }`,
 		},
 		{
 			"services: unconfigured",
 			false,
-			&ServicesConditionConfig{
-				ServicesMonitorConfig{
-					Regexp: String(""),
-				},
-			},
+			DefaultConditionConfig(),
 			"config.hcl",
 			`
 task {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,11 @@ var (
 						},
 					},
 				},
-				SourceInput: DefaultSourceInputConfig(),
+				SourceInput: &ServicesSourceInputConfig{
+					ServicesMonitorConfig{
+						Regexp: String(""),
+					},
+				},
 			},
 		},
 		TerraformProviders: &TerraformProviderConfigs{{
@@ -320,6 +324,7 @@ func TestConfig_Finalize(t *testing.T) {
 	(*expected.Tasks)[0].BufferPeriod.Min = TimeDuration(20 * time.Second)
 	(*expected.Tasks)[0].BufferPeriod.Max = TimeDuration(60 * time.Second)
 	(*expected.Tasks)[0].WorkingDir = String("working/task")
+	(*expected.Tasks)[0].SourceInput = DefaultSourceInputConfig()
 	(*expected.Services)[0].ID = String("serviceA")
 	(*expected.Services)[0].Namespace = String("")
 	(*expected.Services)[0].Datacenter = String("")

--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -9,10 +9,28 @@ const servicesType = "services"
 
 var _ MonitorConfig = (*ServicesMonitorConfig)(nil)
 
-// ServicesMonitorConfig configures a configuration block adhering to the monitor interface
-// of type 'services'. A services monitor watches for changes that occur to services.
+// ServicesMonitorConfig configures a configuration block adhering to the
+// monitor interface of type 'services'. A services monitor watches for changes
+// that occur to services. ServicesMonitorConfig shares similar fields as the
+// deprecated ServiceConfig
 type ServicesMonitorConfig struct {
 	Regexp *string `mapstructure:"regexp"`
+
+	// Datacenter is the datacenter the service is deployed in.
+	Datacenter *string `mapstricture:"datacenter"`
+
+	// Namespace is the namespace of the service (Consul Enterprise only). If
+	// not provided, the namespace will be inferred from the CTS ACL token, or
+	// default to the `default` namespace.
+	Namespace *string `mapstructure:"namespace"`
+
+	// Filter is used to filter nodes based on a Consul compatible filter
+	// expression.
+	Filter *string `mapstructure:"filter"`
+
+	// CTSUserDefinedMeta is metadata added to a service automated by CTS for
+	// network infrastructure automation.
+	CTSUserDefinedMeta map[string]string `mapstructure:"cts_user_defined_meta"`
 }
 
 // Copy returns a deep copy of this configuration.
@@ -23,6 +41,15 @@ func (c *ServicesMonitorConfig) Copy() MonitorConfig {
 
 	var o ServicesMonitorConfig
 	o.Regexp = StringCopy(c.Regexp)
+	o.Datacenter = StringCopy(c.Datacenter)
+	o.Namespace = StringCopy(c.Namespace)
+	o.Filter = StringCopy(c.Filter)
+	if c.CTSUserDefinedMeta != nil {
+		o.CTSUserDefinedMeta = make(map[string]string)
+		for k, v := range c.CTSUserDefinedMeta {
+			o.CTSUserDefinedMeta[k] = v
+		}
+	}
 
 	return &o
 }
@@ -54,6 +81,23 @@ func (c *ServicesMonitorConfig) Merge(o MonitorConfig) MonitorConfig {
 	if o2.Regexp != nil {
 		r2.Regexp = StringCopy(o2.Regexp)
 	}
+	if o2.Datacenter != nil {
+		r2.Datacenter = StringCopy(o2.Datacenter)
+	}
+	if o2.Namespace != nil {
+		r2.Namespace = StringCopy(o2.Namespace)
+	}
+	if o2.Filter != nil {
+		r2.Filter = StringCopy(o2.Filter)
+	}
+	if o2.CTSUserDefinedMeta != nil {
+		if r2.CTSUserDefinedMeta == nil {
+			r2.CTSUserDefinedMeta = make(map[string]string)
+		}
+		for k, v := range o2.CTSUserDefinedMeta {
+			r2.CTSUserDefinedMeta[k] = v
+		}
+	}
 
 	return r2
 }
@@ -66,6 +110,18 @@ func (c *ServicesMonitorConfig) Finalize([]string) {
 
 	if c.Regexp == nil {
 		c.Regexp = String("")
+	}
+	if c.Datacenter == nil {
+		c.Datacenter = String("")
+	}
+	if c.Namespace == nil {
+		c.Namespace = String("")
+	}
+	if c.Filter == nil {
+		c.Filter = String("")
+	}
+	if c.CTSUserDefinedMeta == nil {
+		c.CTSUserDefinedMeta = make(map[string]string)
 	}
 }
 
@@ -93,7 +149,15 @@ func (c *ServicesMonitorConfig) GoString() string {
 
 	return fmt.Sprintf("&ServicesMonitorConfig{"+
 		"Regexp:%s, "+
+		"Datacenter:%s, "+
+		"Namespace:%s, "+
+		"Filter:%s, "+
+		"CTSUserDefinedMeta:%s"+
 		"}",
 		StringVal(c.Regexp),
+		StringVal(c.Datacenter),
+		StringVal(c.Namespace),
+		StringVal(c.Filter),
+		c.CTSUserDefinedMeta,
 	)
 }

--- a/config/monitor_services_test.go
+++ b/config/monitor_services_test.go
@@ -1,0 +1,369 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServicesMonitorConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ServicesMonitorConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&ServicesMonitorConfig{},
+		},
+		{
+			"fully_configured",
+			&ServicesMonitorConfig{
+				Regexp:     String("^web.*"),
+				Datacenter: String("dc"),
+				Namespace:  String("namespace"),
+				Filter:     String("filter"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			if tc.a == nil {
+				// returned nil interface has nil type, which is unequal to tc.a
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.a, r)
+			}
+		})
+	}
+}
+
+func TestServicesMonitorConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ServicesMonitorConfig
+		b    *ServicesMonitorConfig
+		r    *ServicesMonitorConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{},
+		},
+		{
+			"nil_b",
+			&ServicesMonitorConfig{},
+			nil,
+			&ServicesMonitorConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{},
+		},
+		{
+			"regexp_overrides",
+			&ServicesMonitorConfig{Regexp: String("same")},
+			&ServicesMonitorConfig{Regexp: String("different")},
+			&ServicesMonitorConfig{Regexp: String("different")},
+		},
+		{
+			"regexp_empty_one",
+			&ServicesMonitorConfig{Regexp: String("same")},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Regexp: String("same")},
+		},
+		{
+			"regexp_empty_two",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Regexp: String("same")},
+			&ServicesMonitorConfig{Regexp: String("same")},
+		},
+		{
+			"regexp_empty_same",
+			&ServicesMonitorConfig{Regexp: String("same")},
+			&ServicesMonitorConfig{Regexp: String("same")},
+			&ServicesMonitorConfig{Regexp: String("same")},
+		},
+		{
+			"datacenter_overrides",
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+			&ServicesMonitorConfig{Datacenter: String("dc")},
+			&ServicesMonitorConfig{Datacenter: String("dc")},
+		},
+		{
+			"datacenter_empty_one",
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+		},
+		{
+			"datacenter_empty_two",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+		},
+		{
+			"datacenter_same",
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+			&ServicesMonitorConfig{Datacenter: String("datacenter")},
+		},
+		{
+			"namespace_overrides",
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+			&ServicesMonitorConfig{Namespace: String("ns")},
+			&ServicesMonitorConfig{Namespace: String("ns")},
+		},
+		{
+			"namespace_empty_one",
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+		},
+		{
+			"namespace_empty_two",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+		},
+		{
+			"namespace_same",
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+			&ServicesMonitorConfig{Namespace: String("namespace")},
+		},
+		{
+			"filter_overrides",
+			&ServicesMonitorConfig{Filter: String("filter")},
+			&ServicesMonitorConfig{Filter: String("f")},
+			&ServicesMonitorConfig{Filter: String("f")},
+		},
+		{
+			"filter_empty_one",
+			&ServicesMonitorConfig{Filter: String("filter")},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Filter: String("filter")},
+		},
+		{
+			"filter_empty_two",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{Filter: String("filter")},
+			&ServicesMonitorConfig{Filter: String("filter")},
+		},
+		{
+			"filter_same",
+			&ServicesMonitorConfig{Filter: String("filter")},
+			&ServicesMonitorConfig{Filter: String("filter")},
+			&ServicesMonitorConfig{Filter: String("filter")},
+		},
+		{
+			"cts_user_defined_meta_overrides",
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "new-value"}},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "new-value"}},
+		},
+		{
+			"cts_user_defined_meta_empty_one",
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"cts_user_defined_meta_empty_two",
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
+		{
+			"cts_user_defined_meta_same",
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+			&ServicesMonitorConfig{CTSUserDefinedMeta: map[string]string{"key": "value"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			if tc.r == nil {
+				// returned nil interface has nil type, which is unequal to tc.r
+				assert.Nil(t, r)
+			} else {
+				assert.Equal(t, tc.r, r)
+			}
+		})
+	}
+}
+
+func TestServicesMonitorConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		s    []string
+		i    *ServicesMonitorConfig
+		r    *ServicesMonitorConfig
+	}{
+		{
+			"nil",
+			[]string{},
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			[]string{},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{
+				Regexp:             String(""),
+				Datacenter:         String(""),
+				Namespace:          String(""),
+				Filter:             String(""),
+				CTSUserDefinedMeta: map[string]string{},
+			},
+		},
+		{
+			"fully_configured",
+			[]string{},
+			&ServicesMonitorConfig{
+				Regexp:     String("^web.*"),
+				Datacenter: String("dc"),
+				Namespace:  String("namespace"),
+				Filter:     String("filter"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			},
+			&ServicesMonitorConfig{
+				Regexp:     String("^web.*"),
+				Datacenter: String("dc"),
+				Namespace:  String("namespace"),
+				Filter:     String("filter"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			},
+		},
+
+		{
+			"services_param_unused",
+			[]string{"api"},
+			&ServicesMonitorConfig{},
+			&ServicesMonitorConfig{
+				Regexp:             String(""),
+				Datacenter:         String(""),
+				Namespace:          String(""),
+				Filter:             String(""),
+				CTSUserDefinedMeta: map[string]string{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize(tc.s)
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestServicesMonitorConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *ServicesMonitorConfig
+	}{
+		{
+			"nil",
+			false,
+			nil,
+		},
+		{
+			"valid",
+			false,
+			&ServicesMonitorConfig{
+				Regexp: String(".*"),
+			},
+		},
+		{
+			"invalid_regexp",
+			true,
+			&ServicesMonitorConfig{
+				Regexp: String("*"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestServicesMonitorConfig_GoString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		i        *ServicesMonitorConfig
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*ServicesMonitorConfig)(nil)",
+		},
+		{
+			"fully_configured",
+			&ServicesMonitorConfig{
+				Regexp:     String("^api$"),
+				Datacenter: String("dc"),
+				Namespace:  String("namespace"),
+				Filter:     String("filter"),
+				CTSUserDefinedMeta: map[string]string{
+					"key": "value",
+				},
+			},
+			"&ServicesMonitorConfig{Regexp:^api$, Datacenter:dc, " +
+				"Namespace:namespace, Filter:filter, " +
+				"CTSUserDefinedMeta:map[key:value]}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.i.GoString()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/config/source_input.go
+++ b/config/source_input.go
@@ -22,7 +22,11 @@ type SourceInputConfig interface {
 func DefaultSourceInputConfig() SourceInputConfig {
 	return &ServicesSourceInputConfig{
 		ServicesMonitorConfig{
-			Regexp: String(""),
+			Regexp:             String(""),
+			Datacenter:         String(""),
+			Namespace:          String(""),
+			Filter:             String(""),
+			CTSUserDefinedMeta: map[string]string{},
 		},
 	}
 }

--- a/config/source_input_test.go
+++ b/config/source_input_test.go
@@ -15,6 +15,12 @@ task {
 	source = "..."
 	source_input "services" {
 		regexp = ".*"
+		datacenter = "dc2"
+		namespace = "ns2"
+		filter = "some-filter"
+		cts_user_defined_meta {
+			key = "value"
+		}
 	}
 	condition "schedule" {
 		cron = "* * * * * * *"
@@ -83,7 +89,11 @@ task {
 func TestSourceInput_DefaultSourceInputConfig(t *testing.T) {
 	e := &ServicesSourceInputConfig{
 		ServicesMonitorConfig{
-			Regexp: String(""),
+			Regexp:             String(""),
+			Datacenter:         String(""),
+			Namespace:          String(""),
+			Filter:             String(""),
+			CTSUserDefinedMeta: map[string]string{},
 		},
 	}
 	a := DefaultSourceInputConfig()
@@ -102,19 +112,19 @@ func TestSourceInput_DecodeConfig_Success(t *testing.T) {
 			name: "services happy path",
 			expected: &ServicesSourceInputConfig{
 				ServicesMonitorConfig{
-					Regexp: String(".*"),
+					Regexp:             String(".*"),
+					Datacenter:         String("dc2"),
+					Namespace:          String("ns2"),
+					Filter:             String("some-filter"),
+					CTSUserDefinedMeta: map[string]string{"key": "value"},
 				},
 			},
 			config: testSourceInputServicesSuccess,
 		},
 		{
-			name: "services un-configured",
-			expected: &ServicesSourceInputConfig{
-				ServicesMonitorConfig{
-					Regexp: String(""),
-				},
-			},
-			config: testSourceInputServicesUnconfiguredSuccess,
+			name:     "services un-configured",
+			expected: DefaultSourceInputConfig(),
+			config:   testSourceInputServicesUnconfiguredSuccess,
 		},
 		{
 			name: "consul-kv: happy path",

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -424,9 +424,10 @@ func TestTaskConfig_Finalize(t *testing.T) {
 		{
 			"with_services_source_input",
 			&TaskConfig{
-				Name:        String("task"),
-				Condition:   &ScheduleConditionConfig{},
-				SourceInput: &ServicesSourceInputConfig{ServicesMonitorConfig{String("^api$")}},
+				Name:      String("task"),
+				Condition: &ScheduleConditionConfig{},
+				SourceInput: &ServicesSourceInputConfig{
+					ServicesMonitorConfig{Regexp: String("^api$")}},
 			},
 			&TaskConfig{
 				Description: String(""),
@@ -442,10 +443,17 @@ func TestTaskConfig_Finalize(t *testing.T) {
 					Min:     TimeDuration(0 * time.Second),
 					Max:     TimeDuration(0 * time.Second),
 				},
-				Enabled:     Bool(true),
-				Condition:   &ScheduleConditionConfig{String("")},
-				WorkingDir:  String("sync-tasks/task"),
-				SourceInput: &ServicesSourceInputConfig{ServicesMonitorConfig{String("^api$")}},
+				Enabled:    Bool(true),
+				Condition:  &ScheduleConditionConfig{String("")},
+				WorkingDir: String("sync-tasks/task"),
+				SourceInput: &ServicesSourceInputConfig{
+					ServicesMonitorConfig{
+						Regexp:             String("^api$"),
+						Datacenter:         String(""),
+						Namespace:          String(""),
+						Filter:             String(""),
+						CTSUserDefinedMeta: map[string]string{},
+					}},
 			},
 		},
 	}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -202,19 +202,11 @@ func TestNewDriverTasks(t *testing.T) {
 						"source": "source/providerA",
 					},
 				},
-				Services: []driver.Service{},
-				Source:   "source",
-				VarFiles: []string{},
-				Condition: &config.ServicesConditionConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
-				SourceInput: &config.ServicesSourceInputConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
+				Services:    []driver.Service{},
+				Source:      "source",
+				VarFiles:    []string{},
+				Condition:   config.DefaultConditionConfig(),
+				SourceInput: config.DefaultSourceInputConfig(),
 				BufferPeriod: &driver.BufferPeriod{
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,
@@ -277,19 +269,11 @@ func TestNewDriverTasks(t *testing.T) {
 						"source": "source/providerA",
 					},
 				},
-				Services: []driver.Service{},
-				Source:   "source",
-				VarFiles: []string{},
-				Condition: &config.ServicesConditionConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
-				SourceInput: &config.ServicesSourceInputConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
+				Services:    []driver.Service{},
+				Source:      "source",
+				VarFiles:    []string{},
+				Condition:   config.DefaultConditionConfig(),
+				SourceInput: config.DefaultSourceInputConfig(),
 				BufferPeriod: &driver.BufferPeriod{
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,
@@ -340,16 +324,8 @@ func TestNewDriverTasks(t *testing.T) {
 				Services:     []driver.Service{},
 				Source:       "source",
 				VarFiles:     []string{},
-				Condition: &config.ServicesConditionConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
-				SourceInput: &config.ServicesSourceInputConfig{
-					config.ServicesMonitorConfig{
-						Regexp: config.String(""),
-					},
-				},
+				Condition:    config.DefaultConditionConfig(),
+				SourceInput:  config.DefaultSourceInputConfig(),
 				BufferPeriod: &driver.BufferPeriod{
 					Min: 5 * time.Second,
 					Max: 20 * time.Second,


### PR DESCRIPTION
Update `condition "services"` and `source_input "services"` to support the same services filtering fields as supported in `services` block. Same default values as with `services` block.
- Namespace
- Datacenter
- Filter
- CTS User Defined Meta

Changes:
 - Update struct with new fields
 - Refactor tests for services condition, source input, monitor
 - Update misc tests

Future PR to consume namespace, datacenter, filter, cts user-defined meta

Example usage:

```
  source_input "services" {
    regexp = ".*"
    datacenter = "dc2"
    namespace = "ns2"
    filter = "some-filter"
    cts_user_defined_meta {
      key = "value"
    }
  }
```

```
  condition "services" {
    regexp = ".*"
    datacenter = "dc2"
    namespace = "ns2"
    filter = "some-filter"
    cts_user_defined_meta {
      key = "value"
    }
  }
```

Part of https://github.com/hashicorp/consul-terraform-sync/issues/357