### PR TITLE
Enable Security Scanning (CRT)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:   
+    branches:
       # Push events on main branch
       - main
       # Push events to branches matching refs/heads/release/**

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,13 @@ name: build
 on:
   push:
     # Sequence of patterns matched against refs/heads
-    branches:    
-      # Push events on main branch
-      - main
-      # Push events to branches matching refs/heads/release/**
-      - 'release/**'
+    branches:   
+      # push to enable-security-scan for testing
+      - enable-security-scan 
+      # # Push events on main branch
+      # - main
+      # # Push events to branches matching refs/heads/release/**
+      # - 'release/**'
 
 env:
   PKG_NAME: "consul-terraform-sync"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,10 @@ on:
   push:
     # Sequence of patterns matched against refs/heads
     branches:   
-      # push to enable-security-scan for testing
-      - enable-security-scan 
-      # # Push events on main branch
-      # - main
-      # # Push events to branches matching refs/heads/release/**
-      # - 'release/**'
+      # Push events on main branch
+      - main
+      # Push events to branches matching refs/heads/release/**
+      - 'release/**'
 
 env:
   PKG_NAME: "consul-terraform-sync"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,7 +4,7 @@ project "consul-terraform-sync" {
   team = "consul api tooling"
   slack {
     # feed-consul-api-gh
-    notification_channel = "C026W707YHJ" 
+    notification_channel = "C026W707YHJ"
   }
   github {
     organization = "hashicorp"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,7 +10,7 @@ project "consul-terraform-sync" {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
     release_branches = [
-        enable-security-scan
+        "enable-security-scan"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,13 +4,16 @@ project "consul-terraform-sync" {
   team = "consul api tooling"
   slack {
     # feed-consul-api-gh
-    notification_channel = "C01A3A54G0L" 
+    notification_channel = "C026W707YHJ" 
   }
   github {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
     release_branches = [
-        "enable-security-scan"
+      "main",
+      "release/0.2.x",
+      "release/0.3.x",
+      "release/0.4.x"
     ]
   }
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = true
+	secrets      = true
+}
+
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = true
+	nvd          = true
+}

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,7 +1,7 @@
 container {
 	dependencies = true
 	alpine_secdb = true
-	secrets      = true
+	secrets      = false
 }
 
 binary {

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,7 +5,7 @@ container {
 }
 
 binary {
-	secrets      = true
+	secrets      = false
 	go_modules   = true
 	osv          = true
 	oss_index    = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13 as default
+FROM alpine:3.15.0 as default
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.0 as default
+FROM alpine:3 as default
 
 # NAME and VERSION are the name of the software in releases.hashicorp.com
 # and the version to download. Example: NAME=consul VERSION=1.2.3.


### PR DESCRIPTION
What this PR does is it enables security scanning (owned by the Security team) for this repository. This is a part of the Common Release Tooling (CRT) effort which `enables a consistent workflow for security scanning that can be used across products and services. It provides a single abstraction point to allow us integrate our own scanning capabilities, as well as leverage external tools and APIs from vendors, open source, or free-to-use projects.` Learn more about HashiCorp's security-scanner [here](https://github.com/hashicorp/security-scanner/).

While running the security scan tests, I ran into several [false positives](https://github.com/hashicorp/crt-workflows-common/runs/4472723819?check_suite_focus=true) with `secrets` in the [binary](https://github.com/hashicorp/consul-terraform-sync/blob/51414c677cbe369db24043e8d2f84ba502b7a58e/.release/security-scan.hcl#L8) and [container](https://github.com/hashicorp/consul-terraform-sync/blob/51414c677cbe369db24043e8d2f84ba502b7a58e/.release/security-scan.hcl#L4) stanzas in the security-scan.hcl file. This is a known issue with Security and they suggested me to set these to `false` aka off for the time being. Once Security fixes this, I will test it again and raise a new PR to turn those back on to `true`

You'll also see that I had to upgrade the Dockerfile to use `alpine:3.15.0` as the older version caused the security-scanner to pick up some vulnerabilities, CVEs to be specific. See error outputs [here](https://github.com/hashicorp/crt-workflows-common/runs/4473388427?check_suite_focus=true). We worked with Security and they scanned different versions of the alpine base image and concluded that 3.15.0 was clean and suggested CTS to upgrade to that version to avoid any friction and potential vulnerabilities in the future and simply tidy up the container. 

With that being said, with the alpine version being updated and the secret scanning turned off (for now) the tests with security-scan are [passing](https://github.com/hashicorp/crt-workflows-common/actions/runs/1560728556) at the verify step which is the last workflow event. 

If anyone needs any further clarification or if nothing makes sense, feel free to comment or reach out to me! ❤️ 