### PR TITLE
Feature 522 create client cli

### DIFF
--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -34,7 +34,7 @@ const (
 )
 
 func TestTaskRequest_String(t *testing.T) {
-	var req taskRequest
+	var req TaskRequest
 
 	err := json.Unmarshal([]byte(taskReq), &req)
 	require.NoError(t, err)
@@ -50,12 +50,12 @@ func TestTaskRequest_String(t *testing.T) {
 func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 	cases := []struct {
 		name               string
-		request            *taskRequest
+		request            *TaskRequest
 		taskConfigExpected config.TaskConfig
 	}{
 		{
 			name: "minimum_required_only",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:     "test-name",
 				Module:   "path",
 				Services: &[]string{"api", "web"},
@@ -68,7 +68,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "basic_fields_filled",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Description: config.String("test-description"),
 				Name:        "test-name",
 				Services:    &[]string{"api", "web"},
@@ -99,7 +99,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_services_condition_regexp",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:    "task",
 				Module:  "path",
 				Enabled: config.Bool(true),
@@ -124,7 +124,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_services_condition_names",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:    "task",
 				Module:  "path",
 				Enabled: config.Bool(true),
@@ -149,7 +149,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_catalog_services_condition",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:   "task",
 				Module: "path",
 				Condition: &oapigen.Condition{
@@ -186,7 +186,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_consul_kv_condition",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:     "task",
 				Module:   "path",
 				Services: &[]string{"api", "web"},
@@ -217,7 +217,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_schedule_condition",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:     "task",
 				Module:   "path",
 				Services: &[]string{"api", "web"},
@@ -234,7 +234,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_services_module_input",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:   "task",
 				Module: "path",
 				Condition: &oapigen.Condition{
@@ -258,7 +258,7 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 		},
 		{
 			name: "with_consul_kv_module_input",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:     "task",
 				Module:   "path",
 				Services: &[]string{"api", "web"},
@@ -302,12 +302,12 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 func TestTaskRequest_ToRequestTaskConfig_Error(t *testing.T) {
 	cases := []struct {
 		name     string
-		request  *taskRequest
+		request  *TaskRequest
 		contains string
 	}{
 		{
 			name: "invalid conversion",
-			request: &taskRequest{
+			request: &TaskRequest{
 				Name:     "test-name",
 				Services: &[]string{"api", "web"},
 				BufferPeriod: &oapigen.BufferPeriod{
@@ -329,7 +329,7 @@ func TestTaskRequest_ToRequestTaskConfig_Error(t *testing.T) {
 }
 
 func TestTaskResponse_String(t *testing.T) {
-	resp := taskResponse{
+	resp := TaskResponse{
 		RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 		Task: &oapigen.Task{
 			Name:    "task",
@@ -378,7 +378,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 	cases := []struct {
 		name             string
 		taskConfig       config.TaskConfig
-		expectedResponse taskResponse
+		expectedResponse TaskResponse
 	}{
 		{
 			name: "minimum_required_only",
@@ -390,7 +390,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api", "web"}},
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "test-name",
@@ -418,7 +418,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 				Condition:    config.EmptyConditionConfig(),
 				ModuleInput:  config.EmptyModuleInputConfig(),
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:        "test-name",
@@ -455,7 +455,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(false),
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "task",
@@ -487,7 +487,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(false),
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "task",
@@ -521,7 +521,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "task",
@@ -561,7 +561,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(true),
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:     "task",
@@ -589,7 +589,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 				Enabled:   config.Bool(true),
 				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:     "task",
@@ -619,7 +619,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "task",
@@ -653,7 +653,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedResponse: taskResponse{
+			expectedResponse: TaskResponse{
 				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
 				Task: &oapigen.Task{
 					Name:    "task",

--- a/api/response_writers.go
+++ b/api/response_writers.go
@@ -9,6 +9,11 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
 )
 
+const (
+	ClientErrorResponseCategory = 4 // category for http status codes from 400-499
+	ServerErrorResponseCategory = 5 // category for http status codes from 500-599
+)
+
 // checkStatusCodeCategory checks if a given status code matches
 // a particular category. It does this by taking the first digit
 // of a category (i.e. 4 for 400, 401, etc.) and checking if the first
@@ -52,7 +57,7 @@ func (r *plaintextErrorToJsonResponseWriter) WriteHeader(code int) {
 // Write checks if the status code is a 4xx and if it is plaintext. If it is plaintext,
 // it converts the error into the correct JSON error response
 func (r *plaintextErrorToJsonResponseWriter) Write(p []byte) (int, error) {
-	if checkStatusCodeCategory(4, r.statusCode) {
+	if checkStatusCodeCategory(ClientErrorResponseCategory, r.statusCode) {
 		var errResp oapigen.ErrorResponse
 		if err := json.Unmarshal(p, &errResp); err != nil {
 			msg := strings.TrimSpace(string(p))

--- a/api/task_create.go
+++ b/api/task_create.go
@@ -11,7 +11,6 @@ import (
 )
 
 // CreateTask creates a task
-// TODO: handle inclusion of variables map[string]string
 // TODO: handle setting the bufferPeriod of the driver
 func (h *TaskLifeCycleHandler) CreateTask(w http.ResponseWriter, r *http.Request, params oapigen.CreateTaskParams) {
 	h.mu.Lock()

--- a/api/task_create.go
+++ b/api/task_create.go
@@ -20,7 +20,7 @@ func (h *TaskLifeCycleHandler) CreateTask(w http.ResponseWriter, r *http.Request
 	logger.Trace("create task request received, reading request")
 
 	// Decode the task request
-	var req taskRequest
+	var req TaskRequest
 	ctx := r.Context()
 	requestID := requestIDFromContext(ctx)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {

--- a/api/task_create_test.go
+++ b/api/task_create_test.go
@@ -144,7 +144,7 @@ func TestTaskLifeCycleHandler_CreateTask_RunInspect(t *testing.T) {
 
 	// Check response, expect task and run
 	decoder := json.NewDecoder(resp.Body)
-	var actual taskResponse
+	var actual TaskResponse
 	require.NoError(t, decoder.Decode(&actual))
 	expected := generateExpectedResponse(t, request)
 	expected.Run = &oapigen.Run{

--- a/api/task_lifecycle_client.go
+++ b/api/task_lifecycle_client.go
@@ -102,8 +102,6 @@ func (c *TaskLifecycleClient) CreateTask(ctx context.Context, runOption string, 
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		err = fmt.Errorf("error creating task %s, %w", req.Name, err)
-
 		return TaskResponse{}, err
 	}
 

--- a/api/task_lifecycle_client.go
+++ b/api/task_lifecycle_client.go
@@ -11,11 +11,6 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/config"
 )
 
-const (
-	RunOptionInspect = "inspect"
-	RunOptionNow     = "now"
-)
-
 // TaskLifecycleClient defines a client for task lifecycle requests
 // Currently non task lifecycle requests use the client in api/client.go, but eventually all endpoint
 // may use this new client. In that case TaskLifecycleClient should be renamed

--- a/api/task_lifecycle_client.go
+++ b/api/task_lifecycle_client.go
@@ -106,7 +106,8 @@ func (d *TaskLifecycleHTTPClient) Do(req *http.Request) (*http.Response, error) 
 	// defer resp.Body.Close() not called for happy path, only called for
 	// unhappy path. caller of this method will close if returned err == nil.
 
-	if resp.StatusCode != http.StatusOK {
+	if checkStatusCodeCategory(ClientErrorResponseCategory, resp.StatusCode) ||
+		checkStatusCodeCategory(ServerErrorResponseCategory, resp.StatusCode) {
 		defer resp.Body.Close()
 
 		var errResp ErrorResponse

--- a/command/commands.go
+++ b/command/commands.go
@@ -31,6 +31,9 @@ func Commands() map[string]cli.CommandFactory {
 		cmdTaskDeleteName: func() (cli.Command, error) {
 			return newTaskDeleteCommand(m), nil
 		},
+		cmdTaskCreateName: func() (cli.Command, error) {
+			return newTaskCreateCommand(m), nil
+		},
 	}
 
 	return all

--- a/command/meta.go
+++ b/command/meta.go
@@ -54,7 +54,7 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 
 	// Values provide both default values, and documentation for the default value when -help is used
 	m.port = m.flags.Int(FlagPort, config.DefaultPort,
-		fmt.Sprintf("The port to use for the Consul Terraform Sync API server, it is preferred to use the %s field instead", FlagHTTPAddr))
+		fmt.Sprintf("The port to use for the Consul-Terraform-Sync API server, it is preferred to use the %s field instead", FlagHTTPAddr))
 	m.addr = m.flags.String(FlagHTTPAddr, api.DefaultAddress, fmt.Sprintf("The `address` and port of the CTS daemon. The value can be an IP "+
 		"address or DNS address, but it must also include the port. This can "+
 		"also be specified via the %s environment variable. The "+
@@ -196,7 +196,7 @@ func (m *meta) requestUserApprovalEnable(taskName string) (int, bool) {
 	m.UI.Info("Enabling the task will perform the actions described above.")
 	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
 	m.UI.Output(" - This action cannot be undone.")
-	m.UI.Output(" - Consul Terraform Sync cannot guarantee Terraform will perform")
+	m.UI.Output(" - Consul-Terraform-Sync cannot guarantee Terraform will perform")
 	m.UI.Output("   these exact actions if monitored services have changed.\n")
 	return m.requestUserApproval(taskName, "enabling")
 }
@@ -208,6 +208,18 @@ func (m *meta) requestUserApprovalDelete(taskName string) (int, bool) {
 	m.UI.Info(fmt.Sprintf("Do you want to delete '%s'?", taskName))
 	m.UI.Output(" - This action cannot be undone.")
 	return m.requestUserApproval(taskName, "deleting")
+}
+
+// requestUserApprovalCreate prints a prompt for user approval of deleting a task
+// and waits for the user input. It returns an exit code and boolean describing
+// if the user approved.
+func (m *meta) requestUserApprovalCreate(taskName string) (int, bool) {
+	m.UI.Info("Creating the task will perform the actions described above.")
+	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
+	m.UI.Output(" - This action cannot be undone.")
+	m.UI.Output(" - Consul-Terraform-Sync cannot guarantee Terraform will perform")
+	m.UI.Output("   these exact actions if monitored services have changed.\n")
+	return m.requestUserApproval(taskName, "creating")
 }
 
 // Returns true if the flags have been parsed

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -1,0 +1,181 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/mitchellh/go-wordwrap"
+)
+
+const cmdTaskCreateName = "task create"
+
+// TaskCreateCommand handles the `task create` command
+type taskCreateCommand struct {
+	meta
+	autoApprove *bool
+	flags       *flag.FlagSet
+}
+
+func newTaskCreateCommand(m meta) *taskCreateCommand {
+	flags := m.defaultFlagSet(cmdTaskCreateName)
+	a := flags.Bool(FlagAutoApprove, false, "Skip interactive approval of inspect plan")
+	return &taskCreateCommand{
+		meta:        m,
+		autoApprove: a,
+		flags:       flags,
+	}
+}
+
+// Name returns the subcommand
+func (c taskCreateCommand) Name() string {
+	return cmdTaskCreateName
+}
+
+// Help returns the command's usage, list of flags, and examples
+func (c *taskCreateCommand) Help() string {
+	c.meta.setHelpOptions()
+	helpText := fmt.Sprintf(`
+Usage: consul-terraform-sync task create [options] --task-file=<task config>
+
+  Task Create is used to create a new task. It is not to be used for updating a task, it will not create a task if the
+  task name already exists.
+
+Options:
+%s
+
+Example:
+
+  $ consul-terraform-sync task create --task-file="task.hcl"
+  ==> Inspecting changes to resource if creating task 'my_task'...
+
+  // ... inspection details
+
+  ==> Creating the task will perform the actions described above.
+      Do you want to perform these actions for 'my_task'?
+       - This action cannot be undone.
+       - Consul Terraform Sync cannot guarantee that these exact actions will be
+	     performed if monitored services have changed.
+
+      Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+  
+  // ... output continues
+`, strings.Join(c.meta.helpOptions, "\n"))
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis is a short one-line synopsis of the command
+func (c *taskCreateCommand) Synopsis() string {
+	return "Creates a new task."
+}
+
+// Run runs the command
+func (c *taskCreateCommand) Run(args []string) int {
+	c.meta.setFlagsUsage(c.flags, args, c.Help())
+	var taskFile string
+	c.flags.StringVar(&taskFile, "task-file", "", "A file containing the hcl or json definition of a task")
+
+	if err := c.flags.Parse(args); err != nil {
+		return ExitCodeParseFlagsError
+	}
+
+	// Check that a task file was provided
+	if len(taskFile) == 0 {
+		c.UI.Error("Error: no task file provided")
+		help := fmt.Sprintf("For additional help try 'consul-terraform-sync %s --help'",
+			cmdTaskCreateName)
+		help = wordwrap.WrapString(help, width)
+
+		c.UI.Output(help)
+
+		return ExitCodeRequiredFlagsError
+	}
+
+	client, err := c.meta.taskLifecycleClient()
+	if err != nil {
+		c.UI.Error("Error: unable to create client")
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	// Build a CTS config and use the config.Tasks object only
+	cfg, err := config.BuildConfig([]string{taskFile})
+	if err != nil {
+		c.UI.Error("Error: unable to read task file")
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+	taskConfigs := *cfg.Tasks
+
+	// Check that we have exactly 1 task in the task config return
+	l := len(taskConfigs)
+	if l > 1 {
+		c.UI.Error(fmt.Sprintf("Error: task file %s cannot contain more "+
+			"than 1 task, contains %d tasks", taskFile, l))
+		return ExitCodeError
+	}
+
+	if l == 0 {
+		c.UI.Error(fmt.Sprintf("Error: task file %s does not contain a task, "+
+			"must contain at least one task", taskFile))
+		return ExitCodeError
+	}
+
+	taskConfig := taskConfigs[0]
+	taskName := *taskConfig.Name
+
+	// First inspect the plan
+	c.UI.Info(fmt.Sprintf("Inspecting changes to resource if creating task '%s'...\n", taskName))
+	c.UI.Output("Generating plan that Consul Terraform Sync will use Terraform to execute\n")
+
+	taskReq := api.TaskRequestFromTaskRequestConfig(*taskConfig)
+	taskResp, err := client.CreateTask(context.Background(), api.RunOptionInspect, taskReq)
+
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to generate plan for '%s'", taskName))
+		err = processEOFError(client.Scheme(), err)
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	c.UI.Output(fmt.Sprintf("Request ID: %s", taskResp.RequestId))
+	b, _ := json.MarshalIndent(taskResp.Task, "    ", "  ")
+	c.UI.Output(fmt.Sprintf("Task: %s\n", string(b)))
+	c.UI.Output(fmt.Sprintf("Plan: \n%s", *taskResp.Run.Plan))
+
+	if !*c.autoApprove {
+		if exitCode, approved := c.meta.requestUserApprovalCreate(taskName); !approved {
+			return exitCode
+		}
+	}
+
+	// Plan approved, create new task and run now
+	taskResp, err = client.CreateTask(context.Background(), api.RunOptionNow, taskReq)
+
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to create '%s'", taskName))
+		err = processEOFError(client.Scheme(), err)
+
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	c.UI.Info(fmt.Sprintf("Task '%s' created", taskResp.Task.Name))
+	c.UI.Output(fmt.Sprintf("Request ID: '%s'", taskResp.RequestId))
+
+	return ExitCodeOK
+}

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -348,6 +348,195 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 	}
 }
 
+// TestE2E_CreateTaskCommand tests creating a task with the CTS CLI
+func TestE2E_CreateTaskCommand(t *testing.T) {
+	t.Parallel()
+	taskName := "new-task"
+	cases := []struct {
+		name           string
+		taskName       string
+		inputTask      string
+		args           []string
+		input          string
+		outputContains []string
+		expectErr      bool
+		expectStatus   bool
+	}{
+		{
+			name:     "happy_path",
+			taskName: taskName,
+			inputTask: fmt.Sprintf(`
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}`, taskName),
+			input: "yes\n",
+			outputContains: []string{
+				fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName),
+				fmt.Sprintf("Task '%s' created", taskName)},
+			expectErr:    false,
+			expectStatus: true,
+		},
+		{
+			name:     "auto_approve",
+			taskName: taskName,
+			inputTask: fmt.Sprintf(`
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}`, taskName),
+			outputContains: []string{
+				fmt.Sprintf("Task '%s' created", taskName)},
+			expectErr:    false,
+			expectStatus: true,
+			args:         []string{"-auto-approve"},
+		},
+		{
+			name:     "user_dose_not_approve_creation",
+			taskName: taskName,
+			inputTask: fmt.Sprintf(`
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}`, taskName),
+			input: "no\n",
+			outputContains: []string{
+				fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName),
+				fmt.Sprintf("Cancelled creating task '%s'", taskName),
+			},
+			expectErr:    false,
+			expectStatus: false,
+		},
+		{
+			name:     "error_task_already_exists",
+			taskName: dbTaskName,
+			inputTask: fmt.Sprintf(`
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}`, dbTaskName),
+			input: "no\n",
+			outputContains: []string{
+				fmt.Sprintf("Error: unable to generate plan for '%s'", dbTaskName),
+				fmt.Sprintf("error: task with name %s already exists", dbTaskName),
+			},
+			expectErr:    true,
+			expectStatus: true,
+		},
+		{
+			name:     "error_more_than_one_task",
+			taskName: taskName,
+			inputTask: fmt.Sprintf(`
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}
+task {
+  name           = "%s"
+  description    = "Creates a new task"
+  module         = "./test_modules/local_instances_file"
+  providers      = ["local"]
+  services       = ["api"]
+  enabled = true
+}
+`, taskName, taskName),
+			input: "yes\n",
+			outputContains: []string{
+				"cannot contain more than 1 task, contains 2 tasks",
+			},
+			expectErr:    true,
+			expectStatus: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newTestConsulServer(t)
+			defer srv.Stop()
+			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "create_cmd")
+			cts := ctsSetup(t, srv, tempDir, dbTask())
+
+			// Write task config file
+			var taskConfig hclConfig
+			taskConfig = taskConfig.appendString(tc.inputTask)
+			taskFilePath := filepath.Join(tempDir, "task.hcl")
+			taskConfig.write(t, taskFilePath)
+
+			// Create command and user approval input if required
+			subcmd := []string{"task", "create",
+				fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()),
+			}
+			subcmd = append(subcmd, tc.args...)
+			subcmd = append(subcmd, fmt.Sprintf("--task-file=%s", taskFilePath))
+			output, err := runSubcommand(t, tc.input, subcmd...)
+
+			// Verify result and output of command
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			for _, expect := range tc.outputContains {
+				assert.Contains(t, output, expect)
+			}
+
+			// Confirm whether the task is deleted or not
+			_, err = cts.Status().Task(tc.taskName, nil)
+			if tc.expectStatus {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestE2E_CreateTaskCommand_NoTaskFileProvided tests creating a task with the CTS CLI when no Task File is provided
+func TestE2E_CreateTaskCommand_NoTaskFileProvided(t *testing.T) {
+	srv := newTestConsulServer(t)
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "create_no_file_cmd")
+	cts := ctsSetup(t, srv, tempDir, dbTask())
+
+	// Create command and user approval input if required
+	subcmd := []string{"task", "create",
+		fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()),
+	}
+	output, err := runSubcommand(t, "", subcmd...)
+
+	assert.Error(t, err)
+
+	outputContains := []string{
+		"Error: no task file provided",
+		"For additional help try 'consul-terraform-sync task create --help'",
+	}
+
+	for _, expect := range outputContains {
+		assert.Contains(t, output, expect)
+	}
+}
+
 // TestE2E_DeleteTaskCommand_Help tests that the usage is outputted
 // for the task help commands. Does not require a running CTS binary.
 func TestE2E_TaskCommand_Help(t *testing.T) {
@@ -373,6 +562,13 @@ func TestE2E_TaskCommand_Help(t *testing.T) {
 			command: "delete",
 			outputContains: []string{
 				"Usage: consul-terraform-sync task delete [options] <task name>",
+				"auto-approve false",
+			},
+		},
+		{
+			command: "create",
+			outputContains: []string{
+				"Usage: consul-terraform-sync task create [options] --task-file=<task config>",
 				"auto-approve false",
 			},
 		},

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -7,6 +7,7 @@ package e2e
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -496,6 +497,10 @@ task {
 			} else {
 				assert.NoError(t, err)
 			}
+
+			// remove newlines from output
+			re := regexp.MustCompile(`\r?\n`)
+			output = re.ReplaceAllString(output, " ")
 
 			for _, expect := range tc.outputContains {
 				assert.Contains(t, output, expect)


### PR DESCRIPTION
This PR is for a new CLI client for creating a new task

### Summary:

- create task command allows a user to create a new task using a provided `.hcl` file containing a single task (and only a single task)
- currently doesn't support adding terraform variables or terraform variable files, this will need to be added in a future PR
- the CLI output for `create task` is a WIP, this is the first pass. One area that could be improved (possible in a future PR) is replacing the current JSON task output with a customized human readable output as discussed with @findkim 

### Known Issue
- CLI output when connecting to a server with the wrong scheme is not displaying the correct message. This is a known issue and is being tracked. This issue only effects the CLI output, TLS/mTLS is functionally working as intended.

### New Supported Commands:
`consul-terraform-sync task create`
`consul-terraform-sync task create help`

### How to use `task create` 
`task create help` output
```
Usage: consul-terraform-sync task create [options] --task-file=<task config>

  Task Create is used to create a new task. It is not to be used for updating a task, it will not create a task if the
  task name already exists.

Options:
  auto-approve false
    Skip interactive approval of inspect plan

  ca-cert 
    Path to a CA file to use for TLS when communicating with Consul-Terraform-Sync. This can also be specified using the CTS_CACERT environment variable.

  ca-path 
    Path to a directory of CA certificates to use for TLS when communicating with Consul-Terraform-Sync. This can also be specified using the CTS_CAPATH environment variable.

  client-cert 
    Path to a client cert file to use for TLS when verify_incoming is enabled. This can also be specified using the CTS_CLIENT_CERT environment variable.

  client-key 
    Path to a client key file to use for TLS when verify_incoming is enabled. This can also be specified using the CTS_CLIENT_KEY environment variable.

  http-addr http://localhost:8558
    The `address` and port of the CTS daemon. The value can be an IP address or DNS address, but it must also include the port. This can also be specified via the CTS_ADDRESS environment variable. The default value is http://localhost:8558. The scheme can also be set to HTTPS by including https in the provided address (eg. https://127.0.0.1:8558)

  port 8558
    The port to use for the Consul Terraform Sync API server, it is preferred to use the http-addr field instead

  ssl-verify true
    Boolean to verify SSL or not. Set to true to verify SSL. This can also be specified using the CTS_SSL_VERIFY environment variable.


Example:

  $ consul-terraform-sync task create --task-file="task.hcl"
  ==> Inspecting changes to resource if creating task 'my_task'...

  // ... inspection details

  ==> Creating the task will perform the actions described above.
      Do you want to perform these actions for 'my_task'?
       - This action cannot be undone.
       - Consul Terraform Sync cannot guarantee that these exact actions will be
             performed if monitored services have changed.

      Only 'yes' will be accepted to approve.

  Enter a value: yes
  
  // ... output continues
```

### Samples
#### Sample task.hcl
```hcl
task {
  name           = "api-task"
  description    = "Writes the service name, id, and IP address to a file"
  module         = "./example-module"
  providers      = ["local"]
  services       = ["api"]
  enabled = true
}
```

#### Sample run
```
consul-terraform-sync task create --task-file="task.hcl"

==> Inspecting changes to resource if creating task 'api-task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

    Request ID: e5957b14-7350-23b6-d0f2-b71ca61ef370
    Task: {
      "description": "Writes the service name, id, and IP address to a file",
      "enabled": true,
      "module": "./example-module",
      "name": "api-task",
      "providers": [
        "local"
      ],
      "services": [
        "api"
      ],
      "variables": {}
    }

    Plan: 

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.api-task.local_file.consul_services will be created
  + resource "local_file" "consul_services" {
      + content              = <<-EOT
            api api 127.0.0.1 
        EOT
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "test.txt"
      + id                   = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

==> Creating the task will perform the actions described above.
    Do you want to perform these actions for 'api-task'?
     - This action cannot be undone.
     - Consul Terraform Sync cannot guarantee Terraform will perform
       these exact actions if monitored services have changed.

    Only 'yes' will be accepted to approve.

Enter a value: yes

==> Task 'api-task' created
    Request ID: '20e901a3-a1d1-ea4c-938e-1fafd1808419'
```




part of #522