### PR TITLE
Only store events on task creation if the task ran successfully

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -238,7 +238,7 @@ func decodeBody(body []byte) (UpdateTaskConfig, error) {
 	return conf, nil
 }
 
-func initNewTask(ctx context.Context, d driver.Driver, runOption string) error {
+func initNewTask(ctx context.Context, d driver.Driver) error {
 	logger := logging.FromContext(ctx)
 
 	err := d.InitTask(ctx)
@@ -265,15 +265,6 @@ func initNewTask(ctx context.Context, d driver.Driver, runOption string) error {
 
 	// TODO: Set the buffer period
 	// d.SetBufferPeriod()
-
-	var storedErr error
-	if runOption == driver.RunOptionNow {
-		logger.Trace("run now option", "task_name", taskName)
-		err := d.ApplyTask(ctx)
-		if err != nil {
-			return storedErr
-		}
-	}
 
 	return nil
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -489,15 +489,25 @@ func TestE2E_TaskEndpoints_Create(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, resp.StatusCode, "response body %s", string(bodyBytes))
 
-	// Check that the task has been created, and that a single event was stored
+	// Check that the task has been created
 	s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", taskName)
 	resp = testutils.RequestHTTP(t, http.MethodGet, s, "")
-
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	e := events(t, taskName, cts.Port())
-	require.Equal(t, len(e), 1)
+	// Check that the status of the task is unknown because task has not run
+	var taskStatuses map[string]api.TaskStatus
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&taskStatuses)
+	require.NoError(t, err)
+	task, ok := taskStatuses[taskName]
+	require.True(t, ok)
+	assert.True(t, task.Enabled)
+	assert.Equal(t, "unknown", task.Status)
+
+	// Check no events stored
+	e := eventCount(t, taskName, cts.Port())
+	require.Equal(t, e, 0)
 
 	// Verify that the task did not run
 	resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)
@@ -513,8 +523,8 @@ func TestE2E_TaskEndpoints_Create(t *testing.T) {
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
 	api.WaitForEvent(t, cts, taskName, time.Now(), defaultWaitForEvent)
 
-	e = events(t, taskName, cts.Port())
-	require.Equal(t, len(e), 2)
+	e = eventCount(t, taskName, cts.Port())
+	require.Equal(t, e, 1)
 
 	resourcesPath = filepath.Join(tempDir, taskName, resourcesDir)
 	validateServices(t, true, []string{service.ID}, resourcesPath)


### PR DESCRIPTION
Previously, we were always creating an event. If the task was not created in the end,
we would then have an oprhaned event that had no driver associated with it. This caused
an error when getting the overall event statuses.

For a task that is created and not run, the status will be unknown until the first run
is triggered.

Changes:
- Moved where we call the task apply out of the initNewTask method and into the main creation method
- Update storing event to only happen if the task was applied successfully with `?run=now`
- Moved the initialization to happen before checking whether `?run=inspect`