### PR TITLE
Refactor getServicesMetaData no longer rely on TF driver

### DIFF
--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -818,12 +818,7 @@ func TestGetServicesMetaData(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tf := &Terraform{
-				task:   tc.task,
-				logger: logging.NewNullLogger(),
-			}
-
-			actual, err := tf.getServicesMetaData()
+			actual, err := getServicesMetaData(logging.NewNullLogger(), tc.task)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expFunc(), actual)
 		})


### PR DESCRIPTION
Pass data in rather than retrieve from the receiver