### PR TITLE
Add `names` config field to `condition "services"` and `source_input "services"`

### DIFF
--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -141,8 +141,9 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 					},
 					Enabled: config.Bool(true),
 					Condition: &config.ServicesConditionConfig{
-						config.ServicesMonitorConfig{
+						ServicesMonitorConfig: config.ServicesMonitorConfig{
 							Regexp:             config.String("^web.*"),
+							Names:              []string{},
 							Datacenter:         config.String(""),
 							Namespace:          config.String(""),
 							Filter:             config.String(""),
@@ -345,13 +346,15 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 					Condition:  &config.ScheduleConditionConfig{config.String("*/10 * * * * * *")},
 					WorkingDir: config.String("sync-tasks/task"),
 					SourceInput: &config.ServicesSourceInputConfig{
-						config.ServicesMonitorConfig{
+						ServicesMonitorConfig: config.ServicesMonitorConfig{
 							Regexp:             config.String("^api$"),
+							Names:              []string{},
 							Datacenter:         config.String(""),
 							Namespace:          config.String(""),
 							Filter:             config.String(""),
 							CTSUserDefinedMeta: map[string]string{},
-						}},
+						},
+					},
 				},
 			},
 		},

--- a/config/condition_services.go
+++ b/config/condition_services.go
@@ -73,7 +73,11 @@ func (c *ServicesConditionConfig) Validate() error {
 	if c == nil { // config not required, return early
 		return nil
 	}
-	return c.ServicesMonitorConfig.Validate()
+	if err := c.ServicesMonitorConfig.Validate(); err != nil {
+		return fmt.Errorf("error validating `condition \"services\"` block: %s",
+			err)
+	}
+	return nil
 }
 
 // GoString defines the printable version of this struct.

--- a/config/condition_services_test.go
+++ b/config/condition_services_test.go
@@ -149,7 +149,7 @@ func TestServicesConditionConfig_Finalize(t *testing.T) {
 			&ServicesConditionConfig{},
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
-					Regexp:             String(""),
+					Regexp:             nil,
 					Datacenter:         String(""),
 					Namespace:          String(""),
 					Filter:             String(""),

--- a/config/condition_services_test.go
+++ b/config/condition_services_test.go
@@ -150,6 +150,7 @@ func TestServicesConditionConfig_Finalize(t *testing.T) {
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
 					Regexp:             nil,
+					Names:              []string{},
 					Datacenter:         String(""),
 					Namespace:          String(""),
 					Filter:             String(""),
@@ -238,8 +239,8 @@ func TestServicesCondition_GoString(t *testing.T) {
 					},
 				},
 			},
-			"&ServicesConditionConfig{&ServicesMonitorConfig{Regexp:^api$, Datacenter:dc, " +
-				"Namespace:namespace, Filter:filter, " +
+			"&ServicesConditionConfig{&ServicesMonitorConfig{Regexp:^api$, Names:[], " +
+				"Datacenter:dc, Namespace:namespace, Filter:filter, " +
 				"CTSUserDefinedMeta:map[key:value]}}",
 		},
 	}

