### PR TITLE
added response writers and middleware

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	middleware "github.com/deepmap/oapi-codegen/pkg/chi-middleware"
 	"github.com/go-chi/chi/v5"
 	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
 	"github.com/hashicorp/consul-terraform-sync/config"
@@ -127,19 +126,10 @@ func NewAPI(conf *APIConfig) (*API, error) {
 	})
 
 	r.Group(func(r chi.Router) {
-		swagger, err := oapigen.GetSwagger()
-		if err != nil {
-			logger.Error("Error loading swagger spec", "error", err)
-			panic("this should never error")
-		}
-
-		// Clear out the servers array in the swagger spec. It is recommended to do this so that it skips validating
-		// that server names match.
-		swagger.Servers = nil
-
 		// Use our validation middleware to check all requests against the
 		// OpenAPI schema.
-		r.Use(middleware.OapiRequestValidator(swagger))
+		r.Use(withPlaintextErrorToJson)
+		r.Use(withSwaggerValidate)
 
 		// Generated Endpoints
 		c := TaskLifeCycleHandlerConfig{

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -30,7 +30,7 @@ func withLogging(next http.Handler) http.Handler {
 		}
 
 		// UUID was successfully created, so add it now
-		logger = logger.With("reqID", reqID)
+		logger = logger.With("request_id", reqID)
 		ts := time.Now()
 
 		// Log info before calling the next handler

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"time"
 
+	middleware "github.com/deepmap/oapi-codegen/pkg/chi-middleware"
+	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
 	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/go-uuid"
 )
@@ -13,6 +16,8 @@ const (
 	timeFormat = "2006-01-02T15:04:05.000Z0700"
 )
 
+// withLogging creates a request ID and logger and adds them to the context passed to the
+// next handler. It also handles logging incoming requests and once a request has finished processing.
 func withLogging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Generate a UUID to be included with all log messages for an incoming request
@@ -38,14 +43,22 @@ func withLogging(next http.Handler) http.Handler {
 
 		r = r.WithContext(logging.WithContext(r.Context(), logger))
 		r = r.WithContext(requestIDWithContext(r.Context(), reqID))
-		next.ServeHTTP(w, r)
+
+		// Use logger response writer so that the status code can be captured for logging
+		rw := &loggerResponseWriter{
+			ResponseWriter: w,
+		}
+
+		next.ServeHTTP(rw, r)
 
 		// Log info on exit
 		logger.Info("request complete",
-			"duration", fmt.Sprintf("%dus", time.Since(ts).Microseconds()))
+			"duration", fmt.Sprintf("%dus", time.Since(ts).Microseconds()),
+			"status_code", rw.statusCode)
 	})
 }
 
+// withCORS adds the required CORS headers for interacting with web pages
 func withCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -57,4 +70,35 @@ func withCORS(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		}
 	})
