### PR TITLE
Fix + Update Security Scanner for CRT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,10 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       # Push events on main branch
-      - main
+      # - main
       # Push events to branches matching refs/heads/release/**
-      - 'release/**'
+      # - 'release/**'
+        - 'fix-security-scan'
 
 env:
   PKG_NAME: "consul-terraform-sync"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:
       # Push events on main branch
-      # - main
+      - main
       # Push events to branches matching refs/heads/release/**
-      # - 'release/**'
-        - 'fix-security-scan'
+      - 'release/**'
+
 
 env:
   PKG_NAME: "consul-terraform-sync"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,13 +4,16 @@ project "consul-terraform-sync" {
   team = "consul api tooling"
   slack {
     # feed-consul-api-gh
-    notification_channel = "C01A3A54G0L"
+    notification_channel = "C026W707YHJ"
   }
   github {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
     release_branches = [
-      "fix-security-scan"
+      "main",
+      "release/0.2.x",
+      "release/0.3.x",
+      "release/0.4.x"
     ]
   }
 }

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -4,16 +4,13 @@ project "consul-terraform-sync" {
   team = "consul api tooling"
   slack {
     # feed-consul-api-gh
-    notification_channel = "C026W707YHJ"
+    notification_channel = "C01A3A54G0L"
   }
   github {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
     release_branches = [
-      "main",
-      "release/0.2.x",
-      "release/0.3.x",
-      "release/0.4.x"
+      "fix-security-scan"
     ]
   }
 }

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,11 +1,11 @@
 container {
 	dependencies = true
 	alpine_secdb = true
-	secrets      = false
+	secrets      = true
 }
 
 binary {
-	secrets      = false
+	secrets      = true
 	go_modules   = true
 	osv          = true
 	oss_index    = true


### PR DESCRIPTION
Right before the holiday, I added `security-scanner` a tool built by Security in this repository for Common Release Tooling. However, there was an issue in the security-scanner that was fixed just until recently. View the change log [here.](https://github.com/hashicorp/security-scanner/releases/tag/v0.0.1-alpha7) This PR is an update to change `secrets` from `false` to `true` to enable security-scanning for secrets in both of the `binaries` and `containers` stanzas in the `security-scan.hcl` file.

 More information about what the issue was can be found in this merged [PR #545](https://github.com/hashicorp/consul-terraform-sync/pull/545)

The tests are now passing! :yay-frog:  

[security-scan-binaries](https://github.com/hashicorp/crt-workflows-common/actions/runs/1659884998) 
[security-scan-containers](https://github.com/hashicorp/crt-workflows-common/actions/runs/1659889085)