### PR TITLE
Undo revert of default to monitoring only passing services

### DIFF
--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -39,7 +39,15 @@ func TestCompatibility_Consul(t *testing.T) {
 	// Tested only OSS GA releases for the highest patch version given a
 	// major minor version. v1.4.5 starts losing compatibility, details in
 	// comments. Theoretical compatible versions 0.1.0 GA:
-	consulVersions := []string{"1.10.3", "1.9.10", "1.8.16", "1.7.14", "1.6.10", "1.5.3"}
+	consulVersions := []string{
+		"1.11.0-beta1",
+		"1.10.3",
+		"1.9.10",
+		"1.8.16",
+		"1.7.14",
+		"1.6.10",
+		"1.5.3",
+	}
 
 	cases := []struct {
 		name              string
@@ -277,7 +285,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 	assert.Contains(t, content, "tag3")
 
 	// 2. change health status. when no health check, 'passing' by default.
-	// add a 'critical' health check
+	// add a 'critical' health check. Critical services do not render by default.
 	serviceInstance.Check = &capi.AgentServiceCheck{
 		CheckID:  "db1_check",
 		HTTP:     "fake_url",
@@ -286,7 +294,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 	}
 	registerService(t, serviceInstance, port)
 	content = testutils.CheckFile(t, true, workingDir, tftmpl.TFVarsFilename)
-	assert.Contains(t, content, "critical")
+	assert.NotContains(t, content, "critical")
 }
 
 // testTagQueryCompatibility tests the compatibility of Consul's Health Service

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -320,3 +320,88 @@ func TestE2EValidateError(t *testing.T) {
 			taskName))
 	delete()
 }
+
+// TestE2E_FilterStatus checks the behavior of including/excluding non-passing
+// service instances. It runs Consul registered with a critical service instance
+// and CTS in once-mode and checks the terraform.tfvars contents to see whats
+// included/excluded. It checks the following behavior:
+// 1. By default, CTS only includes passing service instances (checked by
+//    confirming in terraform.tfvars)
+// 2. CTS can include non-passing service instances through additional
+//    configuration
+func TestE2E_FilterStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		tmpDirSuffix string
+		config       string
+		checkTfvars  func(*testing.T, string)
+	}{
+		{
+			"default config excludes non-passing service instances",
+			"_default",
+			`task {
+				name = "%s"
+				source = "./test_modules/null_resource"
+				services = ["api", "unhealthy-service"]
+			}
+			`,
+			func(t *testing.T, contents string) {
+				assert.NotContains(t, contents, "unhealthy-service")
+				assert.NotContains(t, contents, `= "critical"`)
+
+				// confirm that healthy service is still included
+				assert.Contains(t, contents, "api")
+				assert.Contains(t, contents, `= "passing"`)
+			},
+		},
+		{
+			"services filter includes non-passing service instances",
+			"_w_filter",
+			`task {
+				name = "%s"
+				source = "./test_modules/null_resource"
+				services = ["api", "unhealthy-service"]
+			}
+			service {
+				name = "unhealthy-service"
+				filter = "Checks.Status != \"\""
+			}
+			`,
+			func(t *testing.T, contents string) {
+				assert.Contains(t, contents, "unhealthy-service")
+				assert.Contains(t, contents, `= "critical"`)
+
+				// confirm that healthy service is still included
+				assert.Contains(t, contents, "api")
+				assert.Contains(t, contents, `= "passing"`)
+			},
+		},
+	}
+
+	srv := newTestConsulServer(t)
+	defer srv.Stop()
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir := fmt.Sprintf("%s%s%s", tempDirPrefix, "filter_statuses", tc.tmpDirSuffix)
+			delete := testutils.MakeTempDir(t, tempDir)
+
+			taskName := "status_filter_task"
+
+			configPath := filepath.Join(tempDir, configFile)
+			config := baseConfig(tempDir).appendConsulBlock(srv).appendTerraformBlock().
+				appendString(fmt.Sprintf(tc.config, taskName))
+			config.write(t, configPath)
+
+			api.StartCTS(t, configPath, api.CTSOnceModeFlag)
+
+			taskDir := filepath.Join(tempDir, taskName)
+			contents := testutils.CheckFile(t, true, taskDir, "terraform.tfvars")
+
+			tc.checkTfvars(t, contents)
+			delete()
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.0.0-20211129154418-087458595acd
+	github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -394,7 +394,6 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-connlimit v0.3.0/go.mod h1:OUj9FGL1tPIhl/2RCfzYHrIiWj+VVPGNyVPnUX8AqS0=
 github.com/hashicorp/go-discover v0.0.0-20200501174627-ad1e96bde088/go.mod h1:vZu6Opqf49xX5lsFAu7iFNewkcVF1sn/wyapZh5ytlg=
-github.com/hashicorp/go-gatedio v0.5.0/go.mod h1:Lr3t8L6IyxD3DAeaUxGcgl2JnRUpWMCsmBl4Omu/2t4=
 github.com/hashicorp/go-getter v1.5.3 h1:NF5+zOlQegim+w/EUhSLh6QhXHmZMEeHLQzllkQ3ROU=
 github.com/hashicorp/go-getter v1.5.3/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
 github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9uLqI8l75knNv3lV1kA55veR+WUPSiKIWcQHudI=