--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -88,6 +88,7 @@ task {
 			&ServicesConditionConfig{
 				ServicesMonitorConfig{
 					Regexp:     String(".*"),
+					Names:      []string{},
 					Datacenter: String("dc"),
 					Namespace:  String("namespace"),
 					Filter:     String("filter"),

--- a/config/monitor_services_test.go
+++ b/config/monitor_services_test.go
@@ -237,7 +237,7 @@ func TestServicesMonitorConfig_Finalize(t *testing.T) {
 			[]string{},
 			&ServicesMonitorConfig{},
 			&ServicesMonitorConfig{
-				Regexp:             String(""),
+				Regexp:             nil,
 				Datacenter:         String(""),
 				Namespace:          String(""),
 				Filter:             String(""),
@@ -272,7 +272,7 @@ func TestServicesMonitorConfig_Finalize(t *testing.T) {
 			[]string{"api"},
 			&ServicesMonitorConfig{},
 			&ServicesMonitorConfig{
-				Regexp:             String(""),
+				Regexp:             nil,
 				Datacenter:         String(""),
 				Namespace:          String(""),
 				Filter:             String(""),
@@ -307,6 +307,13 @@ func TestServicesMonitorConfig_Validate(t *testing.T) {
 			false,
 			&ServicesMonitorConfig{
 				Regexp: String(".*"),
+			},
+		},
+		{
+			"valid_regexp_empty_string",
+			false,
+			&ServicesMonitorConfig{
+				Regexp: String(""),
 			},
 		},
 		{

--- a/config/source_input_services.go
+++ b/config/source_input_services.go
@@ -72,7 +72,10 @@ func (c *ServicesSourceInputConfig) Validate() error {
 	if c == nil { // config not required, return early
 		return nil
 	}
-	return c.ServicesMonitorConfig.Validate()
+	if err := c.ServicesMonitorConfig.Validate(); err != nil {
+		return fmt.Errorf("error validating `source_input \"services\"`: %s", err)
+	}
+	return nil
 }
 
 // GoString defines the printable version of this struct.

--- a/config/source_input_services_test.go
+++ b/config/source_input_services_test.go
@@ -150,7 +150,7 @@ func TestServicesSourceInputConfig_Finalize(t *testing.T) {
 			&ServicesSourceInputConfig{},
 			&ServicesSourceInputConfig{
 				ServicesMonitorConfig{
-					Regexp:             String(""),
+					Regexp:             nil,
 					Datacenter:         String(""),
 					Namespace:          String(""),
 					Filter:             String(""),

--- a/config/source_input_services_test.go
+++ b/config/source_input_services_test.go
@@ -151,6 +151,7 @@ func TestServicesSourceInputConfig_Finalize(t *testing.T) {
 			&ServicesSourceInputConfig{
 				ServicesMonitorConfig{
 					Regexp:             nil,
+					Names:              []string{},
 					Datacenter:         String(""),
 					Namespace:          String(""),
 					Filter:             String(""),
@@ -237,6 +238,7 @@ func TestGoString(t *testing.T) {
 			"&ServicesSourceInputConfig{" +
 				"&ServicesMonitorConfig{" +
 				"Regexp:^api$, " +
+				"Names:[], " +
 				"Datacenter:dc2, " +
 				"Namespace:ns2, " +
 				"Filter:some-filter, " +

--- a/config/source_input_test.go
+++ b/config/source_input_test.go
@@ -89,6 +89,7 @@ func TestSourceInput_DecodeConfig_Success(t *testing.T) {
 			expected: &ServicesSourceInputConfig{
 				ServicesMonitorConfig{
 					Regexp:             String(".*"),
+					Names:              []string{},
 					Datacenter:         String("dc2"),
 					Namespace:          String("ns2"),
 					Filter:             String("some-filter"),

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -449,6 +449,7 @@ func TestTaskConfig_Finalize(t *testing.T) {
 				SourceInput: &ServicesSourceInputConfig{
 					ServicesMonitorConfig{
 						Regexp:             String("^api$"),
+						Names:              []string{},
 						Datacenter:         String(""),
 						Namespace:          String(""),
 						Filter:             String(""),

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -571,7 +571,7 @@ func TestTaskConfig_Validate(t *testing.T) {
 		},
 		// services condition test case
 		{
-			"valid: services cond: cond.regexp configured & no services",
+			"valid: services cond: no services",
 			&TaskConfig{
 				Name:   String("task"),
 				Source: String("source"),
@@ -584,26 +584,16 @@ func TestTaskConfig_Validate(t *testing.T) {
 			true,
 		},
 		{
-			"invalid: services cond: empty regexp configured & no services",
-			&TaskConfig{
-				Name:   String("task"),
-				Source: String("source"),
-				Condition: &ServicesConditionConfig{
-					ServicesMonitorConfig{
-						Regexp: String(""),
-					},
-				},
-			},
-			false,
-		},
-		{
-			"invalid: services cond: cond.regexp configured & services configured",
+			"invalid: services cond: services configured",
 			&TaskConfig{
 				Name:     String("task"),
 				Source:   String("source"),
 				Services: []string{"api"},
 				Condition: &ServicesConditionConfig{
-					ServicesMonitorConfig{Regexp: String("^service.*")}},
+					ServicesMonitorConfig{
+						Regexp: String(""),
+					},
+				},
 			},
 			false,
 		},
@@ -653,20 +643,6 @@ func TestTaskConfig_Validate(t *testing.T) {
 			false,
 		},
 		{
-			"invalid: sched cond: no services & nil source_input regex",
-			&TaskConfig{
-				Name:      String("task"),
-				Source:    String("source"),
-				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
-				SourceInput: &ServicesSourceInputConfig{
-					ServicesMonitorConfig{
-						Regexp: nil,
-					},
-				},
-			},
-			false,
-		},
-		{
 			"invalid: sched cond: services source_input configured & services configured",
 			&TaskConfig{
 				Name:      String("task"),
@@ -674,7 +650,8 @@ func TestTaskConfig_Validate(t *testing.T) {
 				Services:  []string{"api"},
 				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
 				SourceInput: &ServicesSourceInputConfig{
-					ServicesMonitorConfig{Regexp: String(".*")}},
+					ServicesMonitorConfig{Names: []string{"api"}},
+				},
 			},
 			false,
 		},


### PR DESCRIPTION
Add new `names` config. Examples:

```
source_input "services" {
  names = ["api", "web"]
}
```
```
condition "services" {
  names = ["db"]
}
```

Changes:
- Add support regexp="" as a valid regex (needed to determine if regexp is configured or not)
- Add names field
- Update `condition "services"` and `source_input "services"` relationship with `task.services` list such that condition nor source_input can be configured when services list is configured
  - This is backwards breaking but in a non-meaningful way
  - Users were previously not permitted to configure condition/source_input services with a regexp along with task.services
  - With this change, users can no longer configure an empty condition/source_input services
     ```
     task {
       name = "task"
       description = "example of empty cond with services - no longer permitted"
       services = ["api"]
       condition "services {
       }
     }
     ```