### PR TITLE
Implement Services Condition & Source Input MetaData field

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -615,9 +615,12 @@ func getTerraformHandlers(taskName string, providers TerraformProviderBlocks) (h
 }
 
 // getServicesMetaData helps retrieve metadata which can come from a number of
-// configuration sources: service block, condition block, source_input block.
-// Currently, it is only possible for a task to have metadata defined in one of
-// the listed sources
+// configuration sources: task.services' related service block, condition
+// "service" block, source_input "service" block.
+//
+// Currently it is only possible for a task to be configured with one of these
+// configuration sources, hence a task only has one metadata source. This is
+// validated at the configuration-level. This method relies on this assumption.
 func (tf *Terraform) getServicesMetaData() (*tmplfunc.ServicesMeta, error) {
 	servicesMeta := &tmplfunc.ServicesMeta{}
 

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -36,6 +36,9 @@ func TestCondition_Services_Regexp(t *testing.T) {
 	condition "services" {
 		regexp = "api-"
 		filter = "Service.Tags not contains \"tag_a\""
+		cts_user_defined_meta {
+			my_meta_key = "my_meta_value"
+		}
 	}
 }
 `, taskName)
@@ -49,7 +52,8 @@ func TestCondition_Services_Regexp(t *testing.T) {
 	// 1. Register db service instance. Confirm that the task was not triggered
 	//    (no new event) and its data is filtered out of services variable.
 	// 2. Register api-web service instance. Confirm that task was triggered
-	//    (one new event) and its data exists in the services variable.
+	//    (one new event) and its data exists in the services variable and
+	//    confirm metadata in tfvars
 	// 3. Register a second node to the api-web service. Confirm that task was triggered
 	//    (one new event) and its data exists in the services variable.
 	// 4. Register a third node to the api-web service with tag_a. Confirm that
@@ -84,6 +88,7 @@ func TestCondition_Services_Regexp(t *testing.T) {
 		"event count did not increment once. task was not triggered as expected")
 	resourcesPath := filepath.Join(workingDir, resourcesDir)
 	validateServices(t, true, []string{"api-web-1"}, resourcesPath)
+	validateVariable(t, true, workingDir, "services", "my_meta_value")
 
 	// 3. Add a second node to the service "api-web"
 	now = time.Now()

--- a/templates/tftmpl/tmplfunc/hcl_service_func.go
+++ b/templates/tftmpl/tmplfunc/hcl_service_func.go
@@ -11,17 +11,16 @@ import (
 // hclServiceFunc is a wrapper of the template function to marshal Consul
 // service information into HCL. The function accepts a map representing
 // metadata for services in scope of a task.
-func hclServiceFunc(meta ServicesMeta) func(sDep *dep.HealthService) string {
+func hclServiceFunc(meta *ServicesMeta) func(sDep *dep.HealthService) string {
 	return func(sDep *dep.HealthService) string {
 		if sDep == nil {
 			return ""
 		}
 
-		// Find metdata based Consul service name scoped to a task to append to
-		// that service within var.services
+		// Find any user-defined metadata for this service and append to variable
 		var serviceMeta map[string]string
 		if meta != nil {
-			serviceMeta = meta[sDep.Name]
+			serviceMeta = meta.Get(sDep.Name)
 		}
 
 		// Convert the hcat type to an HCL marshal-able object

--- a/templates/tftmpl/tmplfunc/hcl_service_func_test.go
+++ b/templates/tftmpl/tmplfunc/hcl_service_func_test.go
@@ -119,12 +119,10 @@ cts_user_defined_meta = {}`,
 }
 
 func TestHCLServiceFunc_ctsUserDefinedMeta(t *testing.T) {
-	meta := ServicesMeta{
-		"api": {
-			"key":        "value",
-			"foo_bar":    "baz",
-			"spaced key": "spaced value",
-		},
+	meta := map[string]string{
+		"key":        "value",
+		"foo_bar":    "baz",
+		"spaced key": "spaced value",
 	}
 	content := &dep.HealthService{
 		ID:      "api",
@@ -153,6 +151,30 @@ cts_user_defined_meta = {
   "spaced key" = "spaced value"
 }`
 
-	actual := hclServiceFunc(meta)(content)
-	assert.Equal(t, expected, actual)
+	cases := []struct {
+		name         string
+		servicesMeta *ServicesMeta
+	}{
+		{
+			"meta-map",
+			&ServicesMeta{
+				metaMap: map[string]map[string]string{
+					"api": meta,
+				},
+			},
+		},
+		{
+			"meta",
+			&ServicesMeta{
+				meta: meta,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := hclServiceFunc(tc.servicesMeta)(content)
+			assert.Equal(t, expected, actual)
+		})
+	}
 }

--- a/templates/tftmpl/tmplfunc/services_meta.go
+++ b/templates/tftmpl/tmplfunc/services_meta.go
@@ -1,0 +1,62 @@
+package tmplfunc
+
+import (
+	"fmt"
+)
+
+// ServicesMeta holds the user-defined metadata for the services of a task.
+// From task configuration, metadata is provided to a task's services in one
+// of two ways:
+// 1. map of metadata: a map of service-name to metadata so that each service
+//    has its own unique metadata
+// 2. metadata: a set of metadata is shared across all services that a task is
+//    configured with
+type ServicesMeta struct {
+	// Deprecated in 0.5
+	// When this happens: when task.services field and associated
+	// services.cts_user_defined_meta field are configured
+	metaMap map[string]map[string]string
+
+	// Introduced in 0.5. Replaces metaMap
+	// When this happens: when task.condition "services" or
+	// task.source_input "services" cts_user_defined_meta field is configured
+	meta map[string]string
+}
+
+// SetMetaMap sets the task's services' meta with a map of service-name to meta.
+// This will error if meta (non-map form) is already set.
+func (m *ServicesMeta) SetMetaMap(metaMap map[string]map[string]string) error {
+	if m.meta != nil {
+		return fmt.Errorf("cannot set meta-map. already set with meta %+v",
+			m.meta)
+	}
+
+	m.metaMap = metaMap
+	return nil
+}
+
+// SetMeta sets the task's services' meta with a map of service-name to meta.
+// This will error if meta (map form) is already set.
+func (m *ServicesMeta) SetMeta(meta map[string]string) error {
+	if m.metaMap != nil {
+		return fmt.Errorf("cannot set meta. already set with meta-map %+v", m.metaMap)
+	}
+
+	m.meta = meta
+	return nil
+}
+
+// Get returns the metadata for a given service name. Returns an empty map if
+// no meta is associated with the service.
+func (m *ServicesMeta) Get(serviceName string) map[string]string {
+	if m.metaMap != nil {
+		return m.metaMap[serviceName]
+	}
+
+	if m.meta != nil {
+		// all services share the same meta
+		return m.meta
+	}
+
+	return make(map[string]string)
+}

--- a/templates/tftmpl/tmplfunc/services_meta_test.go
+++ b/templates/tftmpl/tmplfunc/services_meta_test.go
@@ -1,0 +1,100 @@
+package tmplfunc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServicesMeta_SetMetaMap(t *testing.T) {
+	metaMap := map[string]map[string]string{
+		"api": {
+			"key": "value",
+		},
+	}
+
+	t.Run("happy_path", func(t *testing.T) {
+		m := &ServicesMeta{}
+
+		err := m.SetMetaMap(metaMap)
+		assert.NoError(t, err)
+
+		assert.Equal(t, metaMap, m.metaMap)
+		assert.Nil(t, m.meta)
+	})
+
+	t.Run("error_meta_already_set", func(t *testing.T) {
+		m := &ServicesMeta{}
+
+		// set meta first
+		err := m.SetMeta(map[string]string{"key": "value"})
+		assert.NoError(t, err)
+
+		// confirm setting metamap errors
+		err = m.SetMetaMap(metaMap)
+		assert.Error(t, err)
+	})
+}
+
+func TestServicesMeta_SetMeta(t *testing.T) {
+	meta := map[string]string{"key": "value"}
+
+	t.Run("happy_path", func(t *testing.T) {
+		m := &ServicesMeta{}
+
+		err := m.SetMeta(meta)
+		assert.NoError(t, err)
+
+		assert.Equal(t, meta, m.meta)
+		assert.Nil(t, m.metaMap)
+	})
+
+	t.Run("error_meta_map_already_set", func(t *testing.T) {
+		m := &ServicesMeta{}
+
+		// set meta-map first
+		err := m.SetMetaMap(map[string]map[string]string{
+			"api": {
+				"key": "value",
+			},
+		})
+		assert.NoError(t, err)
+
+		// confirm setting meta errors
+		err = m.SetMeta(meta)
+		assert.Error(t, err)
+	})
+}
+
+func TestServicesMeta_Get(t *testing.T) {
+	meta := map[string]string{
+		"key": "value",
+	}
+
+	cases := []struct {
+		name         string
+		servicesMeta *ServicesMeta
+	}{
+		{
+			"meta-map",
+			&ServicesMeta{
+				metaMap: map[string]map[string]string{
+					"api": meta,
+				},
+			},
+		},
+		{
+			"meta",
+			&ServicesMeta{
+				meta: meta,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.servicesMeta.Get("api")
+			assert.Equal(t, meta, actual)
+		})
+	}
+}

--- a/templates/tftmpl/tmplfunc/tmpl_func.go
+++ b/templates/tftmpl/tmplfunc/tmpl_func.go
@@ -13,7 +13,7 @@ import (
 
 // HCLMap is the map of template functions for rendering HCL
 // to their respective implementations
-func HCLMap(meta ServicesMeta) template.FuncMap {
+func HCLMap(meta *ServicesMeta) template.FuncMap {
 	tmplFuncs := hcat.FuncMapConsulV1()
 	tmplFuncs["catalogServicesRegistration"] = catalogServicesRegistrationFunc
 	tmplFuncs["servicesRegex"] = servicesRegexFunc

--- a/templates/tftmpl/tmplfunc/tmpl_func.go
+++ b/templates/tftmpl/tmplfunc/tmpl_func.go
@@ -11,10 +11,6 @@ import (
 	"github.com/hashicorp/hcat/tfunc"
 )
 
-// ServicesMeta is a useful type to abstract from the nested map of string which
-// represents the user defined meta for each service a task monitors
-type ServicesMeta map[string]map[string]string
-
 // HCLMap is the map of template functions for rendering HCL
 // to their respective implementations
 func HCLMap(meta ServicesMeta) template.FuncMap {


### PR DESCRIPTION
Implement new field `cts_user_defined_meta`

Note:
 - This is a parallel field to the existing `cts_user_defined_meta` in the `service` block
 - Configuration added in earlier PR: https://github.com/hashicorp/consul-terraform-sync/pull/520
 - New query fields implemented in earlier PR: https://github.com/hashicorp/consul-terraform-sync/pull/523

Changes:
 - Update ServicesMeta to support both `cts_user_defined_meta` in the `service` block (existing) and in `condition "services"` new
 - Update references to ServicesMeta
 - Update driver to pass both types of metadata to template
 - Test new `cts_user_defined_meta` in services condition e2e test
   - Note: manually tested for services source input because source input is currently only supported with scheduled conditions. Adding testing for this to scheduled conditions e2e test felt out of scope. Will add e2e tests when source input is supported by other conditions)

Part of #357