+}
+
+// withPlaintextErrorToJson processes any plain text errors and converts them
+// to the CTS JSON error response
+func withPlaintextErrorToJson(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rw := &plaintextErrorToJsonResponseWriter{
+			ResponseWriter: w,
+			buf:            &bytes.Buffer{},
+			requestID:      requestIDFromContext(r.Context()),
+		}
+
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// withSwaggerValidate validates incoming requests against the openAPI schema.
+// This schema is generated as part of the openAPI generated code.
+func withSwaggerValidate(next http.Handler) http.Handler {
+	swagger, err := oapigen.GetSwagger()
+	if err != nil {
+		// This should never error
+		panic("there was an error getting the swagger")
+	}
+
+	// Clear out the servers array in the swagger spec. It is recommended to do this so that it skips validating
+	// that server names match.
+	swagger.Servers = nil
+
+	f := middleware.OapiRequestValidator(swagger)
+	return f(next)
 }

--- a/api/response_writers.go
+++ b/api/response_writers.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
+)
+
+// checkStatusCodeCategory checks if a given status code matches
+// a particular category. It does this by taking the first digit
+// of a category (i.e. 4 for 400, 401, etc.) and checking if the first
+// digit of the status code matches.
+// eg. category = 4, statusCode = 401 checkStatusCodeCategory returns true
+func checkStatusCodeCategory(category int, statusCode int) bool {
+	var i int
+	for i = statusCode; i >= 10; i = i / 10 {
+	}
+
+	return category == i
+}
+
+// plaintextErrorToJsonResponseWriter catches plaintext error responses and
+// reprocesses them to use the correct JSON error response
+type plaintextErrorToJsonResponseWriter struct {
+	http.ResponseWriter
+	buf        *bytes.Buffer
+	requestID  oapigen.RequestID
+	statusCode int
+}
+
+// Header handles setting the header, if the content type
+// is plaintext, it sets the header to json instead
+func (r *plaintextErrorToJsonResponseWriter) Header() http.Header {
+	h := r.ResponseWriter.Header()
+	if h.Get("content-Type") == "text/plain; charset=utf-8" {
+		h.Set("content-Type", "application/json")
+	}
+
+	return h
+}
+
+// WriteHeader handles writing the header and captures the
+// status code
+func (r *plaintextErrorToJsonResponseWriter) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+// Write checks if the status code is a 4xx and if it is plaintext. If it is plaintext,
+// it converts the error into the correct JSON error response
+func (r *plaintextErrorToJsonResponseWriter) Write(p []byte) (int, error) {
+	if checkStatusCodeCategory(4, r.statusCode) {
+		var errResp oapigen.ErrorResponse
+		if err := json.Unmarshal(p, &errResp); err != nil {
+			errResp = oapigen.ErrorResponse{
+				Error: oapigen.Error{
+					Message: string(p),
+				},
+				RequestId: r.requestID,
+			}
+
+			b, err := json.Marshal(errResp)
+			if err != nil {
+				return 0, err
+			}
+
+			return r.ResponseWriter.Write(b)
+		}
+	}
+
+	return r.ResponseWriter.Write(p)
+}
+
+// loggerResponseWriter is a wrapper around the stand http response writer that
+// captures the status code for use in logging
+type loggerResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// WriteHeader handles writing the header and captures the
+// status code
+func (r *loggerResponseWriter) WriteHeader(code int) {
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -616,9 +616,14 @@ func TestE2E_TaskEndpoints_InvalidSchema(t *testing.T) {
 	resp := testutils.RequestHTTP(t, http.MethodPost, u, badRequest)
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
-	assert.Contains(t, string(bodyBytes), `request body has an error: doesn't match the schema: `+
-		`Error at "/source": Field must be set to string or not be present`)
 	require.NoError(t, err)
+
+	var errorResponse oapigen.ErrorResponse
+	err = json.Unmarshal(bodyBytes, &errorResponse)
+	require.NoError(t, err)
+
+	assert.Contains(t, errorResponse.Error.Message, `request body has an error: doesn't match the schema: `+
+		`Error at "/source": Field must be set to string or not be present`)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	// Check that the task has not been created


### PR DESCRIPTION
This PR adds new middleware for REST request handling. 

1) refactor the swagger middleware 
2) new response writer and middleware for handling atypical/non-json error responses.
3) new response writer for getting the status code so it can be logged

### Background
 
**Error Plaintext**
The swagger 3rd party middleware writes out a plaintext error response if validation fails:
`request body has an error: doesn't match the schema: Error at "/enabled": Field must be set to boolean or not be present`

With the new response writer, this plaintext response is caught and re-processed into the correct CTS JSON error response:
```json
{
    "error": {
        "message": "request body has an error: doesn't match the schema: Error at \"/enabled\": Field must be set to boolean or not be present\n"
    },
    "request_id": "87c2e422-1822-70c4-2091-5ebd0620431e"
}
```

**Status Code Logging**
Before: `2021-12-20T08:40:34.227-0800 [INFO]  api: request complete: reqID=87c2e422-1822-70c4-2091-5ebd0620431e duration=282us`
After: `2021-12-20T08:40:34.227-0800 [INFO]  api: request complete: reqID=87c2e422-1822-70c4-2091-5ebd0620431e duration=282us status_code=400`