### PR TITLE
Feature 522 create task handler endpoint

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -35,6 +35,7 @@ func sendError(w http.ResponseWriter, r *http.Request, code int, message string)
 		RequestId: requestIDFromContext(r.Context()),
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	err := json.NewEncoder(w).Encode(taskErr)
 	if err != nil {

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -429,3 +429,483 @@ func TestTaskRequest_ToConfigTaskConfig_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskResponse_String(t *testing.T) {
+	resp := taskResponse{
+		RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+		Task: &oapigen.Task{
+			Name:    "task",
+			Source:  "test-source",
+			Version: config.String(""),
+			BufferPeriod: &oapigen.BufferPeriod{
+				Enabled: config.Bool(false),
+				Max:     config.String("0s"),
+				Min:     config.String("0s"),
+			},
+			Enabled: config.Bool(true),
+			Condition: &oapigen.Condition{
+				CatalogServices: &oapigen.CatalogServicesCondition{
+					Regexp:            config.String(".*"),
+					SourceIncludesVar: config.Bool(true),
+					Datacenter:        config.String("dc2"),
+					Namespace:         config.String("ns2"),
+					NodeMeta: &oapigen.CatalogServicesCondition_NodeMeta{
+						AdditionalProperties: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+				},
+			},
+			SourceInput: &oapigen.SourceInput{
+				Services: &oapigen.ServicesSourceInput{
+					Regexp: config.String(""),
+				},
+			},
+			WorkingDir: config.String("sync-tasks/task"),
+		},
+	}
+
+	actual := fmt.Sprintf("%s", resp)
+	expected := `{"request_id":"e9926514-79b8-a8fc-8761-9b6aaccf1e15",` +
+		`"task":{"buffer_period":{"enabled":false,"max":"0s","min":"0s"},` +
+		`"condition":{"catalog_services":{"datacenter":"dc2","namespace":"ns2",` +
+		`"node_meta":{"key1":"value1","key2":"value2"},"regexp":".*",` +
+		`"source_includes_var":true}},"enabled":true,"name":"task","source":"test-source",` +
+		`"source_input":{"services":{"regexp":""}},"version":"","working_dir":"sync-tasks/task"}}`
+	require.Equal(t, expected, actual)
+}
+
+func TestTaskResponse_taskResponseFromConfigTaskConfig(t *testing.T) {
+	cases := []struct {
+		name             string
+		taskConfig       *config.TaskConfig
+		expectedResponse taskResponse
+	}{
+		{
+			name: "minimum_required_only",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("test-name"),
+				Providers:    []string{},
+				Services:     []string{"api", "web"},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    config.DefaultConditionConfig(),
+				WorkingDir:   config.String("sync-tasks"),
+				SourceInput:  config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "test-name",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Services: &oapigen.ServicesCondition{
+							Regexp: config.String(""),
+						},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{"api", "web"},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "basic_fields_filled",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String("test-description"),
+				Name:         config.String("test-name"),
+				Providers:    []string{"test-provider-1", "test-provider-2"},
+				Services:     []string{"api", "web"},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				TFVersion:    config.String(""),
+				Version:      config.String("test-version"),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    config.DefaultConditionConfig(),
+				WorkingDir:   config.String("sync-tasks"),
+				SourceInput:  config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "test-name",
+					Source:      "test-source",
+					Version:     config.String("test-version"),
+					Description: config.String("test-description"),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Services: &oapigen.ServicesCondition{
+							Regexp: config.String(""),
+						},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{"api", "web"},
+					Providers:  &[]string{"test-provider-1", "test-provider-2"},
+				},
+			},
+		},
+		{
+			name: "with_services_condition",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Providers:    []string{},
+				Services:     []string{},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition: &config.ServicesConditionConfig{
+					config.ServicesMonitorConfig{
+						Regexp:             config.String("^web.*"),
+						Datacenter:         config.String(""),
+						Namespace:          config.String(""),
+						Filter:             config.String(""),
+						CTSUserDefinedMeta: map[string]string{},
+					},
+				},
+				WorkingDir:  config.String("sync-tasks"),
+				SourceInput: config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Services: &oapigen.ServicesCondition{
+							Regexp: config.String("^web.*"),
+						},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "with_catalog_services_condition",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Providers:    []string{},
+				Services:     []string{},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition: &config.CatalogServicesConditionConfig{
+					config.CatalogServicesMonitorConfig{
+						Regexp:            config.String(".*"),
+						SourceIncludesVar: config.Bool(true),
+						Datacenter:        config.String("dc2"),
+						Namespace:         config.String("ns2"),
+						NodeMeta: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+				},
+				WorkingDir:  config.String("sync-tasks"),
+				SourceInput: config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						CatalogServices: &oapigen.CatalogServicesCondition{
+							Regexp:            config.String(".*"),
+							SourceIncludesVar: config.Bool(true),
+							Datacenter:        config.String("dc2"),
+							Namespace:         config.String("ns2"),
+							NodeMeta: &oapigen.CatalogServicesCondition_NodeMeta{
+								AdditionalProperties: map[string]string{
+									"key1": "value1",
+									"key2": "value2",
+								},
+							},
+						},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "with_consul_kv_condition",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Providers:    []string{},
+				Services:     []string{"api", "web"},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition: &config.ConsulKVConditionConfig{
+					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
+						Path:       config.String("key-path"),
+						Recurse:    config.Bool(true),
+						Datacenter: config.String("dc2"),
+						Namespace:  config.String("ns2"),
+					},
+					SourceIncludesVar: config.Bool(true),
+				},
+				WorkingDir:  config.String("sync-tasks"),
+				SourceInput: config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						ConsulKv: &oapigen.ConsulKVCondition{
+							Path:              "key-path",
+							Recurse:           config.Bool(true),
+							Datacenter:        config.String("dc2"),
+							Namespace:         config.String("ns2"),
+							SourceIncludesVar: config.Bool(true),
+						},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{"api", "web"},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "with_schedule_condition",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Providers:    []string{},
+				Services:     []string{"api", "web"},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    &config.ScheduleConditionConfig{config.String("*/10 * * * * * *")},
+				WorkingDir:   config.String("sync-tasks"),
+				SourceInput:  config.DefaultSourceInputConfig(),
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{"api", "web"},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "with_services_source_input",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Services:     []string{},
+				Providers:    []string{},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    &config.ScheduleConditionConfig{config.String("*/10 * * * * * *")},
+				WorkingDir:   config.String("sync-tasks"),
+				SourceInput: &config.ServicesSourceInputConfig{
+					config.ServicesMonitorConfig{
+						Regexp:             config.String("^api$"),
+						Datacenter:         config.String(""),
+						Namespace:          config.String(""),
+						Filter:             config.String(""),
+						CTSUserDefinedMeta: map[string]string{},
+					}},
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+					},
+					SourceInput: &oapigen.SourceInput{
+						Services: &oapigen.ServicesSourceInput{
+							Regexp: config.String("^api$"),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{},
+					Providers:  &[]string{},
+				},
+			},
+		},
+		{
+			name: "with_consul_kv_source_input",
+			taskConfig: &config.TaskConfig{
+				Description:  config.String(""),
+				Name:         config.String("task"),
+				Services:     []string{"api", "web"},
+				Providers:    []string{},
+				Source:       config.String("test-source"),
+				VarFiles:     []string{},
+				Version:      config.String(""),
+				TFVersion:    config.String(""),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    &config.ScheduleConditionConfig{config.String("*/10 * * * * * *")},
+				WorkingDir:   config.String("sync-tasks"),
+				SourceInput: &config.ConsulKVSourceInputConfig{
+					config.ConsulKVMonitorConfig{
+						Path:       config.String("fake-path"),
+						Recurse:    config.Bool(false),
+						Datacenter: config.String(""),
+						Namespace:  config.String(""),
+					},
+				},
+			},
+			expectedResponse: taskResponse{
+				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+				Task: &oapigen.Task{
+					Name:        "task",
+					Source:      "test-source",
+					Version:     config.String(""),
+					Description: config.String(""),
+					BufferPeriod: &oapigen.BufferPeriod{
+						Enabled: config.Bool(true),
+						Max:     config.String("20s"),
+						Min:     config.String("5s"),
+					},
+					Enabled: config.Bool(true),
+					Condition: &oapigen.Condition{
+						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+					},
+					SourceInput: &oapigen.SourceInput{
+						ConsulKv: &oapigen.ConsulKVSourceInput{
+							Path:       "fake-path",
+							Recurse:    config.Bool(false),
+							Datacenter: config.String(""),
+							Namespace:  config.String(""),
+						},
+					},
+					WorkingDir: config.String("sync-tasks"),
+					Services:   &[]string{"api", "web"},
+					Providers:  &[]string{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := taskResponseFromConfigTaskConfig(tc.taskConfig, "e9926514-79b8-a8fc-8761-9b6aaccf1e15")
+			assert.Equal(t, actual, tc.expectedResponse)
+		})
+	}
+}

--- a/api/task_create.go
+++ b/api/task_create.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
+	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/event"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+)
+
+// CreateTask creates a task
+// TODO: handle inclusion of variables map[string]string
+// TODO: handle setting the bufferPeriod of the driver
+func (h *TaskLifeCycleHandler) CreateTask(w http.ResponseWriter, r *http.Request, params oapigen.CreateTaskParams) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	logger := logging.FromContext(r.Context()).Named(createTaskSubsystemName)
+	logger.Trace("create task request received, reading request")
+
+	// Decode the task request
+	var req taskRequest
+	requestID := requestIDFromContext(r.Context())
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		logger.Error("bad request", "error", err, "create_task_request", r.Body)
+		sendError(w, r, http.StatusBadRequest, fmt.Sprintf("error decoding the request: %v", err))
+		return
+	}
+	logger.Trace("create task request", "create_task_request", req)
+
+	// Check if task exists, if it does, do not create again
+	if _, ok := h.drivers.Get(req.Name); ok {
+		logger.Trace("task already exists", "task_name", req.Name)
+		sendError(w, r, http.StatusBadRequest, fmt.Sprintf("task with name %s already exists", req.Name))
+		return
+	}
+
+	// Convert task request to config task config
+	tc, err := req.ToConfigTaskConfig(h.bufferPeriod, h.workingDir)
+	if err != nil {
+		err = fmt.Errorf("error converting create task request to task config, %s", err)
+		logger.Error("error creating task", "error", err)
+		sendError(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Create new driver
+	var d driver.Driver
+	d, err = h.createNewTaskDriver(*tc)
+	if err != nil {
+		err = fmt.Errorf("error creating new task driver, %v", err)
+		logger.Error("error creating task", "error", err)
+		sendError(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	var run string
+	var storedErr error
+	if params.Run != nil {
+		run = string(*params.Run)
+	}
+
+	// Create a new event for tracking infrastructure change required actions
+	task := d.Task()
+	ev, err := event.NewEvent(task.Name(), &event.Config{
+		Providers: task.ProviderNames(),
+		Services:  task.ServiceNames(),
+		Source:    task.Source(),
+	})
+	if err != nil {
+		err = fmt.Errorf("error creating new event, %s", err)
+		logger.Error("error creating task", "error", err)
+		sendError(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+	defer func() {
+		ev.End(storedErr)
+		logger.Trace("adding event", "event", ev.GoString())
+		if err := h.store.Add(*ev); err != nil {
+			// only log error since creating a task occurred successfully by now
+			logger.Error("error storing event", "event", ev.GoString(), "error", err)
+		}
+	}()
+	ev.Start()
+
+	// Initialize the new task
+	storedErr = initNewTask(r.Context(), d, run)
+	if storedErr != nil {
+		err = fmt.Errorf("error initializing new task, %s", storedErr)
+		logger.Error("error creating task", "error", err)
+		sendError(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Add the task driver to the driver list
+	err = h.drivers.Add(req.Name, d)
+	if err != nil {
+		err = fmt.Errorf("error initializing new task, %s", err)
+		logger.Error("error creating task", "error", err)
+		sendError(w, r, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	// Return the task response
+	resp := taskResponseFromConfigTaskConfig(tc, requestID)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		logger.Error("error encoding json", "error", err, "create_task_response", resp)
+	}
+	logger.Trace("task created", "create_task_response", resp)
+}

--- a/api/task_create.go
+++ b/api/task_create.go
@@ -107,7 +107,7 @@ func (h *TaskLifeCycleHandler) CreateTask(w http.ResponseWriter, r *http.Request
 	resp := taskResponseFromConfigTaskConfig(tc, requestID)
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusCreated)
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
 		logger.Error("error encoding json", "error", err, "create_task_response", resp)

--- a/api/task_create_test.go
+++ b/api/task_create_test.go
@@ -1,0 +1,289 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/event"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/driver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCreateTaskRequest = `{
+    "description": "Writes the service name, id, and IP address to a file",
+    "enabled": true,
+    "name": "api-task",
+    "providers": [
+        "local"
+    ],
+    "services": [
+        "api"
+    ],
+    "source": "./example-module"
+}`
+	testTaskName         = "api-task"
+	testWorkingDirectory = "sync-task"
+)
+
+func TestTaskLifeCycleHandler_CreateTask(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		taskName   string
+		request    string
+		run        string
+		statusCode int
+	}{
+		{
+			name:       "happy_path",
+			taskName:   testTaskName,
+			request:    testCreateTaskRequest,
+			run:        "",
+			statusCode: http.StatusCreated,
+		},
+		{
+			name:       "happy_path_run_now",
+			taskName:   testTaskName,
+			request:    testCreateTaskRequest,
+			run:        driver.RunOptionNow,
+			statusCode: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, d := generateTaskLifecycleHandlerTestDependencies()
+
+			// Expected driver mock calls and returns
+			conf := driver.TaskConfig{
+				Name: tc.taskName,
+			}
+			task, err := driver.NewTask(conf)
+			require.NoError(t, err)
+
+			d.On("Task").Return(task)
+			d.On("InitTask", mock.Anything).Return(nil)
+			d.On("RenderTemplate", mock.Anything).Return(true, nil)
+			if tc.run == driver.RunOptionNow {
+				d.On("ApplyTask", mock.Anything).Return(nil)
+			}
+
+			resp := runTestCreateTask(t, c, tc.run, tc.statusCode, tc.request)
+
+			// Task should be added to the drivers list
+			_, ok := c.drivers.Get(tc.taskName)
+			require.True(t, ok)
+
+			// A single event should be registered
+			checkTestEventCount(t, tc.taskName, c.store, 1)
+
+			// Check response
+			decoder := json.NewDecoder(resp.Body)
+			var actual taskResponse
+			err = decoder.Decode(&actual)
+			require.NoError(t, err)
+			expected := generateExpectedResponse(t, tc.request)
+			assert.Equal(t, expected, actual)
+			d.AssertExpectations(t)
+		})
+	}
+}
+
+func TestTaskLifeCycleHandler_CreateTask_BadRequest(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		taskName   string
+		request    string
+		statusCode int
+		message    string
+	}{
+		{
+			name:       "task already exists",
+			taskName:   testTaskName,
+			request:    testCreateTaskRequest,
+			message:    fmt.Sprintf("task with name %s already exists", testTaskName),
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "empty request",
+			taskName:   testTaskName,
+			request:    "",
+			message:    "error decoding the request: EOF",
+			statusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, d := generateTaskLifecycleHandlerTestDependencies()
+
+			err := c.drivers.Add(tc.taskName, d)
+			require.NoError(t, err)
+
+			resp := runTestCreateTask(t, c, "", tc.statusCode, tc.request)
+
+			// Task should be added to the drivers list
+			_, ok := c.drivers.Get(tc.taskName)
+			require.True(t, ok)
+
+			// No events should be registered
+			checkTestEventCount(t, tc.taskName, c.store, 0)
+
+			// Check response
+			decoder := json.NewDecoder(resp.Body)
+			var actual oapigen.ErrorResponse
+			err = decoder.Decode(&actual)
+			require.NoError(t, err)
+
+			expected := generateErrorResponse("", tc.message)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestTaskLifeCycleHandler_CreateTask_InternalError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		taskName   string
+		request    string
+		statusCode int
+		run        string
+		message    string
+		response   taskResponse
+	}{
+		{
+			name:       "task already exists",
+			taskName:   testTaskName,
+			request:    testCreateTaskRequest,
+			message:    "error initializing new task, mock error",
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "invalid run param",
+			taskName:   testTaskName,
+			request:    testCreateTaskRequest,
+			run:        "invalid",
+			message:    "error initializing new task, invalid run option 'invalid'. Please select a valid option",
+			statusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, d := generateTaskLifecycleHandlerTestDependencies()
+
+			d.On("InitTask", mock.Anything).Return(errors.New("mock error"))
+			conf := driver.TaskConfig{
+				Name: tc.taskName,
+			}
+			task, err := driver.NewTask(conf)
+			require.NoError(t, err)
+			d.On("Task").Return(task)
+
+			resp := runTestCreateTask(t, c, tc.run, tc.statusCode, tc.request)
+
+			// Task should not be added to the list
+			_, ok := c.drivers.Get(tc.taskName)
+			require.False(t, ok)
+
+			// Only one event should be registered
+			checkTestEventCount(t, tc.taskName, c.store, 1)
+
+			// Check response
+			decoder := json.NewDecoder(resp.Body)
+			var actual oapigen.ErrorResponse
+			err = decoder.Decode(&actual)
+			require.NoError(t, err)
+
+			expected := generateErrorResponse("", tc.message)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func generateExpectedResponse(t *testing.T, req string) taskResponse {
+	var treq taskRequest
+	err := json.Unmarshal([]byte(req), &treq)
+	require.NoError(t, err)
+
+	tc, err := treq.ToConfigTaskConfig(config.DefaultBufferPeriodConfig(), testWorkingDirectory)
+	require.NoError(t, err)
+
+	tresp := taskResponseFromConfigTaskConfig(tc, "")
+	require.NoError(t, err)
+
+	return tresp
+}
+
+func generateErrorResponse(requestID, message string) oapigen.ErrorResponse {
+	errResp := oapigen.ErrorResponse{
+		Error: oapigen.Error{
+			Message: message,
+		},
+		RequestId: oapigen.RequestID(requestID),
+	}
+
+	return errResp
+}
+
+func generateTaskLifecycleHandlerTestDependencies() (TaskLifeCycleHandlerConfig, *mocks.Driver) {
+	// Create dependencies
+	d := new(mocks.Driver)
+	createNewTaskDriver := func(taskConfig config.TaskConfig) (driver.Driver, error) {
+		return d, nil
+	}
+
+	c := TaskLifeCycleHandlerConfig{
+		store:               event.NewStore(),
+		drivers:             driver.NewDrivers(),
+		bufferPeriod:        config.DefaultBufferPeriodConfig(),
+		workingDir:          testWorkingDirectory,
+		createNewTaskDriver: createNewTaskDriver,
+	}
+
+	return c, d
+}
+
+func runTestCreateTask(t *testing.T, c TaskLifeCycleHandlerConfig, run string, expectedStatus int, request string) *httptest.ResponseRecorder {
+	path := "/v1/tasks"
+	handler := NewTaskLifeCycleHandler(c)
+	r := strings.NewReader(request)
+	req, err := http.NewRequest(http.MethodPost, path, r)
+	require.NoError(t, err)
+	resp := httptest.NewRecorder()
+
+	runOp := oapigen.CreateTaskParamsRun(run)
+	params := oapigen.CreateTaskParams{
+		Run: &runOp,
+	}
+
+	handler.CreateTask(resp, req, params)
+	require.Equal(t, expectedStatus, resp.Code)
+
+	return resp
+}
+
+func checkTestEventCount(t *testing.T, taskName string, store *event.Store, eventCount int) {
+	data := store.Read(taskName)
+	events, ok := data[taskName]
+
+	if eventCount <= 0 {
+		assert.False(t, ok)
+	} else {
+		assert.True(t, ok)
+	}
+	assert.Equal(t, eventCount, len(events), "event count not expected")
+}

--- a/api/task_delete_test.go
+++ b/api/task_delete_test.go
@@ -58,7 +58,12 @@ func TestTaskDelete_DeleteTaskByName(t *testing.T) {
 			store := event.NewStore()
 			err := store.Add(event.Event{TaskName: existingTask})
 			require.NoError(t, err)
-			handler := NewTaskLifeCycleHandler(store, drivers)
+
+			c := TaskLifeCycleHandlerConfig{
+				store:   store,
+				drivers: drivers,
+			}
+			handler := NewTaskLifeCycleHandler(c)
 
 			path := fmt.Sprintf("/v1/tasks/%s", tc.taskName)
 			req, err := http.NewRequest(http.MethodDelete, path, nil)

--- a/api/task_test.go
+++ b/api/task_test.go
@@ -67,7 +67,8 @@ func TestTask_ServeHTTP(t *testing.T) {
 	patchUpdateD := new(mocks.Driver)
 	patchUpdateD.On("UpdateTask", mock.Anything, mock.Anything).
 		Return(driver.InspectPlan{}, nil).Once()
-	drivers.Add("task_patch_update", patchUpdateD)
+	err := drivers.Add("task_patch_update", patchUpdateD)
+	require.NoError(t, err)
 
 	handler := newTaskHandler(event.NewStore(), drivers, "v1")
 
@@ -187,7 +188,8 @@ func TestTask_updateTask(t *testing.T) {
 			d.On("UpdateTask", mock.Anything, mock.Anything).
 				Return(tc.updateTaskRet, tc.updateTaskErr).Once()
 			d.On("Task").Return(&driver.Task{}).Once()
-			drivers.Add("task_a", d)
+			err := drivers.Add("task_a", d)
+			require.NoError(t, err)
 
 			store := event.NewStore()
 			handler := newTaskHandler(store, drivers, "v1")
@@ -221,13 +223,13 @@ func TestTask_updateTask(t *testing.T) {
 			}
 			require.True(t, ok)
 			assert.Len(t, events, 1, "expected one event")
-			event := events[0]
+			e := events[0]
 			if tc.updateTaskErr == nil {
-				assert.True(t, event.Success)
-				assert.Nil(t, event.EventError)
+				assert.True(t, e.Success)
+				assert.Nil(t, e.EventError)
 			} else {
-				assert.False(t, event.Success)
-				assert.NotNil(t, event.EventError)
+				assert.False(t, e.Success)
+				assert.NotNil(t, e.EventError)
 			}
 		})
 	}
@@ -365,7 +367,7 @@ func TestTask_RunOption(t *testing.T) {
 			req, err := http.NewRequest(http.MethodPatch, tc.path, nil)
 			require.NoError(t, err)
 
-			actual, err := runOption(req)
+			actual, err := parseRunOption(req)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -141,8 +141,8 @@ func TestBaseControllerInit(t *testing.T) {
 	}
 }
 
-func TestNewDriverTasks(t *testing.T) {
-	// newDriverTasks function reorganizes various user-defined configuration
+func TestNewDriverTask(t *testing.T) {
+	// newDriverTask function reorganizes various user-defined configuration
 	// blocks into a task object with all the information for the driver to
 	// execute on.
 	testCases := []struct {
@@ -347,11 +347,28 @@ func TestNewDriverTasks(t *testing.T) {
 				}
 			}
 
-			tasks, err := newDriverTasks(tc.conf, providerConfigs)
+			tasks, err := newTestDriverTasks(tc.conf, providerConfigs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.tasks, tasks)
 		})
 	}
+}
+
+func newTestDriverTasks(conf *config.Config, providerConfigs driver.TerraformProviderBlocks) ([]*driver.Task, error) {
+	if conf == nil {
+		return []*driver.Task{}, nil
+	}
+
+	tasks := make([]*driver.Task, len(*conf.Tasks))
+	for i, t := range *conf.Tasks {
+		var err error
+		tasks[i], err = newDriverTask(conf, t, providerConfigs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return tasks, nil
 }
 
 func newTestTask(tb testing.TB, conf driver.TaskConfig) *driver.Task {

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -241,10 +241,13 @@ func (rw *ReadWrite) Once(ctx context.Context) error {
 // ServeAPI runs the API server for the controller
 func (rw *ReadWrite) ServeAPI(ctx context.Context) error {
 	a, err := api.NewAPI(&api.APIConfig{
-		Store:   rw.store,
-		Drivers: rw.drivers,
-		Port:    config.IntVal(rw.conf.Port),
-		TLS:     rw.conf.TLS},
+		Store:               rw.store,
+		Drivers:             rw.drivers,
+		Port:                config.IntVal(rw.conf.Port),
+		TLS:                 rw.conf.TLS,
+		BufferPeriod:        rw.conf.BufferPeriod,
+		WorkingDir:          *rw.conf.WorkingDir,
+		CreateNewTaskDriver: rw.createNewTaskDriver},
 	)
 	if err != nil {
 		return err
@@ -262,7 +265,7 @@ func (rw *ReadWrite) ServeAPI(ctx context.Context) error {
 //     were dependency changes)
 //
 // Note on #2: no event is stored when a dynamic task renders but does not apply.
-// This can occur becauser driver.RenderTemplate() may need to be called multiple
+// This can occur because driver.RenderTemplate() may need to be called multiple
 // times before a template is ready to be applied.
 func (rw *ReadWrite) checkApply(ctx context.Context, d driver.Driver, retry, once bool) (bool, error) {
 	task := d.Task()

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -7,6 +7,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -18,6 +19,21 @@ import (
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	createTestTaskTemplate = `{
+	   "description": "Writes the service name, id, and IP address to a file",
+	   "enabled": true,
+	   "name": "%s",
+	   "providers": [
+	       "local"
+	   ],
+	   "services": [
+	       "%s"
+	   ],
+	   "source": "./test_modules/local_instances_file"
+	}`
 )
 
 // TestE2E_StatusEndpoints tests all of the CTS status endpoints and query
@@ -343,15 +359,16 @@ func TestE2E_TaskEndpoints_Delete(t *testing.T) {
 		moduleTaskConfig(taskName, "./test_modules/local_instances_file"))
 
 	// Delete task
-	u := fmt.Sprintf("http://localhost:%d/%s/tasks/%s",
-		cts.Port(), "v1", taskName)
+	u := fmt.Sprintf("http://localhost:%d/%s/tasks/%s", cts.Port(), "v1", taskName)
 	resp := testutils.RequestHTTP(t, http.MethodDelete, u, "")
+	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Check that the task no longer exists
 	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s",
 		cts.Port(), "v1", taskName)
 	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 
 	// Make a change that would have triggered the task, expect no event
@@ -364,6 +381,7 @@ func TestE2E_TaskEndpoints_Delete(t *testing.T) {
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
 	time.Sleep(defaultWaitForNoEvent)
 	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)
 	validateServices(t, false, []string{"api"}, resourcesPath)
@@ -404,9 +422,9 @@ func TestE2E_TaskEndpoints_Delete_Conflict(t *testing.T) {
 
 	// Attempt to delete the task while running, expect failure
 	time.Sleep(2 * time.Second) // task completion is delayed by 5s
-	u := fmt.Sprintf("http://localhost:%d/%s/tasks/%s",
-		cts.Port(), "v1", taskName)
+	u := fmt.Sprintf("http://localhost:%d/%s/tasks/%s", cts.Port(), "v1", taskName)
 	resp := testutils.RequestHTTP(t, http.MethodDelete, u, "")
+	defer resp.Body.Close()
 	require.Equal(t, http.StatusConflict, resp.StatusCode)
 
 	// Check that the task still exists, wait for it to complete
@@ -416,12 +434,196 @@ func TestE2E_TaskEndpoints_Delete_Conflict(t *testing.T) {
 
 	// Delete task now that it is completed
 	resp = testutils.RequestHTTP(t, http.MethodDelete, u, "")
+	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Check that the task no longer exists
-	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s",
-		cts.Port(), "v1", taskName)
+	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
 	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+// TestE2E_TaskEndpoints_Create tests the create task endpoint. This
+// runs a Consul server and the CTS binary in daemon mode.
+//	POST /v1/tasks
+func TestE2E_TaskEndpoints_Create(t *testing.T) {
+	t.Parallel()
+	// Test creating a task
+	// 1. Start with a task
+	// 2. Create infrastructure change that would trigger new task
+	// 3. Create a new task
+	// 4. Check that the new task exists
+	// 5. Check that the task did not run
+	// 6. Make a service change to a service tracked by the new task, verify an event exists
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "create_task")
+	initialTaskName := "initial-task"
+	cts := ctsSetup(t, srv, tempDir,
+		moduleTaskConfig(initialTaskName, "./test_modules/local_instances_file"))
+
+	// Make a change that would trigger the new task, if it existed
+	taskName := "created-task"
+	serviceName := "testService"
+	service := testutil.TestService{
+		ID:      serviceName,
+		Name:    serviceName,
+		Address: "5.6.7.8",
+		Port:    8080,
+	}
+	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+
+	// Create task
+	u := fmt.Sprintf("http://localhost:%d/v1/tasks", cts.Port())
+
+	createTaskRequest := fmt.Sprintf(createTestTaskTemplate, taskName, serviceName)
+
+	resp := testutils.RequestHTTP(t, http.MethodPost, u, createTaskRequest)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "response body %s", string(bodyBytes))
+
+	// Check that the task has been created, and that a single event was stored
+	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
+	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	e := events(t, taskName, cts.Port())
+	require.Equal(t, len(e), 1)
+
+	// Verify that the task did not run
+	resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)
+	validateServices(t, false, []string{service.ID}, resourcesPath)
+
+	// Make a change that triggers the new task, verify that it runs
+	service = testutil.TestService{
+		ID:      serviceName + "-2",
+		Name:    serviceName,
+		Address: "5.6.7.9",
+		Port:    8080,
+	}
+	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+	api.WaitForEvent(t, cts, taskName, time.Now(), defaultWaitForEvent)
+
+	e = events(t, taskName, cts.Port())
+	require.Equal(t, len(e), 2)
+
+	resourcesPath = filepath.Join(tempDir, taskName, resourcesDir)
+	validateServices(t, true, []string{service.ID}, resourcesPath)
+}
+
+// TestE2E_TaskEndpoints_Create_Run_Now tests the create task endpoint with run now.
+// This runs a Consul server and the CTS binary in daemon mode.
+// POST /v1/tasks
+func TestE2E_TaskEndpoints_Create_Run_Now(t *testing.T) {
+	t.Parallel()
+	// Test creating a task
+	// 1. Start with a task
+	// 2. Create infrastructure change that would trigger new task
+	// 3. Create a new task with run=now
+	// 4. Check that the new task exists
+	// 5. Check that new task ran based on (2) infrastructure change
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "create_task_run_now")
+	initialTaskName := "initial-task"
+	cts := ctsSetup(t, srv, tempDir,
+		moduleTaskConfig(initialTaskName, "./test_modules/local_instances_file"))
+
+	// Make a change that would trigger the new task, if it existed
+	taskName := "created-task"
+	serviceName := "testService"
+	service := testutil.TestService{
+		ID:      serviceName,
+		Name:    serviceName,
+		Address: "5.6.7.8",
+		Port:    8080,
+	}
+	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+
+	// Create task
+	u := fmt.Sprintf("http://localhost:%d/v1/tasks", cts.Port())
+	u = fmt.Sprintf("%s?run=now", u)
+
+	createTaskRequest := fmt.Sprintf(createTestTaskTemplate, taskName, serviceName)
+
+	resp := testutils.RequestHTTP(t, http.MethodPost, u, createTaskRequest)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "response body %s", string(bodyBytes))
+
+	// Check that the task has been created
+	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
+	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Verify that the task did run and only a single event was stored
+	e := events(t, taskName, cts.Port())
+	require.Equal(t, len(e), 1)
+	resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)
+	validateServices(t, true, []string{service.ID}, resourcesPath)
+}
+
+// TestE2E_TaskEndpoints_InvalidSchema tests the create task endpoint with an invalid schema, no task
+// should be created. This runs a Consul server and the CTS binary in daemon mode.
+//	POST /v1/tasks
+func TestE2E_TaskEndpoints_InvalidSchema(t *testing.T) {
+	t.Parallel()
+	// Test deleting a task
+	// 1. Start with a task
+	// 2. Attempt to create a new task with an invalid schema
+	// 3. Check that the new task does not exist
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "create_task_invalid_schema")
+	initialTaskName := "initial-task"
+	cts := ctsSetup(t, srv, tempDir,
+		moduleTaskConfig(initialTaskName, "./test_modules/local_instances_file"))
+
+	// Create a task with invalid source field (boolean instead of string)
+	u := fmt.Sprintf("http://localhost:%d/v1/tasks", cts.Port())
+
+	taskName := "created-task"
+	badRequest := fmt.Sprintf(`{
+	   "description": "Writes the service name, id, and IP address to a file",
+	   "enabled": true,
+	   "name": "%s",
+	   "providers": [
+	       "local"
+	   ],
+	   "services": [
+	       "api"
+	   ],
+	   "source": true
+	}`, taskName)
+
+	resp := testutils.RequestHTTP(t, http.MethodPost, u, badRequest)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	assert.Contains(t, string(bodyBytes), `request body has an error: doesn't match the schema: `+
+		`Error at "/source": Field must be set to string or not be present`)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Check that the task has not been created
+	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
+	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
+	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -486,7 +486,7 @@ func TestE2E_TaskEndpoints_Create(t *testing.T) {
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "response body %s", string(bodyBytes))
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "response body %s", string(bodyBytes))
 
 	// Check that the task has been created, and that a single event was stored
 	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
@@ -561,7 +561,7 @@ func TestE2E_TaskEndpoints_Create_Run_Now(t *testing.T) {
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode, "response body %s", string(bodyBytes))
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "response body %s", string(bodyBytes))
 
 	// Check that the task has been created
 	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -161,6 +161,7 @@ func RequestHTTP(t testing.TB, method, url, body string) *http.Response {
 	req, err := http.NewRequest(method, url, r)
 	require.NoError(t, err)
 
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 	return resp


### PR DESCRIPTION
This PR covers some of the work for creating a new task

### Change summary:
- Controller/controller.go does a lot of initial setup, to allow for this setup to be utilized later in the span of CTS's running lifespan, a new method is required which can create a task driver based on a task config. `createNewTaskDriver`
- Refactor controller to use `createNewTaskDriver` when initializing the controller when CTS starts up
- Create a handler for creating a task `POST /v1/tasks`. Upon receiving a request, the handler will:
1) Create a new task driver using the controllers `createNewTaskDriver` method
2) Initialize the task
3) Render the template
4) Apply the task if RunOption = "now"

### Examples:

**JSON request:**

```json
{
    "description": "Writes the service name, id, and IP address to a file",
    "enabled": true,
    "name": "api-task",
    "providers": [
        "local"
    ],
    "services": [
        "api"
    ],
    "source": "./example-module"
}
```

**CURL Request**
```
curl --location --request POST 'http://localhost:8558/v1/tasks' \
--header 'Content-Type: application/json' \
--data-raw '{
    "description": "Writes the service name, id, and IP address to a file",
    "enabled": true,
    "name": "api-task",
    "providers": [
        "local"
    ],
    "services": [
        "api"
    ],
    "source": "./example-module"
}'
```

**CURL Request With Run=now**
```
curl --location --request POST 'http://localhost:8558/v1/tasks?run=now' \
--header 'Content-Type: application/json' \
--data-raw '{
    "description": "Writes the service name, id, and IP address to a file",
    "enabled": true,
    "name": "api-task",
    "providers": [
        "local"
    ],
    "services": [
        "api"
    ],
    "source": "./example-module"
}'
```

**Response**
```JSON
{
    "request_id": "5756036a-681c-df73-e6b9-ffb8d9b4ec0c",
    "task": {
        "buffer_period": {
            "enabled": true,
            "max": "25s",
            "min": "5s"
        },
        "condition": {
            "services": {
                "regexp": ""
            }
        },
        "description": "Writes the service name, id, and IP address to a file",
        "enabled": true,
        "name": "api-task",
        "providers": [
            "local"
        ],
        "services": [
            "api"
        ],
        "source": "./example-module",
        "source_input": {
            "services": {
                "regexp": ""
            }
        },
        "version": "",
        "working_dir": "create-task/api-task"
    }
}
```

### Future Work for this release

**Handling Buffer Periods**
- Currently calling the drivers `SetBufferPeriod` method is not behaving as expected.
- Currently tasks created through the `/v1/tasks` will trigger on all changes and do not honour even the global buffer period

**Handling Variables**
- Design of create task endpoint requires `variables` field of type `map[string]string` be an optional field
- Currently this field will not be supported as the driver only allows for a variables files, not strings or maps of strings

part of #522 
