### PR TITLE
Flakey test

### DIFF
--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -228,6 +228,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 	for _, tc := range cases {
 		tb := &testutils.TestingTB{}
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Setup Consul server
 			log.SetOutput(ioutil.Discard)
@@ -340,7 +341,7 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 				re, err := r.Run(tmpl, w)
 				require.NoError(t, err)
 
-				if re.Complete {
+				if re.Complete && !re.NoChange {
 					// there may be a race with the consul services registering
 					// let's retry once.
 					contents := string(re.Contents)


### PR DESCRIPTION
Ran the flakey test `TestRenderTFVarsTmpl` several times to fail and again with updates to check for flakeyness.

[CircleCI](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/2478/workflows/4d68035d-8290-4550-aa79-e9048627c210/jobs/5411)
```
go test ./templates/tftmpl -tags integration -count 10
```

The tests flake based on Consul information returned to CTS -- sometimes there are no tagged node address causing the test to fail which expects them.

[With the changes, i've ran it 50 times w/o fail](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync?branch=flakey-test)? my guess is running these in parallel slows down the tests for consul to get the full information