### PR TITLE
Auto-approve option for delete and enable commands

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -45,6 +45,8 @@ const (
 	FlagClientCert = "client-cert"
 	FlagClientKey  = "client-key"
 	FlagSSLVerify  = "ssl-verify"
+
+	FlagAutoApprove = "auto-approve"
 )
 
 func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
@@ -72,6 +74,11 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 		"This can also be specified using the %s environment variable.", api.EnvTLSSSLVerify))
 
 	m.flags.SetOutput(ioutil.Discard)
+
+	return m.flags
+}
+
+func (m *meta) setHelpOptions() {
 	m.flags.VisitAll(func(f *flag.Flag) {
 		option := fmt.Sprintf("  %s %s\n    %s\n", f.Name, f.Value, f.Usage)
 		m.helpOptions = append(m.helpOptions, option)
@@ -79,8 +86,6 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 	if len(m.helpOptions) == 0 {
 		m.helpOptions = append(m.helpOptions, "No options are currently available")
 	}
-
-	return m.flags
 }
 
 func (m *meta) setFlagsUsage(flags *flag.FlagSet, args []string, help string) {

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -34,6 +34,7 @@ func (c taskDisableCommand) Name() string {
 
 // Help returns the command's usage, list of flags, and examples
 func (c *taskDisableCommand) Help() string {
+	c.meta.setHelpOptions()
 	helpText := fmt.Sprintf(`
 Usage: consul-terraform-sync task disable [options] <task name>
 

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -129,13 +129,6 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 			outputContains: "Cancelled enabling task",
 			expectEnabled:  false,
 		},
-		{
-			name:           "help flag",
-			args:           []string{"-help"},
-			input:          "",
-			outputContains: "Usage: consul-terraform-sync task enable [options] <task name>",
-			expectEnabled:  false,
-		},
 	}
 
 	for _, tc := range cases {
@@ -187,11 +180,6 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 			"happy path",
 			[]string{fmt.Sprintf("-port=%d", cts.Port()), dbTaskName},
 			"disable complete!",
-		},
-		{
-			"help flag",
-			[]string{"-help"},
-			"consul-terraform-sync task disable [options] <task name>",
 		},
 	}
 
@@ -294,7 +282,7 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			name:     "auto_approve",
 			taskName: dbTaskName,
 			input:    "",
-			args: []string{"-auto-approve"},
+			args:     []string{"-auto-approve"},
 			outputContains: []string{
 				fmt.Sprintf("Deleted task '%s'", dbTaskName)},
 			expectErr:     false,
@@ -317,7 +305,7 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			input:    "yes\n",
 			outputContains: []string{
 				fmt.Sprintf("Error: unable to delete '%s'", "nonexistent_task"),
-				fmt.Sprintf("request returned 404 status code with error:"),
+				"request returned 404 status code with error:",
 			},
 			expectErr:     true,
 			expectDeleted: true, // never existed, same as deleted
@@ -361,13 +349,44 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 }
 
 // TestE2E_DeleteTaskCommand_Help tests that the usage is outputted
-// for the task delete help command. Does not require a running
-// CTS binary.
-func TestE2E_DeleteTaskCommand_Help(t *testing.T) {
+// for the task help commands. Does not require a running CTS binary.
+func TestE2E_TaskCommand_Help(t *testing.T) {
 	t.Parallel()
-	subcmd := []string{"task", "delete", "-help"}
-	output, err := runSubcommand(t, "", subcmd...)
-	assert.NoError(t, err)
-	assert.Contains(t, output,
-		"Usage: consul-terraform-sync task delete [options] <task name>")
+	cases := []struct {
+		command        string
+		outputContains []string
+	}{
+		{
+			command: "enable",
+			outputContains: []string{
+				"Usage: consul-terraform-sync task enable [options] <task name>",
+				"auto-approve false",
+			},
+		},
+		{
+			command: "disable",
+			outputContains: []string{
+				"Usage: consul-terraform-sync task disable [options] <task name>",
+			},
+		},
+		{
+			command: "delete",
+			outputContains: []string{
+				"Usage: consul-terraform-sync task delete [options] <task name>",
+				"auto-approve false",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			subcmd := []string{"task", tc.command, "-help"}
+			output, err := runSubcommand(t, "", subcmd...)
+			assert.NoError(t, err)
+
+			for _, expect := range tc.outputContains {
+				assert.Contains(t, output, expect)
+			}
+		})
+	}
 }

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -116,6 +116,13 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 			expectEnabled:  true,
 		},
 		{
+			name:           "auto approve",
+			args:           []string{"-auto-approve", disabledTaskName},
+			input:          "",
+			outputContains: "enable complete!",
+			expectEnabled:  true,
+		},
+		{
 			name:           "user does not approve plan",
 			args:           []string{disabledTaskName},
 			input:          "no\n",
@@ -279,6 +286,16 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			input:    "yes\n",
 			outputContains: []string{
 				fmt.Sprintf("Do you want to delete '%s'?", dbTaskName),
+				fmt.Sprintf("Deleted task '%s'", dbTaskName)},
+			expectErr:     false,
+			expectDeleted: true,
+		},
+		{
+			name:     "auto_approve",
+			taskName: dbTaskName,
+			input:    "",
+			args: []string{"-auto-approve"},
+			outputContains: []string{
 				fmt.Sprintf("Deleted task '%s'", dbTaskName)},
 			expectErr:     false,
 			expectDeleted: true,


### PR DESCRIPTION
Adds `-auto-approve` as an option to skip the interactive approval step when enabling a task that has changes or deleting a task. The flag name was based on [a similar option for Terraform apply](https://www.terraform.io/cli/commands/apply#automatic-plan-mode).

For enabling tasks, if there are changes, CTS will still inspect the task and output the Terraform plan so that users are able to see what changes will happen when the apply is run.

This same option will be added to task creation once the CLI command has been implemented.