### PR TITLE
Refactor api status endpoints to use server interface

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/event"
 )
 
 //go:generate mockery --name=Server --filename=server.go --output=../mocks/server
@@ -11,8 +12,9 @@ import (
 // Server represents the Controller methods used for the API server
 type Server interface {
 	Config() config.Config
+	Events(ctx context.Context, taskName string) (map[string][]event.Event, error)
 
-	Task(ctx context.Context, taskname string) (config.TaskConfig, error)
+	Task(ctx context.Context, taskName string) (config.TaskConfig, error)
 	TaskCreate(context.Context, config.TaskConfig) (config.TaskConfig, error)
 	TaskCreateAndRun(context.Context, config.TaskConfig) (config.TaskConfig, error)
 	TaskDelete(ctx context.Context, taskName string) error
@@ -22,4 +24,5 @@ type Server interface {
 	// options can be changed and determine the location of sharable objects
 	// across packages
 	TaskUpdate(ctx context.Context, updateConf config.TaskConfig, runOp string) (bool, string, string, error)
+	Tasks(context.Context) ([]config.TaskConfig, error)
 }

--- a/command/cli.go
+++ b/command/cli.go
@@ -15,8 +15,6 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/controller"
-	"github.com/hashicorp/consul-terraform-sync/driver"
-	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul-terraform-sync/version"
 	mcli "github.com/mitchellh/cli"
@@ -268,21 +266,7 @@ func (cli *CLI) runBinary(configFiles, inspectTasks config.FlagAppendSliceValue,
 			if isInspect {
 				return
 			}
-			// TODO: remove this once store and drivers are removed from status & task handlers
-			var store *event.Store
-			var drivers *driver.Drivers
-			switch c := ctrl.(type) {
-			case *controller.ReadWrite:
-				store = c.Store()
-				drivers = c.Drivers()
-			default:
-				store = event.NewStore()
-				drivers = driver.NewDrivers()
-			}
-
 			s, err := api.NewAPI(api.APIConfig{
-				Store:      store,
-				Drivers:    drivers,
 				Controller: ctrl.(api.Server),
 				Port:       config.IntVal(conf.Port),
 				TLS:        conf.TLS,

--- a/controller/server.go
+++ b/controller/server.go
@@ -15,7 +15,7 @@ func (rw *ReadWrite) Config() config.Config {
 }
 
 func (rw *ReadWrite) Events(ctx context.Context, taskName string) (map[string][]event.Event, error) {
-	return nil, fmt.Errorf("not implemented")
+	return rw.store.Read(taskName), nil
 }
 
 func (rw *ReadWrite) Task(ctx context.Context, taskName string) (config.TaskConfig, error) {
@@ -161,6 +161,16 @@ func (rw *ReadWrite) TaskUpdate(ctx context.Context, updateConf config.TaskConfi
 	return plan.ChangesPresent, plan.Plan, "", nil
 }
 
+func (rw *ReadWrite) Tasks(ctx context.Context) ([]config.TaskConfig, error) {
+	drivers := rw.drivers.Map()
+	confs := make([]config.TaskConfig, 0, len(drivers))
+	for _, d := range rw.drivers.Map() {
+		conf := configFromDriverTask(d.Task())
+		confs = append(confs, conf)
+	}
+	return confs, nil
+}
+
 func configFromDriverTask(t *driver.Task) config.TaskConfig {
 	vars := make(map[string]string)
 	for k, v := range t.Variables() {
@@ -197,8 +207,4 @@ func configFromDriverTask(t *driver.Task) config.TaskConfig {
 		ModuleInput:  t.SourceInput(),
 		WorkingDir:   config.String(t.WorkingDir()),
 	}
-}
-
-func (rw *ReadWrite) Tasks(ctx context.Context) ([]config.TaskConfig, error) {
-	return nil, fmt.Errorf("not implemented")
 }

--- a/controller/server.go
+++ b/controller/server.go
@@ -14,16 +14,9 @@ func (rw *ReadWrite) Config() config.Config {
 	return *rw.baseController.conf
 }
 
-// TODO: remove getter functions when status and task API handlers are refactored
-func (rw *ReadWrite) Drivers() *driver.Drivers {
-	return rw.drivers
+func (rw *ReadWrite) Events(ctx context.Context, taskName string) (map[string][]event.Event, error) {
+	return nil, fmt.Errorf("not implemented")
 }
-
-func (rw *ReadWrite) Store() *event.Store {
-	return rw.store
-}
-
-// End TODO
 
 func (rw *ReadWrite) Task(ctx context.Context, taskName string) (config.TaskConfig, error) {
 	// TODO handle ctx while waiting for driver lock if it is currently active
@@ -204,4 +197,8 @@ func configFromDriverTask(t *driver.Task) config.TaskConfig {
 		ModuleInput:  t.SourceInput(),
 		WorkingDir:   config.String(t.WorkingDir()),
 	}
+}
+
+func (rw *ReadWrite) Tasks(ctx context.Context) ([]config.TaskConfig, error) {
+	return nil, fmt.Errorf("not implemented")
 }

--- a/mocks/server/server.go
+++ b/mocks/server/server.go
@@ -7,6 +7,8 @@ import (
 
 	config "github.com/hashicorp/consul-terraform-sync/config"
 
+	event "github.com/hashicorp/consul-terraform-sync/event"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -29,20 +31,43 @@ func (_m *Server) Config() config.Config {
 	return r0
 }
 
-// Task provides a mock function with given fields: ctx, taskname
-func (_m *Server) Task(ctx context.Context, taskname string) (config.TaskConfig, error) {
-	ret := _m.Called(ctx, taskname)
+// Events provides a mock function with given fields: ctx, taskName
+func (_m *Server) Events(ctx context.Context, taskName string) (map[string][]event.Event, error) {
+	ret := _m.Called(ctx, taskName)
+
+	var r0 map[string][]event.Event
+	if rf, ok := ret.Get(0).(func(context.Context, string) map[string][]event.Event); ok {
+		r0 = rf(ctx, taskName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string][]event.Event)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, taskName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Task provides a mock function with given fields: ctx, taskName
+func (_m *Server) Task(ctx context.Context, taskName string) (config.TaskConfig, error) {
+	ret := _m.Called(ctx, taskName)
 
 	var r0 config.TaskConfig
 	if rf, ok := ret.Get(0).(func(context.Context, string) config.TaskConfig); ok {
-		r0 = rf(ctx, taskname)
+		r0 = rf(ctx, taskName)
 	} else {
 		r0 = ret.Get(0).(config.TaskConfig)
 	}
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, taskname)
+		r1 = rf(ctx, taskName)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -174,4 +199,27 @@ func (_m *Server) TaskUpdate(ctx context.Context, updateConf config.TaskConfig, 
 	}
 
 	return r0, r1, r2, r3
+}
+
+// Tasks provides a mock function with given fields: _a0
+func (_m *Server) Tasks(_a0 context.Context) ([]config.TaskConfig, error) {
+	ret := _m.Called(_a0)
+
+	var r0 []config.TaskConfig
+	if rf, ok := ret.Get(0).(func(context.Context) []config.TaskConfig); ok {
+		r0 = rf(_a0)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]config.TaskConfig)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }


### PR DESCRIPTION
Last series of the API refactor PRs for now to increase data encapsulation of the server implementation.
* Replaces store/driver dependencies in the API handler for `/v1/status`, `/v1/status/tasks`, and `/v1/status/task/:task_name`
* Reduce tests sleeping 3s each waiting on starting up go server

Note for the future: the server interface in the `api` package is growing, it may get to the point we need to break up the interfaces and group them by domain. We'll see how this shakes out.
```go
type Server interface {
	Config() config.Config
	Events(ctx context.Context, taskName string) (map[string][]event.Event, error)

	Task(ctx context.Context, taskName string) (config.TaskConfig, error)
	TaskCreate(context.Context, config.TaskConfig) (config.TaskConfig, error)
	TaskCreateAndRun(context.Context, config.TaskConfig) (config.TaskConfig, error)
	TaskDelete(ctx context.Context, taskName string) error
	TaskUpdate(ctx context.Context, updateConf config.TaskConfig, runOp string) (bool, string, string, error)
	Tasks(context.Context) ([]config.TaskConfig, error)
}
```