### PR TITLE
Keep `regexp` nil when unset for ServicesMonitor config

### DIFF
--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -14,8 +14,9 @@ var _ MonitorConfig = (*ServicesMonitorConfig)(nil)
 // that occur to services. ServicesMonitorConfig shares similar fields as the
 // deprecated ServiceConfig
 type ServicesMonitorConfig struct {
-	// Regexp configures the services to monitor by matching on the service name
-	// Either Regexp or Names must be configured, not both.
+	// Regexp configures the services to monitor by matching on the service name.
+	// Either Regexp or Names must be configured, not both. When Regexp is unset,
+	// it will retain a nil value even after Finalize().
 	Regexp *string `mapstructure:"regexp"`
 
 	// Names configures the services to monitor by listing the service name.
@@ -112,9 +113,13 @@ func (c *ServicesMonitorConfig) Merge(o MonitorConfig) MonitorConfig {
 	return r2
 }
 
-// Finalize ensures there no nil pointers. with the _exception_ of Regexp. There
-// is a need to distinguish betweeen nil regex (unconfigured regex) and empty
-// string regex ("" regex pattern) at Validate()
+// Finalize ensures there no nil pointers.
+//
+// Exception: `Regexp` is never finalized and can potentially be nil.
+//  - There is a need to distinguish betweeen nil regex (unconfigured regex) and
+//  empty string regex ("" regex pattern) at Validate().
+//  - Setting `Regexp` as an empty string is not idempotent. There is a need to
+//  call Finalize() and Validate() multiple times.
 func (c *ServicesMonitorConfig) Finalize() {
 	if c == nil { // config not required, return early
 		return
@@ -162,8 +167,6 @@ func (c *ServicesMonitorConfig) Validate() error {
 		if _, err := regexp.Compile(StringVal(c.Regexp)); err != nil {
 			return fmt.Errorf("unable to compile services regexp: %s", err)
 		}
-	} else {
-		c.Regexp = String("") // Finalize
 	}
 
 	// Check that names does not contain empty strings

--- a/config/monitor_services_test.go
+++ b/config/monitor_services_test.go
@@ -453,3 +453,27 @@ func TestServicesMonitorConfig_GoString(t *testing.T) {
 		})
 	}
 }
+
+// TestServicesMonitorConfig_RegexpNil tests the exception that when `Regexp` is
+// unset, it retains nil value after Finalize() and Validate(). Tests it is
+// idempotent
+func TestServicesMonitorConfig_RegexpNil(t *testing.T) {
+	t.Parallel()
+
+	conf := &ServicesMonitorConfig{
+		Names: []string{"api"},
+		// Regexp unset
+	}
+
+	// Confirm `Regexp` nil
+	conf.Finalize()
+	err := conf.Validate()
+	assert.NoError(t, err)
+	assert.Nil(t, conf.Regexp)
+
+	// Confirm idempotent - Validate() doesn't error and `Regexp` still nil
+	conf.Finalize()
+	err = conf.Validate()
+	assert.NoError(t, err)
+	assert.Nil(t, conf.Regexp)
+}

--- a/driver/task.go
+++ b/driver/task.go
@@ -350,17 +350,17 @@ func (t *Task) configureRootModuleInput(input *tftmpl.RootModuleInputData) {
 			SourceIncludesVar: *v.UseAsModuleInput,
 		}
 	case *config.ServicesConditionConfig:
-		if len(v.Names) > 0 {
-			condition = &tftmpl.ServicesTemplate{
-				Names:             v.Names,
+		if v.Regexp != nil {
+			condition = &tftmpl.ServicesRegexTemplate{
+				Regexp:            *v.Regexp,
 				Datacenter:        *v.Datacenter,
 				Namespace:         *v.Namespace,
 				Filter:            *v.Filter,
 				SourceIncludesVar: *v.UseAsModuleInput,
 			}
 		} else {
-			condition = &tftmpl.ServicesRegexTemplate{
-				Regexp:            *v.Regexp,
+			condition = &tftmpl.ServicesTemplate{
+				Names:             v.Names,
 				Datacenter:        *v.Datacenter,
 				Namespace:         *v.Namespace,
 				Filter:            *v.Filter,
@@ -389,9 +389,9 @@ func (t *Task) configureRootModuleInput(input *tftmpl.RootModuleInputData) {
 	var sourceInput tftmpl.Template
 	switch v := t.sourceInput.(type) {
 	case *config.ServicesModuleInputConfig:
-		if len(v.Names) > 0 {
-			sourceInput = &tftmpl.ServicesTemplate{
-				Names:      v.Names,
+		if v.Regexp != nil {
+			sourceInput = &tftmpl.ServicesRegexTemplate{
+				Regexp:     *v.Regexp,
 				Datacenter: *v.Datacenter,
 				Namespace:  *v.Namespace,
 				Filter:     *v.Filter,
@@ -399,8 +399,8 @@ func (t *Task) configureRootModuleInput(input *tftmpl.RootModuleInputData) {
 				SourceIncludesVar: true,
 			}
 		} else {
-			sourceInput = &tftmpl.ServicesRegexTemplate{
-				Regexp:     *v.Regexp,
+			sourceInput = &tftmpl.ServicesTemplate{
+				Names:      v.Names,
 				Datacenter: *v.Datacenter,
 				Namespace:  *v.Namespace,
 				Filter:     *v.Filter,


### PR DESCRIPTION
Make an exception to allow `regexp` config field for ServicesMonitor to remain
nil even after Finalize() and Validate()

Reason: we may want to validate a config multiple times
Source: https://github.com/hashicorp/consul-terraform-sync/pull/587#discussion_r779917409