### PR TITLE
Fix logging Terraform plan output in inspect mode

### DIFF
--- a/api/test.go
+++ b/api/test.go
@@ -18,6 +18,8 @@ const (
 	CTSOnceModeFlag = "-once"
 	// CTSDevModeFlag is an optional flag to run CTS with development client
 	CTSDevModeFlag = "--client-type=development"
+	// CTSInspectFlag is an optional flag to run CTS in inspect mode
+	CTSInspectFlag = "-inspect"
 )
 
 // StartCTS starts the CTS from binary and returns a function to stop CTS. If
@@ -47,7 +49,7 @@ func configureCTS(t *testing.T, scheme string, configPath string, tlsConfig TLSC
 
 	// run CTS in once-mode
 	for _, opt := range opts {
-		if opt == CTSOnceModeFlag {
+		if opt == CTSOnceModeFlag || opt == CTSInspectFlag {
 			cmd.Run() // blocking
 			return nil, func(t *testing.T) {}
 		}

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -98,8 +98,15 @@ func (ctrl *ReadOnly) checkInspect(ctx context.Context, d driver.Driver) (bool, 
 		ctrl.logger.Trace("template for task rendered", taskNameLogKey, taskName)
 
 		ctrl.logger.Info("inspecting task", taskNameLogKey, taskName)
-		if _, err := d.InspectTask(ctx); err != nil {
+		p, err := d.InspectTask(ctx)
+		if err != nil {
 			return false, fmt.Errorf("could not apply changes for task %s: %s", taskName, err)
+		}
+
+		if p.URL != "" {
+			ctrl.logger.Info("inspection results", taskNameLogKey, taskName, "plan", p.Plan, "url", p.URL)
+		} else {
+			ctrl.logger.Info("inspection results", taskNameLogKey, taskName, "plan", p.Plan)
 		}
 
 		ctrl.logger.Info("inspected task", taskNameLogKey, taskName)


### PR DESCRIPTION
Inspect mode was not printing the plan results because we started
returning the plan to the inspect API. Moved the logging to the
controller so that it is only printed in inspect mode.

**Before**
```
2022-01-07T13:23:39.720-0600 [INFO]  ctrl: inspecting all tasks
2022-01-07T13:23:39.831-0600 [INFO]  ctrl: inspecting task: task_name=test-task
2022/01/07 13:23:39 [INFO] running Terraform command: /.../terraform plan -no-color -input=false -detailed-exitcode -lock-timeout=0s -var-file=terraform.tfvars -var-file=providers.tfvars -lock=true -parallelism=10 -refresh=true
module.test-task.local_file.greeting_services: Refreshing state... [id=f1f13de367505e14bf6928dd14534de0788ff510]
module.test-task.local_file.greeting: Refreshing state... [id=69342c5c39e5ae5f0077aecc32c0f81811fb8193]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
2022-01-07T13:23:40.436-0600 [INFO]  ctrl: inspected task: task_name=test-task
2022-01-07T13:23:40.436-0600 [INFO]  ctrl: completed task inspections
```

**After**
```
2022-01-11T15:39:27.448-0600 [INFO]  ctrl: inspecting all tasks
2022-01-11T15:39:27.560-0600 [INFO]  ctrl: inspecting task: task_name=test-task
2022/01/11 15:39:27 [INFO] running Terraform command: /.../terraform plan -no-color -input=false -detailed-exitcode -lock-timeout=0s -lock=true -parallelism=10 -refresh=true
2022-01-11T15:39:28.169-0600 [INFO]  ctrl: inspection results: task_name=test-task
  plan=
  | module.test-task.local_file.greeting: Refreshing state... [id=69342c5c39e5ae5f0077aecc32c0f81811fb8193]
  | module.test-task.local_file.greeting_services: Refreshing state... [id=f1f13de367505e14bf6928dd14534de0788ff510]
  |
  | No changes. Your infrastructure matches the configuration.
  |
  | Terraform has compared your real infrastructure against your configuration
  | and found no differences, so no changes are needed.

2022-01-11T15:39:28.169-0600 [INFO]  ctrl: inspected task: task_name=test-task
2022-01-11T15:39:28.169-0600 [INFO]  ctrl: completed task inspections
```

**API Inspect Request (No Plan Outputted)**
```
2022-01-11T15:41:09.108-0600 [INFO]  api: received request: request_id=41dadc29-2462-79f4-657e-c58f6ccecaf9 time=2022-01-11T15:41:09.108-0600 remote_ip=127.0.0.1:51844 uri=/v1/tasks?run=inspect method=POST host=127.0.0.1:8558
2022-01-11T15:41:09.108-0600 [INFO]  client.terraformcli: Terraform output is muted
2022-01-11T15:41:09.108-0600 [INFO]  driver.terraform: retrieved 0 Terraform handlers for task: task_name=mkam_inspected_task
2022-01-11T15:41:09.108-0600 [INFO]  templates.tftmpl: overwriting file in root module for task: file_name=variables.tf task_name=mkam_inspected_task
2022-01-11T15:41:09.128-0600 [INFO]  templates.tftmpl: overwriting file in root module for task: file_name=main.tf task_name=mkam_inspected_task
2022-01-11T15:41:09.149-0600 [INFO]  templates.tftmpl: overwriting file in root module for task: file_name=terraform.tfvars.tmpl task_name=mkam_inspected_task
2022-01-11T15:41:09.170-0600 [INFO]  templates.tftmpl: overwriting file in root module for task: file_name=providers.auto.tfvars task_name=mkam_inspected_task
2022-01-11T15:41:12.813-0600 [INFO]  api: request complete: request_id=41dadc29-2462-79f4-657e-c58f6ccecaf9 duration=3704932us status_code=200
```