### PR TITLE
Support condition/source_input "services" regexp empty string

### DIFF
--- a/templates/tftmpl/template_services_regex.go
+++ b/templates/tftmpl/template_services_regex.go
@@ -32,9 +32,6 @@ func (t ServicesRegexTemplate) IsServicesVar() bool {
 func (t ServicesRegexTemplate) appendModuleAttribute(*hclwrite.Body) {}
 
 func (t ServicesRegexTemplate) appendTemplate(w io.Writer) error {
-	if t.Regexp == "" {
-		return nil
-	}
 	q := t.hcatQuery()
 
 	if t.SourceIncludesVar {
@@ -66,9 +63,8 @@ func (t ServicesRegexTemplate) SourceIncludesVariable() bool {
 func (t ServicesRegexTemplate) hcatQuery() string {
 	var opts []string
 
-	if t.Regexp != "" {
-		opts = append(opts, fmt.Sprintf("regexp=%s", t.Regexp))
-	}
+	// Support regexp == "" (same as a wildcard)
+	opts = append(opts, fmt.Sprintf("regexp=%s", t.Regexp))
 
 	if t.Datacenter != "" {
 		opts = append(opts, fmt.Sprintf("dc=%s", t.Datacenter))

--- a/templates/tftmpl/template_services_regex_test.go
+++ b/templates/tftmpl/template_services_regex_test.go
@@ -55,11 +55,20 @@ services = {
 `,
 		},
 		{
-			"unconfigured & includes_var false",
+			"regexp empty string",
 			&ServicesRegexTemplate{
+				Regexp:            "",
 				SourceIncludesVar: false,
 			},
-			"",
+			`
+{{- with $srv := servicesRegex "regexp=" }}
+  {{- range $s := $srv}}
+  "{{ joinStrings "." .ID .Node .Namespace .NodeDatacenter }}" = {
+{{ HCLService $s | indent 4 }}
+  },
+  {{- end}}
+{{- end}}
+`,
 		},
 	}
 
@@ -85,6 +94,13 @@ func TestServicesRegexTemplate_hcatQuery(t *testing.T) {
 				Regexp: ".*",
 			},
 			`"regexp=.*"`,
+		},
+		{
+			"valid regexp empty string",
+			&ServicesRegexTemplate{
+				Regexp: "",
+			},
+			`"regexp="`,
 		},
 		{
 			"all_parameters",

--- a/templates/tftmpl/tmplfunc/services_regex_test.go
+++ b/templates/tftmpl/tmplfunc/services_regex_test.go
@@ -32,6 +32,14 @@ func TestNewServicesRegexQuery(t *testing.T) {
 			true,
 		},
 		{
+			"regexp empty string",
+			[]string{"regexp="},
+			&servicesRegexQuery{
+				regexp: regexp.MustCompile(""),
+			},
+			false,
+		},
+		{
 			"regexp",
 			[]string{"regexp=.*"},
 			&servicesRegexQuery{


### PR DESCRIPTION
Previously updated condition/source_input "services" regexp configuration to
support an empty string (which is behaves the same as a wildcard)
Commit: https://github.com/hashicorp/consul-terraform-sync/pull/543/commits/89785a332c572fc24c248927cd978814226e7175

Update templating, which did a check for `regexp == ""`, to allow template and hcat
query to be appended