### PR TITLE
Update TaskInspect to return an additional string

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -16,5 +16,5 @@ type Server interface {
 	TaskCreate(context.Context, config.TaskConfig) (config.TaskConfig, error)
 	TaskCreateAndRun(context.Context, config.TaskConfig) (config.TaskConfig, error)
 	TaskDelete(ctx context.Context, taskName string) error
-	TaskInspect(context.Context, config.TaskConfig) (bool, string, error)
+	TaskInspect(context.Context, config.TaskConfig) (bool, string, string, error)
 }

--- a/api/task_create.go
+++ b/api/task_create.go
@@ -82,7 +82,7 @@ func (h *TaskLifeCycleHandler) createDryRunTask(w http.ResponseWriter, r *http.R
 	logger := logging.FromContext(ctx).Named(createTaskSubsystemName).With("task_name", *taskConf.Name)
 
 	// Inspect task
-	changes, plan, err := h.ctrl.TaskInspect(ctx, taskConf)
+	changes, plan, _, err := h.ctrl.TaskInspect(ctx, taskConf)
 	if err != nil {
 		err = fmt.Errorf("error inspecting new task: %s", err)
 		sendError(w, r, http.StatusBadRequest, err)

--- a/api/task_create_test.go
+++ b/api/task_create_test.go
@@ -137,7 +137,7 @@ func TestTaskLifeCycleHandler_CreateTask_RunInspect(t *testing.T) {
 
 	ctrl := new(mocks.Server)
 	ctrl.On("Task", mock.Anything, taskName).Return(config.TaskConfig{}, fmt.Errorf("DNE")).
-		On("TaskInspect", mock.Anything, taskConf).Return(true, "foobar-plan", nil)
+		On("TaskInspect", mock.Anything, taskConf).Return(true, "foobar-plan", "", nil)
 	handler := NewTaskLifeCycleHandler(ctrl)
 
 	resp := runTestCreateTask(t, handler, "inspect", http.StatusOK, request)

--- a/controller/server.go
+++ b/controller/server.go
@@ -94,14 +94,15 @@ func (rw *ReadWrite) TaskDelete(ctx context.Context, name string) error {
 	return nil
 }
 
-func (rw *ReadWrite) TaskInspect(ctx context.Context, taskConfig config.TaskConfig) (bool, string, error) {
+// TaskInspect creates and inspects a temporary task that is not added to the drivers list.
+func (rw *ReadWrite) TaskInspect(ctx context.Context, taskConfig config.TaskConfig) (bool, string, string, error) {
 	d, err := rw.createTask(ctx, taskConfig)
 	if err != nil {
-		return false, "", err
+		return false, "", "", err
 	}
 
 	plan, err := d.InspectTask(ctx)
-	return plan.ChangesPresent, plan.Plan, err
+	return plan.ChangesPresent, plan.Plan, "", err
 }
 
 func configFromDriverTask(t *driver.Task) config.TaskConfig {

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 // BenchmarkTaskTrigger benchmarks the time for a Consul catalog change to
@@ -39,8 +40,7 @@ func BenchmarkTaskTrigger(b *testing.B) {
 		numServices: 25,
 	})
 
-	ctrl, err := controller.NewReadWrite(conf)
-	rwCtrl := ctrl.(*controller.ReadWrite)
+	rwCtrl, err := controller.NewReadWrite(conf)
 	require.NoError(b, err)
 	err = rwCtrl.Init(ctx)
 	require.NoError(b, err)
@@ -49,7 +49,7 @@ func BenchmarkTaskTrigger(b *testing.B) {
 
 	ctrlStopped := make(chan error)
 	go func() {
-		err := ctrl.Run(ctx)
+		err := rwCtrl.Run(ctx)
 		ctrlStopped <- err
 	}()
 

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 // BenchmarkTasksConcurrent executes the ReadWrite controller directly to
@@ -73,9 +74,8 @@ func benchmarkTasksConcurrent(b *testing.B, bConf benchmarkConfig) {
 
 	conf := generateConf(b, bConf)
 
-	ctrl, err := controller.NewReadWrite(conf)
+	rwCtrl, err := controller.NewReadWrite(conf)
 	require.NoError(b, err)
-	rwCtrl := ctrl.(*controller.ReadWrite)
 
 	err = rwCtrl.Init(context.Background())
 	require.NoError(b, err)

--- a/mocks/server/server.go
+++ b/mocks/server/server.go
@@ -107,7 +107,7 @@ func (_m *Server) TaskDelete(ctx context.Context, taskName string) error {
 }
 
 // TaskInspect provides a mock function with given fields: _a0, _a1
-func (_m *Server) TaskInspect(_a0 context.Context, _a1 config.TaskConfig) (bool, string, error) {
+func (_m *Server) TaskInspect(_a0 context.Context, _a1 config.TaskConfig) (bool, string, string, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 bool
@@ -124,12 +124,19 @@ func (_m *Server) TaskInspect(_a0 context.Context, _a1 config.TaskConfig) (bool,
 		r1 = ret.Get(1).(string)
 	}
 
-	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, config.TaskConfig) error); ok {
+	var r2 string
+	if rf, ok := ret.Get(2).(func(context.Context, config.TaskConfig) string); ok {
 		r2 = rf(_a0, _a1)
 	} else {
-		r2 = ret.Error(2)
+		r2 = ret.Get(2).(string)
 	}
 
-	return r0, r1, r2
+	var r3 error
+	if rf, ok := ret.Get(3).(func(context.Context, config.TaskConfig) error); ok {
+		r3 = rf(_a0, _a1)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }


### PR DESCRIPTION
This is needed in CTS enterprise to return the run URL of the TFC speculative plan. Also fixed the benchmark tests which were still expecting the Controller interface instead of a ReadWriteController.