### PR TITLE
Fix query types to use blocking queries

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -116,6 +116,7 @@ func TestBaseControllerInit(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			d := new(mocksD.Driver)
+			d.On("TemplateIDs").Return(nil)
 			d.On("InitTask", mock.Anything).Return(tc.initTaskErr).Once()
 
 			baseCtrl := baseController{

--- a/controller/readonly_test.go
+++ b/controller/readonly_test.go
@@ -64,6 +64,7 @@ func TestReadOnlyRun(t *testing.T) {
 
 			d := new(mocksD.Driver)
 			d.On("Task").Return(enabledTestTask(t, "task"))
+			d.On("TemplateIDs").Return(nil)
 			d.On("RenderTemplate", mock.Anything).
 				Return(true, tc.renderTmplErr)
 			d.On("InspectTask", mock.Anything).
@@ -95,6 +96,7 @@ func TestReadOnlyRun_context_cancel(t *testing.T) {
 
 	d := new(mocksD.Driver)
 	d.On("Task").Return(enabledTestTask(t, "task"))
+	d.On("TemplateIDs").Return(nil)
 	d.On("RenderTemplate", mock.Anything).Return(false, nil)
 	drivers := driver.NewDrivers()
 	err := drivers.Add("task", d)

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -76,10 +76,14 @@ func (rw *ReadWrite) Run(ctx context.Context) error {
 		rw.watcherCh = make(chan string, rw.drivers.Len()+2)
 	}
 	go func() {
-		err := rw.watcher.Watch(ctx, rw.watcherCh)
-		if err != nil {
-			rw.logger.Error("error watching template dependencies", "error", err)
-			errCh <- err
+		for {
+			rw.logger.Trace("starting template dependency monitoring")
+			err := rw.watcher.Watch(ctx, rw.watcherCh)
+			if err == nil || err == context.Canceled {
+				rw.logger.Info("stopping dependency monitoring")
+				return
+			}
+			rw.logger.Error("error monitoring template dependencies", "error", err)
 		}
 	}()
 

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/logging"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocksTmpl "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates"
@@ -58,9 +59,7 @@ func TestServer_TaskCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		mockD := new(mocksD.Driver)
-		mockD.On("Task").Return(driverTask).
-			On("InitTask", mock.Anything).Return(nil).
-			On("RenderTemplate", mock.Anything).Return(true, nil)
+		mockDriver(ctx, mockD, driverTask)
 		ctrl.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
@@ -126,10 +125,7 @@ func TestServer_TaskCreateAndRun(t *testing.T) {
 			Name:    "task",
 		})
 		require.NoError(t, err)
-		mockD.On("Task").Return(task).
-			On("InitTask", ctx).Return(nil).
-			On("RenderTemplate", mock.Anything).Return(true, nil).
-			On("ApplyTask", ctx).Return(nil)
+		mockDriver(ctx, mockD, task)
 		ctrl.store = event.NewStore()
 		ctrl.drivers = driver.NewDrivers()
 		ctrl.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
@@ -155,9 +151,7 @@ func TestServer_TaskCreateAndRun(t *testing.T) {
 			Name:    "task",
 		})
 		require.NoError(t, err)
-		mockD.On("Task").Return(task).
-			On("InitTask", ctx).Return(nil).
-			On("RenderTemplate", mock.Anything).Return(true, nil)
+		mockDriver(ctx, mockD, task)
 		ctrl.store = event.NewStore()
 		ctrl.drivers = driver.NewDrivers()
 		ctrl.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
@@ -223,6 +217,7 @@ func TestServer_TaskDelete(t *testing.T) {
 		{
 			"success",
 			func(d *driver.Drivers) {
+				mockD.On("TemplateIDs").Return(nil)
 				d.Add("success", mockD)
 			},
 			"",
@@ -233,6 +228,7 @@ func TestServer_TaskDelete(t *testing.T) {
 		}, {
 			"active",
 			func(d *driver.Drivers) {
+				mockD.On("TemplateIDs").Return(nil)
 				d.Add("active", mockD)
 				d.SetActive("active")
 			},
@@ -292,8 +288,8 @@ func TestServer_TaskUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		d := new(mocksD.Driver)
-		d.On("Task").Return(task).
-			On("UpdateTask", mock.Anything, driver.PatchTask{Enabled: false}).
+		mockDriver(ctx, d, task)
+		d.On("UpdateTask", mock.Anything, driver.PatchTask{Enabled: false}).
 			Return(driver.InspectPlan{ChangesPresent: false, Plan: ""}, nil)
 		err = ctrl.drivers.Add(taskName, d)
 		require.NoError(t, err)
@@ -339,8 +335,8 @@ func TestServer_TaskUpdate(t *testing.T) {
 		}
 		// add a driver
 		d := new(mocksD.Driver)
-		d.On("Task").Return(&driver.Task{}, nil).
-			On("UpdateTask", mock.Anything, mock.Anything).Return(expectedPlan, nil).Once()
+		mockDriver(ctx, d, &driver.Task{})
+		d.On("UpdateTask", mock.Anything, mock.Anything).Return(expectedPlan, nil).Once()
 		err := ctrl.drivers.Add("task_b", d)
 		require.NoError(t, err)
 
@@ -365,8 +361,8 @@ func TestServer_TaskUpdate(t *testing.T) {
 
 		// add a driver
 		d := new(mocksD.Driver)
-		d.On("Task").Return(&driver.Task{}, nil).
-			On("UpdateTask", mock.Anything, mock.Anything).Return(driver.InspectPlan{}, nil).Once()
+		mockDriver(ctx, d, &driver.Task{})
+		d.On("UpdateTask", mock.Anything, mock.Anything).Return(driver.InspectPlan{}, nil).Once()
 		err := ctrl.drivers.Add(taskName, d)
 		require.NoError(t, err)
 
@@ -384,4 +380,13 @@ func TestServer_TaskUpdate(t *testing.T) {
 		events := ctrl.store.Read(taskName)
 		assert.Len(t, events, 1)
 	})
+}
+
+// mockDriver sets up a mock driver with the happy path for all methods
+func mockDriver(ctx context.Context, d *mocks.Driver, task *driver.Task) {
+	d.On("Task").Return(task).
+		On("InitTask", ctx).Return(nil).
+		On("TemplateIDs").Return(nil).
+		On("RenderTemplate", mock.Anything).Return(true, nil).
+		On("ApplyTask", ctx).Return(nil)
 }

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -15,6 +15,9 @@ type Driver interface {
 	// SetBufferPeriod sets the task's buffer period on the watcher
 	SetBufferPeriod()
 
+	// TemplateIDs returns the list of template IDs for the driver
+	TemplateIDs() []string
+
 	// RenderTemplate renders a template. Returns if template rendering
 	// completed or not
 	RenderTemplate(ctx context.Context) (bool, error)

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -54,7 +54,7 @@ func (d *Drivers) Add(taskName string, driver Driver) error {
 	return nil
 }
 
-// Get retrieves the driver for a task
+// Get retrieves the driver for a task by task name
 func (d *Drivers) Get(taskName string) (Driver, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -67,12 +67,18 @@ func (d *Drivers) Get(taskName string) (Driver, bool) {
 	return driver, true
 }
 
-func (d *Drivers) GetTask(tmplID string) (string, bool) {
+// GetTaskByTemplate retrieves the driver for a task by template ID
+func (d *Drivers) GetTaskByTemplate(tmplID string) (Driver, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
 	taskName, ok := d.driverTemplates[tmplID]
-	return taskName, ok
+	if !ok {
+		return nil, false
+	}
+
+	driver, ok := d.drivers[taskName]
+	return driver, ok
 }
 
 func (d *Drivers) Reset() {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -47,7 +47,7 @@ var (
 // Terraform is a Sync driver that uses the Terraform CLI to interface with
 // low-level network infrastructure.
 type Terraform struct {
-	mu *sync.RWMutex
+	mu sync.RWMutex
 
 	task              *Task
 	backend           map[string]interface{}
@@ -132,7 +132,6 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 	}
 
 	return &Terraform{
-		mu:                &sync.RWMutex{},
 		task:              config.Task,
 		backend:           config.Backend,
 		requiredProviders: config.RequiredProviders,
@@ -560,12 +559,10 @@ func (tf *Terraform) initTaskTemplate() error {
 
 	tf.setNotifier(tmpl)
 
-	if !tf.watcher.Watching(tf.template.ID()) {
-		err = tf.watcher.Register(tf.template)
-		if err != nil && err != hcat.RegistryErr {
-			tf.logger.Error("unable to register template", taskNameLogKey, tf.task.Name(), "error", err)
-			return err
-		}
+	err = tf.watcher.Register(tf.template)
+	if err != nil && err != hcat.RegistryErr {
+		tf.logger.Error("unable to register template", taskNameLogKey, tf.task.Name(), "error", err)
+		return err
 	}
 
 	return nil

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -198,6 +198,16 @@ func (tf *Terraform) SetBufferPeriod() {
 	tf.watcher.SetBufferPeriod(bp.Min, bp.Max, tf.template.ID())
 }
 
+func (tf *Terraform) TemplateIDs() []string {
+	tf.mu.RLock()
+	defer tf.mu.RUnlock()
+
+	if tf.template == nil {
+		return nil
+	}
+	return []string{tf.template.ID()}
+}
+
 // RenderTemplate fetches data for the template. If the data is complete fetched,
 // renders the template. Rendering a template for the first time may take several
 // cycles to load all the dependencies asynchronously. Returns a boolean whether

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -553,7 +553,7 @@ func (tf *Terraform) initTaskTemplate() error {
 		}
 
 		// cleanup old template from watcher
-		tf.watcher.Mark(tf.template)
+		tf.watcher.MarkForSweep(tf.template)
 		tf.watcher.Sweep(tf.template)
 	}
 

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -86,7 +85,6 @@ func TestRenderTemplate(t *testing.T) {
 			tmpl.On("Render", mock.Anything).Return(hcat.RenderResult{}, tc.renderErr).Once()
 
 			tf := &Terraform{
-				mu:       &sync.RWMutex{},
 				task:     &Task{name: "RenderTemplateTest", enabled: true, logger: logging.NewNullLogger()},
 				resolver: r,
 				template: tmpl,
@@ -148,7 +146,6 @@ func TestApplyTask(t *testing.T) {
 			c.On("Apply", ctx).Return(tc.applyReturn).Once()
 
 			tf := &Terraform{
-				mu:        &sync.RWMutex{},
 				task:      &Task{name: "ApplyTaskTest", enabled: true, logger: logging.NewNullLogger()},
 				client:    c,
 				postApply: tc.postApply,
@@ -263,10 +260,8 @@ func TestUpdateTask(t *testing.T) {
 			}
 
 			w := new(mocksTmpl.Watcher)
-			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 			tf := &Terraform{
-				mu: &sync.RWMutex{},
 				task: &Task{name: "test_task", enabled: tc.orig.Enabled, workingDir: tc.dirName,
 					logger: logging.NewNullLogger()},
 				client:   c,
@@ -369,11 +364,9 @@ func TestUpdateTask(t *testing.T) {
 			c.On("Apply", ctx).Return(tc.applyErr).Once()
 
 			w := new(mocksTmpl.Watcher)
-			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 
 			tf := &Terraform{
-				mu: &sync.RWMutex{},
 				task: &Task{name: "test_task", enabled: false, workingDir: tc.dirName,
 					logger: logging.NewNullLogger()},
 				client:   c,
@@ -442,11 +435,9 @@ func TestUpdateTask_Inspect(t *testing.T) {
 			c.On("SetStdout", mock.Anything)
 
 			w := new(mocksTmpl.Watcher)
-			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil)
 
 			tf := &Terraform{
-				mu:       &sync.RWMutex{},
 				task:     tc.task,
 				client:   c,
 				resolver: r,
@@ -531,7 +522,6 @@ func TestSetBufferPeriod(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tf := &Terraform{
-				mu:     &sync.RWMutex{},
 				task:   tc.task,
 				logger: logging.NewNullLogger(),
 			}
@@ -579,7 +569,6 @@ func TestInitTaskTemplates(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := new(mocksTmpl.Watcher)
-			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 			tf := &Terraform{
 				fileReader: tc.fileReader,
@@ -669,7 +658,6 @@ func TestDisabledTask(t *testing.T) {
 		// not throw any errors
 
 		tf := &Terraform{
-			mu:      &sync.RWMutex{},
 			task:    &Task{name: "disabled_task", enabled: false},
 			watcher: new(mocksTmpl.Watcher),
 			logger:  logging.NewNullLogger(),
@@ -738,11 +726,9 @@ func TestInitTask(t *testing.T) {
 			c.On("Validate", ctx).Return(tc.validateErr)
 
 			w := new(mocksTmpl.Watcher)
-			w.On("Watching", mock.Anything).Return(false)
 			w.On("Register", mock.Anything).Return(nil).Once()
 
 			tf := &Terraform{
-				mu:         &sync.RWMutex{},
 				task:       &Task{name: "InitTaskTest", enabled: true, workingDir: dirName, logger: logging.NewNullLogger()},
 				client:     c,
 				fileReader: func(string) ([]byte, error) { return []byte{}, nil },

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629
+	github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629 h1:NunPx+DC3CgwMtj9d5mxN0zapv/Q7YlhNJCI8AAqnzA=
-github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e h1:YgGBo8mJz6+iTaPb38YETBp4IvnRk0Lyu1URG79hC5U=
+github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -105,6 +105,22 @@ func (_m *Driver) Task() *driver.Task {
 	return r0
 }
 
+// TemplateIDs provides a mock function with given fields:
+func (_m *Driver) TemplateIDs() []string {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	return r0
+}
+
 // UpdateTask provides a mock function with given fields: ctx, task
 func (_m *Driver) UpdateTask(ctx context.Context, task driver.PatchTask) (driver.InspectPlan, error) {
 	ret := _m.Called(ctx, task)

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -155,17 +155,3 @@ func (_m *Watcher) Watch(_a0 context.Context, _a1 chan string) error {
 
 	return r0
 }
-
-// Watching provides a mock function with given fields: _a0
-func (_m *Watcher) Watching(_a0 string) bool {
-	ret := _m.Called(_a0)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -142,6 +142,20 @@ func (_m *Watcher) WaitCh(_a0 context.Context) <-chan error {
 	return r0
 }
 
+// Watch provides a mock function with given fields: _a0, _a1
+func (_m *Watcher) Watch(_a0 context.Context, _a1 chan string) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, chan string) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Watching provides a mock function with given fields: _a0
 func (_m *Watcher) Watching(_a0 string) bool {
 	ret := _m.Called(_a0)

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -49,8 +49,8 @@ func (_m *Watcher) Complete(_a0 hcat.Notifier) bool {
 	return r0
 }
 
-// Mark provides a mock function with given fields: notifier
-func (_m *Watcher) Mark(notifier hcat.IDer) {
+// MarkForSweep provides a mock function with given fields: notifier
+func (_m *Watcher) MarkForSweep(notifier hcat.IDer) {
 	_m.Called(notifier)
 }
 

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -42,7 +42,6 @@ type Resolver interface {
 type Watcher interface {
 	Watch(context.Context, chan string) error
 	WaitCh(context.Context) <-chan error
-	Watching(string) bool
 	Buffer(hcat.Notifier) bool
 	BufferReset(hcat.Notifier)
 	Mark(notifier hcat.IDer)

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -40,6 +40,7 @@ type Resolver interface {
 // used by this project
 // https://github.com/hashicorp/hcat
 type Watcher interface {
+	Watch(context.Context, chan string) error
 	WaitCh(context.Context) <-chan error
 	Watching(string) bool
 	Buffer(hcat.Notifier) bool

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -44,7 +44,7 @@ type Watcher interface {
 	WaitCh(context.Context) <-chan error
 	Buffer(hcat.Notifier) bool
 	BufferReset(hcat.Notifier)
-	Mark(notifier hcat.IDer)
+	MarkForSweep(notifier hcat.IDer)
 	SetBufferPeriod(min, max time.Duration, tmplIDs ...string)
 	Size() int
 	Stop()

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -108,10 +108,10 @@ func (d *catalogServicesRegistrationQuery) Fetch(clients dep.Clients) (interface
 	default:
 	}
 
-	hcatOpts := &hcat.QueryOptions{
+	hcatOpts := d.opts.Merge(&hcat.QueryOptions{
 		Datacenter: d.dc,
 		Namespace:  d.ns,
-	}
+	})
 	opts := hcatOpts.ToConsulOpts()
 	if len(d.nodeMeta) != 0 {
 		opts.NodeMeta = d.nodeMeta

--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -144,10 +144,10 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	}
 
 	// Fetch all services via catalog services
-	hcatOpts := &hcat.QueryOptions{
+	hcatOpts := d.opts.Merge(&hcat.QueryOptions{
 		Datacenter: d.dc,
 		Namespace:  d.ns,
-	}
+	})
 	opts := hcatOpts.ToConsulOpts()
 	if len(d.nodeMeta) != 0 {
 		opts.NodeMeta = d.nodeMeta

--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -118,7 +118,7 @@ func newServicesRegexQuery(opts []string) (*servicesRegexQuery, error) {
 		_, err := bexpr.CreateFilter(opt)
 		if err != nil {
 			return nil, fmt.Errorf(
-				"health.service: invalid filter: %q: %s", opt, err)
+				"service.regex: invalid filter: %q: %s", opt, err)
 		}
 		filters = append(filters, opt)
 	}
@@ -157,6 +157,12 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 		return nil, nil, errors.Wrap(err, d.String())
 	}
 
+	// Track the indexes of catalog services, not the individual health services
+	rm := &dep.ResponseMetadata{
+		LastIndex:   qm.LastIndex,
+		LastContact: qm.LastContact,
+	}
+
 	// Filter out only the services that match the regex
 	var matchServices []string
 	for name := range catalog {
@@ -166,14 +172,23 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 		matchServices = append(matchServices, name)
 	}
 
-	// Fetch the health of each matching service
-	if d.filter != "" {
-		opts.Filter = d.filter
+	// Fetch the health of each matching service. We aren't tracking the latest
+	// index for each service, only for the catalog, so we'll do synchronous API
+	// requests to fetch the latest
+	hcatOpts = &hcat.QueryOptions{
+		Datacenter: d.dc,
+		Namespace:  d.ns,
+		Filter:     d.filter,
 	}
+	opts = hcatOpts.ToConsulOpts()
+	if len(d.nodeMeta) != 0 {
+		opts.NodeMeta = d.nodeMeta
+	}
+
 	var services []*dep.HealthService
 	for _, s := range matchServices {
 		var entries []*consulapi.ServiceEntry
-		entries, qm, err = clients.Consul().Health().Service(s, "", false, opts)
+		entries, _, err = clients.Consul().Health().Service(s, "", true, opts)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, d.String())
 		}
@@ -206,12 +221,6 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	}
 
 	sort.Stable(ByNodeThenID(services))
-
-	rm := &dep.ResponseMetadata{
-		LastIndex:   qm.LastIndex,
-		LastContact: qm.LastContact,
-	}
-
 	return services, rm, nil
 }
 


### PR DESCRIPTION
### Bug 1
hcat would update the query index for blocking queries as expected since https://github.com/hashicorp/hcat/pull/73, but CTS was not utilizing it in the next API request to Consul and instead using a clean `hcat.QueryOptions` that didn't have reference of the iterating index.

Changes now use the updated query options by using it as the base and merging in the other query parameters. This was my bad missing this detail when I had attempted to fix it earlier https://github.com/hashicorp/consul-terraform-sync/pull/460

Resolves https://github.com/hashicorp/consul-terraform-sync/issues/529

### Bug 2
Fixing the blocking query exposed an existing race condition whether the API request for the health service or catalog-services would return within a [microsecond](https://github.com/hashicorp/hcat/blob/master/watcher.go#L211-L226).

To fix the race condition for multiple API calls pertaining to the same Consul service, there is an added conditional delay to account for service propagation time in a large Consul cluster.

Changes
* Refactored CTS to use new proposed watcher.Watch which provides template information and continuously processes new data.
* CTS now needs context of which hcat template IDs correspond to which task
* CTS checks template rendering more efficiently and only attempts when notified by watcher.Watch
* Removed unnecessary watcher.Watching calls which I mistakenly thought it accepted template IDs but actually expected view IDs which are irrelevant to the caller.
* Remove unnecessary references of `&sync.RWMutex{}` which made updating tests annoying.

### Bug 3
* ServicesRegexQuery was not properly setting the indexes to be used for blocking queries
* ServicesRegexQuery was returning non-passing health services