### PR TITLE
Delete Task CLI

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -400,6 +400,22 @@ func (t *TaskClient) Update(name string, config UpdateTaskConfig, q *QueryParam)
 	return plan, nil
 }
 
+// Delete is used to make a delete request
+func (t *TaskClient) Delete(name string, q *QueryParam) error {
+	if q == nil {
+		q = &QueryParam{}
+	}
+
+	path := fmt.Sprintf("%s/%s", taskPath, name)
+	resp, err := t.request(http.MethodDelete, path, q.Encode(), "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
 func parseAddress(addr string) (addressComposite, error) {
 	ac := addressComposite{}
 	ac.scheme = HTTPScheme

--- a/command/commands.go
+++ b/command/commands.go
@@ -22,11 +22,14 @@ func Commands() map[string]cli.CommandFactory {
 	}
 
 	all := map[string]cli.CommandFactory{
-		"task disable": func() (cli.Command, error) {
+		cmdTaskDisableName: func() (cli.Command, error) {
 			return newTaskDisableCommand(m), nil
 		},
-		"task enable": func() (cli.Command, error) {
+		cmdTaskEnableName: func() (cli.Command, error) {
 			return newTaskEnableCommand(m), nil
+		},
+		cmdTaskDeleteName: func() (cli.Command, error) {
+			return newTaskDeleteCommand(m), nil
 		},
 	}
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -157,13 +157,9 @@ func (m *meta) client() (*api.Client, error) {
 }
 
 // requestUserApproval returns an exit code and boolean describing if the user
-// approved. If the user did not approve (false is returned), exit code is provided.
-func (m *meta) requestUserApproval(taskName string) (int, bool) {
-	m.UI.Info("Enabling the task will perform the actions described above.")
-	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
-	m.UI.Output(" - This action cannot be undone.")
-	m.UI.Output(" - Consul Terraform Sync cannot guarantee Terraform will perform")
-	m.UI.Output("   these exact actions if monitored services have changed.\n")
+// approved a given action. If the user did not approve (false is returned) or
+// if there is an error in processing the user input, an exit code is provided.
+func (m *meta) requestUserApproval(taskName, action string) (int, bool) {
 	m.UI.Output("Only 'yes' will be accepted to approve.\n")
 	v, err := m.UI.Ask("Enter a value:")
 	m.UI.Output("")
@@ -173,11 +169,31 @@ func (m *meta) requestUserApproval(taskName string) (int, bool) {
 		return ExitCodeError, false
 	}
 	if v != "yes" {
-		m.UI.Output(fmt.Sprintf("Cancelled enabling task '%s'", taskName))
+		m.UI.Output(fmt.Sprintf("Cancelled %s task '%s'", action, taskName))
 		return ExitCodeOK, false
 	}
-
 	return 0, true
+}
+
+// requestUserApprovalEnable prints a prompt for user approval of enabling a task
+// and waits for the user input. It returns an exit code and boolean describing
+// if the user approved.
+func (m *meta) requestUserApprovalEnable(taskName string) (int, bool) {
+	m.UI.Info("Enabling the task will perform the actions described above.")
+	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
+	m.UI.Output(" - This action cannot be undone.")
+	m.UI.Output(" - Consul Terraform Sync cannot guarantee Terraform will perform")
+	m.UI.Output("   these exact actions if monitored services have changed.\n")
+	return m.requestUserApproval(taskName, "enabling")
+}
+
+// requestUserApprovalDelete prints a prompt for user approval of deleting a task
+// and waits for the user input. It returns an exit code and boolean describing
+// if the user approved.
+func (m *meta) requestUserApprovalDelete(taskName string) (int, bool) {
+	m.UI.Info(fmt.Sprintf("Do you want to delete '%s'?", taskName))
+	m.UI.Output(" - This action cannot be undone.")
+	return m.requestUserApproval(taskName, "deleting")
 }
 
 // Returns true if the flags have been parsed

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -35,7 +35,7 @@ func (c *taskDeleteCommand) Help() string {
 	helpText := fmt.Sprintf(`
 Usage: consul-terraform-sync task delete [options] <task name>
 
-  Task Delete is used to delete existing tasks. Will not delete a task
+  Task Delete is used to delete an existing task. Will not delete a task
   if the task is currently running.
 
 Options:
@@ -57,7 +57,7 @@ Example:
 
 // Synopsis is a short one-line synopsis of the command
 func (c *taskDeleteCommand) Synopsis() string {
-	return "Deletes existing tasks."
+	return "Deletes an existing task."
 }
 
 // Run runs the command

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -1,0 +1,106 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/go-wordwrap"
+)
+
+const cmdTaskDeleteName = "task delete"
+
+// TaskDeleteCommand handles the `task delete` command
+type taskDeleteCommand struct {
+	meta
+
+	flags *flag.FlagSet
+}
+
+func newTaskDeleteCommand(m meta) *taskDeleteCommand {
+	flags := m.defaultFlagSet(cmdTaskDeleteName)
+	return &taskDeleteCommand{
+		meta:  m,
+		flags: flags,
+	}
+}
+
+// Name returns the subcommand
+func (c taskDeleteCommand) Name() string {
+	return cmdTaskDeleteName
+}
+
+// Help returns the command's usage, list of flags, and examples
+func (c *taskDeleteCommand) Help() string {
+	helpText := fmt.Sprintf(`
+Usage: consul-terraform-sync task delete [options] <task name>
+
+  Task Delete is used to delete existing tasks. Will not delete a task
+  if the task is currently running.
+
+Options:
+%s
+
+Example:
+
+  $ consul-terraform-sync task delete my_task
+	==> Do you want to delete 'my_task'?
+		- This action cannot be undone.
+	Only 'yes' will be accepted to approve.
+
+	Enter a value: yes
+
+	==> 'my_task' delete complete!
+`, strings.Join(c.meta.helpOptions, "\n"))
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is a short one-line synopsis of the command
+func (c *taskDeleteCommand) Synopsis() string {
+	return "Deletes existing tasks."
+}
+
+// Run runs the command
+func (c *taskDeleteCommand) Run(args []string) int {
+	c.meta.setFlagsUsage(c.flags, args, c.Help())
+
+	if err := c.flags.Parse(args); err != nil {
+		return ExitCodeParseFlagsError
+	}
+
+	args = c.flags.Args()
+	if ok := c.meta.oneArgCheck(c.Name(), args); !ok {
+		return ExitCodeRequiredFlagsError
+	}
+
+	taskName := args[0]
+
+	client, err := c.meta.client()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to create client for '%s'", taskName))
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	if exitCode, approved := c.meta.requestUserApprovalDelete(taskName); !approved {
+		return exitCode
+	}
+
+	c.UI.Info(fmt.Sprintf("Deleting task '%s'...\n", taskName))
+	err = client.Task().Delete(taskName, nil)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to delete '%s'", taskName))
+		err = processEOFError(client.Scheme(), err)
+
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	c.UI.Info(fmt.Sprintf("Deleted task '%s'", taskName))
+
+	return ExitCodeOK
+}

--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -135,7 +135,7 @@ func (c *taskEnableCommand) Run(args []string) int {
 		return ExitCodeOK
 	}
 
-	if exitCode, approved := c.meta.requestUserApproval(taskName); !approved {
+	if exitCode, approved := c.meta.requestUserApprovalEnable(taskName); !approved {
 		return exitCode
 	}
 


### PR DESCRIPTION
Adds the client and the CLI command for deleting a task.

**Example Outputs**
Happy path/approved
```
$ consul-terraform-sync task delete test-task
==> Do you want to delete 'test-task'?
     - This action cannot be undone.
    Only 'yes' will be accepted to approve.

Enter a value: yes

==> Deleting task 'test-task'...

==> Deleted task 'test-task'
```
Denied
```
$ consul-terraform-sync task delete test-task
==> Do you want to delete 'test-task'?
     - This action cannot be undone.
    Only 'yes' will be accepted to approve.

Enter a value: no

    Cancelled deleting task 'test-task'
```
Task does not exist
```
$ consul-terraform-sync task delete nonexistent
==> Do you want to delete 'nonexistent'?
     - This action cannot be undone.
    Only 'yes' will be accepted to approve.

Enter a value: yes

==> Deleting task 'nonexistent'...

==> Error: unable to delete 'nonexistent'
    request returned 404 status code with error: a task with the name
'nonexistent' does not exist or has not been initialized yet
```
Task is currently running
```
$ consul-terraform-sync task delete delayed-task
==> Do you want to delete 'delayed-task'?
     - This action cannot be undone.
    Only 'yes' will be accepted to approve.

Enter a value: yes

==> Deleting task 'delayed-task'...

==> Error: unable to delete 'delayed-task'
    request returned 409 status code with error: task 'delayed-task' is currently
running and cannot be deleted at this time
```