### PR TITLE
Add option to return a URL as part of inspection

### DIFF
--- a/api/task_create.go
+++ b/api/task_create.go
@@ -82,7 +82,7 @@ func (h *TaskLifeCycleHandler) createDryRunTask(w http.ResponseWriter, r *http.R
 	logger := logging.FromContext(ctx).Named(createTaskSubsystemName).With("task_name", *taskConf.Name)
 
 	// Inspect task
-	changes, plan, _, err := h.ctrl.TaskInspect(ctx, taskConf)
+	changes, plan, runUrl, err := h.ctrl.TaskInspect(ctx, taskConf)
 	if err != nil {
 		err = fmt.Errorf("error inspecting new task: %s", err)
 		sendError(w, r, http.StatusBadRequest, err)
@@ -96,6 +96,9 @@ func (h *TaskLifeCycleHandler) createDryRunTask(w http.ResponseWriter, r *http.R
 	resp.Run = &oapigen.Run{
 		Plan:           &plan,
 		ChangesPresent: &changes,
+	}
+	if runUrl != "" {
+		resp.Run.TfcRunUrl = &runUrl
 	}
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {

--- a/controller/server.go
+++ b/controller/server.go
@@ -102,7 +102,7 @@ func (rw *ReadWrite) TaskInspect(ctx context.Context, taskConfig config.TaskConf
 	}
 
 	plan, err := d.InspectTask(ctx)
-	return plan.ChangesPresent, plan.Plan, "", err
+	return plan.ChangesPresent, plan.Plan, plan.URL, err
 }
 
 func configFromDriverTask(t *driver.Task) config.TaskConfig {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -253,6 +253,7 @@ func (tf *Terraform) ApplyTask(ctx context.Context) error {
 type InspectPlan struct {
 	ChangesPresent bool   `json:"changes_present"`
 	Plan           string `json:"plan"`
+	URL            string `json:"url,omitempty"`
 }
 
 // UpdateTask updates the task on the driver. Makes any calls to re-init


### PR DESCRIPTION
The Terraform driver currently will not return anything for the URL,
but this will allow the Terraform Cloud driver to return a URL.