### PR TITLE
Add condition/source_input "services" names field empty string validation

### DIFF
--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -157,12 +157,23 @@ func (c *ServicesMonitorConfig) Validate() error {
 		return fmt.Errorf("either the regexp or names field must be configured")
 	}
 
+	// Validate regex
 	if regexConfigured {
 		if _, err := regexp.Compile(StringVal(c.Regexp)); err != nil {
 			return fmt.Errorf("unable to compile services regexp: %s", err)
 		}
 	} else {
 		c.Regexp = String("") // Finalize
+	}
+
+	// Check that names does not contain empty strings
+	if namesConfigured {
+		for _, name := range c.Names {
+			if name == "" {
+				return fmt.Errorf("names field includes empty string(s). " +
+					"services names cannot be empty")
+			}
+		}
 	}
 
 	return nil

--- a/config/monitor_services_test.go
+++ b/config/monitor_services_test.go
@@ -386,6 +386,13 @@ func TestServicesMonitorConfig_Validate(t *testing.T) {
 			},
 		},
 		{
+			"invalid_empty_string_names",
+			true,
+			&ServicesMonitorConfig{
+				Names: []string{"api", ""},
+			},
+		},
+		{
 			"invalid_both_regexp_and_names_configured",
 			true,
 			&ServicesMonitorConfig{


### PR DESCRIPTION
Check that services names in `names` field are not empty strings