@@ -454,8 +453,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.0.0-20211129154418-087458595acd h1:ob56Iox7cgtQUAwid8yufaWipbQGy4b4M81Pf03+gto=
-github.com/hashicorp/hcat v0.0.0-20211129154418-087458595acd/go.mod h1:AJ2fdGudt/27fXjQBl9srE7mOV9fGZnjVxua/CpjT3I=
+github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629 h1:NunPx+DC3CgwMtj9d5mxN0zapv/Q7YlhNJCI8AAqnzA=
+github.com/hashicorp/hcat v0.2.1-0.20220105214302-4b15127c5629/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/templates/hcltmpl/dynamic.go
+++ b/templates/hcltmpl/dynamic.go
@@ -85,10 +85,20 @@ func dynamicValue(ctx context.Context, w tmpls.Watcher, r tmpls.Resolver, v cty.
 		//
 		// Render the template to evaluate the dynamic value and return
 		// out of recursion.
+
+		// add hcat template funcs supported by dynamic templates
+		funcMap := tfunc.Env()
+		for k, v := range tfunc.ConsulV0() {
+			funcMap[k] = v
+		}
+		for k, v := range tfunc.VaultV0() {
+			funcMap[k] = v
+		}
 		tmpl := hcat.NewTemplate(hcat.TemplateInput{
 			Contents:     v.AsString(),
-			FuncMapMerge: tfunc.Env(),
+			FuncMapMerge: funcMap,
 		})
+
 		w.Register(tmpl)
 		rendered, err := renderDynamicValue(ctx, w, r, tmpl)
 		if err != nil {

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -149,8 +149,8 @@ func (d *catalogServicesRegistrationQuery) SetOptions(opts hcat.QueryOptions) {
 	d.opts = opts
 }
 
-// String returns the human-friendly version of this query.
-func (d *catalogServicesRegistrationQuery) String() string {
+// ID returns the human-friendly version of this query.
+func (d *catalogServicesRegistrationQuery) ID() string {
 	var opts []string
 	if d.regexp != nil {
 		opts = append(opts, fmt.Sprintf("regexp=%s", d.regexp.String()))
@@ -170,6 +170,11 @@ func (d *catalogServicesRegistrationQuery) String() string {
 			strings.Join(opts, "&"))
 	}
 	return "catalog.services.registration"
+}
+
+// Stringer interface reuses ID
+func (d *catalogServicesRegistrationQuery) String() string {
+	return d.ID()
 }
 
 // Stop halts the query's fetch function.

--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -221,8 +221,8 @@ func (d *servicesRegexQuery) SetOptions(opts hcat.QueryOptions) {
 	d.opts = opts
 }
 
-// String returns the human-friendly version of this query.
-func (d *servicesRegexQuery) String() string {
+// ID returns the human-friendly version of this query.
+func (d *servicesRegexQuery) ID() string {
 	var opts []string
 	opts = append(opts, fmt.Sprintf("regexp=%s", d.regexp.String()))
 
@@ -242,6 +242,11 @@ func (d *servicesRegexQuery) String() string {
 	sort.Strings(opts)
 	return fmt.Sprintf("service.regex(%s)",
 		strings.Join(opts, "&"))
+}
+
+// Stringer interface reuses ID
+func (d *servicesRegexQuery) String() string {
+	return d.ID()
 }
 
 // Stop halts the query's fetch function.

--- a/templates/tftmpl/tmplfunc/tmpl_func.go
+++ b/templates/tftmpl/tmplfunc/tmpl_func.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/hashicorp/hcat"
 	"github.com/hashicorp/hcat/dep"
 	"github.com/hashicorp/hcat/tfunc"
 )
@@ -14,7 +13,7 @@ import (
 // HCLMap is the map of template functions for rendering HCL
 // to their respective implementations
 func HCLMap(meta *ServicesMeta) template.FuncMap {
-	tmplFuncs := hcat.FuncMapConsulV1()
+	tmplFuncs := tfunc.FuncMapConsulV1()
 	tmplFuncs["catalogServicesRegistration"] = catalogServicesRegistrationFunc
 	tmplFuncs["servicesRegex"] = servicesRegexFunc
 	tmplFuncs["indent"] = tfunc.Helpers()["indent"]


### PR DESCRIPTION
The fix for https://github.com/hashicorp/consul-terraform-sync/issues/430 was a breaking change intended for 0.5.0 to change the default monitoring to be only passing services (rather than all services regardless of status).

Original PRs:
 - https://github.com/hashicorp/consul-terraform-sync/pull/450
 - https://github.com/hashicorp/consul-terraform-sync/pull/455

It was reverted due to a different branching strategy for 0.4.1. Reverted changes:
 - https://github.com/hashicorp/consul-terraform-sync/pull/463
 - https://github.com/hashicorp/consul-terraform-sync/pull/462

This PR undoes the reverts above:
 - Adds back e2e test for expected behavior (test initially fails)
 - Update hcat with latest on master, which contains the fix https://github.com/hashicorp/hcat/pull/72
   - Includes a few other changes due to refactoring in hcat. See commit message for details
 - Cherry-pick back @ findkim's related Consul compatibility testing changes