### PR TITLE
Feature 522 add terraform variable file create task cli

### DIFF
--- a/api/representation.go
+++ b/api/representation.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"io"
+	"os"
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
@@ -18,31 +20,48 @@ type TaskRequest oapigen.TaskRequest
 // TaskRequestFromTaskConfig converts a taskRequest object to a Config TaskConfig object.
 func TaskRequestFromTaskConfig(tc config.TaskConfig) (TaskRequest, error) {
 	if len(tc.VarFiles) > 0 {
-		// Load all variables from passed in variable files before
-		// converting to map[string]string
-		loadedVars := make(hcltmpl.Variables)
+		tc.Variables = make(map[string]string)
 		for _, vf := range tc.VarFiles {
-			tfvars, err := tftmpl.LoadModuleVariables(vf)
+			f, err := os.Open(vf)
 			if err != nil {
 				return TaskRequest{}, err
 			}
 
-			for k, v := range tfvars {
-				loadedVars[k] = v
+			err = readToVariablesMap(vf, f, tc.Variables)
+			if err != nil {
+				return TaskRequest{}, err
 			}
-		}
-
-		// Value can be anything so marshal it to equivalent json
-		// and store json as the string value in the map
-		tc.Variables = make(map[string]string)
-		for k, v := range loadedVars {
-			b, _ := ctyjson.Marshal(v, v.Type())
-			tc.Variables[k] = string(b)
 		}
 	}
 
 	tr := oapigenTaskFromConfigTask(tc)
 	return TaskRequest(tr), nil
+}
+
+func readToVariablesMap(filename string, reader io.Reader, variables map[string]string) error {
+	// Load all variables from passed in variable files before
+	// converting to map[string]string
+	loadedVars := make(hcltmpl.Variables)
+	tfvars, err := tftmpl.LoadModuleVariables(filename, reader)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range tfvars {
+		loadedVars[k] = v
+	}
+
+	// Value can be anything so marshal it to equivalent json
+	// and store json as the string value in the map
+	for k, v := range loadedVars {
+		b, err := ctyjson.Marshal(v, v.Type())
+		if err != nil {
+			return err
+		}
+		variables[k] = string(b)
+	}
+
+	return nil
 }
 
 // ToTaskConfig converts a TaskRequest object to a Config TaskConfig object.

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -47,6 +48,9 @@ func TestTaskRequest_String(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+// Test only bare minimum, task conversion scenarios covered in
+// TestRequest_oapigenTaskFromConfigTask and terraform variable files
+// covered in TestRequest_readToVariablesMap
 func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 	cases := []struct {
 		name            string
@@ -54,23 +58,75 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		expectedRequest TaskRequest
 	}{
 		{
-			name: "minimum_required_only",
-			taskConfig: config.TaskConfig{
-				Name:    config.String("test-name"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
-				Condition: &config.ServicesConditionConfig{
-					ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api", "web"}},
-				},
-			},
-			expectedRequest: TaskRequest{
-				Name:    "test-name",
-				Module:  "path",
-				Enabled: config.Bool(true),
-				Condition: &oapigen.Condition{
-					Services: &oapigen.ServicesCondition{Names: &[]string{"api", "web"}},
-				},
-			},
+			name:            "default_values_only",
+			taskConfig:      config.TaskConfig{},
+			expectedRequest: TaskRequest{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := TaskRequestFromTaskConfig(tc.taskConfig)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRequest, actual)
+		})
+	}
+}
+
+func TestRequest_readToVariablesMap(t *testing.T) {
+	// Simulate input multiple "files" and check various hcl supported types
+	inputTFVars := map[string][]byte{
+		"simple.tfvars": []byte("singleKey = \"value\""),
+		"complex.tfvars": []byte(`
+b = true
+key = "some_key"
+num = 10
+obj = {
+  argStr = "value"
+  argNum = 10
+  argList = ["l", "i", "s", "t"]
+  argMap = {}
+}
+l = [1, 2, 3]
+tup = ["abc", 123, true]`),
+	}
+	expectedMap := map[string]string{
+		"singleKey": "\"value\"",
+		"key":       "\"some_key\"",
+		"b":         "true",
+		"num":       "10",
+		"obj":       "{\"argList\":[\"l\",\"i\",\"s\",\"t\"],\"argMap\":{},\"argNum\":10,\"argStr\":\"value\"}",
+		"l":         "[1,2,3]",
+		"tup":       "[\"abc\",123,true]",
+	}
+
+	// Length should equal number of fields in inputTFVars
+	expectedLength := 7
+
+	m := make(map[string]string)
+
+	for k, v := range inputTFVars {
+		err := readToVariablesMap(k, bytes.NewReader(v), m)
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, expectedLength, len(m))
+
+	for k := range expectedMap {
+		assert.Equal(t, m[k], expectedMap[k])
+	}
+}
+
+func TestRequest_oapigenTaskFromConfigTask(t *testing.T) {
+	cases := []struct {
+		name            string
+		taskConfig      config.TaskConfig
+		expectedRequest oapigen.Task
+	}{
+		{
+			name:            "default_values_only",
+			taskConfig:      config.TaskConfig{},
+			expectedRequest: oapigen.Task{},
 		},
 		{
 			name: "basic_fields_filled",
@@ -87,7 +143,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 				Condition:    config.EmptyConditionConfig(),
 				ModuleInput:  config.EmptyModuleInputConfig(),
 			},
-			expectedRequest: TaskRequest{
+			expectedRequest: oapigen.Task{
 				Name:        "test-name",
 				Module:      "path",
 				Version:     config.String("test-version"),
@@ -107,9 +163,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_services_condition_regexp",
 			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
 				Condition: &config.ServicesConditionConfig{
 					ServicesMonitorConfig: config.ServicesMonitorConfig{
 						Regexp:             config.String("^web.*"),
@@ -121,10 +174,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(false),
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:    "task",
-				Module:  "path",
-				Enabled: config.Bool(true),
+			expectedRequest: oapigen.Task{
 				Condition: &oapigen.Condition{
 					Services: &oapigen.ServicesCondition{
 						Regexp:           config.String("^web.*"),
@@ -136,9 +186,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_services_condition_names",
 			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
 				Condition: &config.ServicesConditionConfig{
 					ServicesMonitorConfig: config.ServicesMonitorConfig{
 						Names:              []string{"api", "web"},
@@ -150,10 +197,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(false),
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:    "task",
-				Module:  "path",
-				Enabled: config.Bool(true),
+			expectedRequest: oapigen.Task{
 				Condition: &oapigen.Condition{
 					Services: &oapigen.ServicesCondition{
 						Names:            &[]string{"api", "web"},
@@ -165,9 +209,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_catalog_services_condition",
 			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
 				Condition: &config.CatalogServicesConditionConfig{
 					CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{
 						Regexp:           config.String(".*"),
@@ -181,10 +222,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:    "task",
-				Module:  "path",
-				Enabled: config.Bool(true),
+			expectedRequest: oapigen.Task{
 				Condition: &oapigen.Condition{
 					CatalogServices: &oapigen.CatalogServicesCondition{
 						Regexp:           ".*",
@@ -204,10 +242,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_consul_kv_condition",
 			taskConfig: config.TaskConfig{
-				Name:     config.String("task"),
-				Services: []string{"api", "web"},
-				Module:   config.String("path"),
-				Enabled:  config.Bool(true),
 				Condition: &config.ConsulKVConditionConfig{
 					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
 						Path:       config.String("key-path"),
@@ -218,11 +252,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					UseAsModuleInput: config.Bool(true),
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:     "task",
-				Services: &[]string{"api", "web"},
-				Module:   "path",
-				Enabled:  config.Bool(true),
+			expectedRequest: oapigen.Task{
 				Condition: &oapigen.Condition{
 					ConsulKv: &oapigen.ConsulKVCondition{
 						Path:             "key-path",
@@ -237,17 +267,9 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_schedule_condition",
 			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Services:  []string{"api", "web"},
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
 				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
 			},
-			expectedRequest: TaskRequest{
-				Name:     "task",
-				Services: &[]string{"api", "web"},
-				Module:   "path",
-				Enabled:  config.Bool(true),
+			expectedRequest: oapigen.Task{
 				Condition: &oapigen.Condition{
 					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
 				},
@@ -256,10 +278,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_services_module_input",
 			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
-				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
 				ModuleInput: &config.ServicesModuleInputConfig{
 					ServicesMonitorConfig: config.ServicesMonitorConfig{
 						Regexp:             config.String("^api$"),
@@ -270,13 +288,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:    "task",
-				Module:  "path",
-				Enabled: config.Bool(true),
-				Condition: &oapigen.Condition{
-					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
-				},
+			expectedRequest: oapigen.Task{
 				ModuleInput: &oapigen.ModuleInput{
 					Services: &oapigen.ServicesModuleInput{
 						Regexp: config.String("^api$"),
@@ -287,11 +299,6 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 		{
 			name: "with_consul_kv_module_input",
 			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Services:  []string{"api", "web"},
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
-				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
 				ModuleInput: &config.ConsulKVModuleInputConfig{
 					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
 						Path:       config.String("fake-path"),
@@ -301,13 +308,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 					},
 				},
 			},
-			expectedRequest: TaskRequest{
-				Name:    "task",
-				Module:  "path",
-				Enabled: config.Bool(true),
-				Condition: &oapigen.Condition{
-					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
-				},
+			expectedRequest: oapigen.Task{
 				ModuleInput: &oapigen.ModuleInput{
 					ConsulKv: &oapigen.ConsulKVModuleInput{
 						Path:       "fake-path",
@@ -316,15 +317,13 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 						Namespace:  config.String("ns"),
 					},
 				},
-				Services: &[]string{"api", "web"},
 			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := TaskRequestFromTaskRequestConfig(tc.taskConfig)
-			require.NoError(t, err)
+			actual := oapigenTaskFromConfigTask(tc.taskConfig)
 			assert.Equal(t, tc.expectedRequest, actual)
 		})
 	}
@@ -657,312 +656,20 @@ func TestTaskResponse_String(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+// Test only bare minimum, task conversion scenarios covered in
+// TestRequest_oapigenTaskFromConfigTask
 func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
-	cases := []struct {
-		name             string
+	tc := struct {
 		taskConfig       config.TaskConfig
 		expectedResponse TaskResponse
 	}{
-		{
-			name: "minimum_required_only",
-			taskConfig: config.TaskConfig{
-				Name:    config.String("test-name"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
-				Condition: &config.ServicesConditionConfig{
-					ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api", "web"}},
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "test-name",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						Services: &oapigen.ServicesCondition{Names: &[]string{"api", "web"}},
-					},
-				},
-			},
-		},
-		{
-			name: "basic_fields_filled",
-			taskConfig: config.TaskConfig{
-				Description:  config.String("test-description"),
-				Name:         config.String("test-name"),
-				Providers:    []string{"test-provider-1", "test-provider-2"},
-				Services:     []string{"api", "web"},
-				Module:       config.String("path"),
-				VarFiles:     []string{""},
-				TFVersion:    config.String(""),
-				Version:      config.String("test-version"),
-				BufferPeriod: config.DefaultBufferPeriodConfig(),
-				Enabled:      config.Bool(true),
-				Condition:    config.EmptyConditionConfig(),
-				ModuleInput:  config.EmptyModuleInputConfig(),
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:        "test-name",
-					Module:      "path",
-					Version:     config.String("test-version"),
-					Description: config.String("test-description"),
-					BufferPeriod: &oapigen.BufferPeriod{
-						Enabled: config.Bool(true),
-						Max:     config.String("20s"),
-						Min:     config.String("5s"),
-					},
-					Enabled:     config.Bool(true),
-					Condition:   &oapigen.Condition{},
-					ModuleInput: &oapigen.ModuleInput{},
-					Services:    &[]string{"api", "web"},
-					Providers:   &[]string{"test-provider-1", "test-provider-2"},
-				},
-			},
-		},
-		{
-			name: "with_services_condition_regexp",
-			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
-				Condition: &config.ServicesConditionConfig{
-					ServicesMonitorConfig: config.ServicesMonitorConfig{
-						Regexp:             config.String("^web.*"),
-						Datacenter:         config.String("dc"),
-						Namespace:          config.String("ns"),
-						Filter:             config.String("filter"),
-						CTSUserDefinedMeta: map[string]string{"key": "value"},
-					},
-					UseAsModuleInput: config.Bool(false),
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "task",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						Services: &oapigen.ServicesCondition{
-							Regexp:           config.String("^web.*"),
-							UseAsModuleInput: config.Bool(false),
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "with_services_condition_names",
-			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
-				Condition: &config.ServicesConditionConfig{
-					ServicesMonitorConfig: config.ServicesMonitorConfig{
-						Names:              []string{"api", "web"},
-						Datacenter:         config.String(""),
-						Namespace:          config.String(""),
-						Filter:             config.String(""),
-						CTSUserDefinedMeta: map[string]string{},
-					},
-					UseAsModuleInput: config.Bool(false),
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "task",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						Services: &oapigen.ServicesCondition{
-							Names:            &[]string{"api", "web"},
-							UseAsModuleInput: config.Bool(false),
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "with_catalog_services_condition",
-			taskConfig: config.TaskConfig{
-				Name:    config.String("task"),
-				Module:  config.String("path"),
-				Enabled: config.Bool(true),
-				Condition: &config.CatalogServicesConditionConfig{
-					CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{
-						Regexp:           config.String(".*"),
-						UseAsModuleInput: config.Bool(true),
-						Datacenter:       config.String("dc2"),
-						Namespace:        config.String("ns2"),
-						NodeMeta: map[string]string{
-							"key1": "value1",
-							"key2": "value2",
-						},
-					},
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "task",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						CatalogServices: &oapigen.CatalogServicesCondition{
-							Regexp:           ".*",
-							UseAsModuleInput: config.Bool(true),
-							Datacenter:       config.String("dc2"),
-							Namespace:        config.String("ns2"),
-							NodeMeta: &oapigen.CatalogServicesCondition_NodeMeta{
-								AdditionalProperties: map[string]string{
-									"key1": "value1",
-									"key2": "value2",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "with_consul_kv_condition",
-			taskConfig: config.TaskConfig{
-				Name:     config.String("task"),
-				Services: []string{"api", "web"},
-				Module:   config.String("path"),
-				Enabled:  config.Bool(true),
-				Condition: &config.ConsulKVConditionConfig{
-					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
-						Path:       config.String("key-path"),
-						Recurse:    config.Bool(true),
-						Datacenter: config.String("dc2"),
-						Namespace:  config.String("ns2"),
-					},
-					UseAsModuleInput: config.Bool(true),
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:     "task",
-					Services: &[]string{"api", "web"},
-					Module:   "path",
-					Enabled:  config.Bool(true),
-					Condition: &oapigen.Condition{
-						ConsulKv: &oapigen.ConsulKVCondition{
-							Path:             "key-path",
-							Recurse:          config.Bool(true),
-							Datacenter:       config.String("dc2"),
-							Namespace:        config.String("ns2"),
-							UseAsModuleInput: config.Bool(true),
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "with_schedule_condition",
-			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Services:  []string{"api", "web"},
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
-				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:     "task",
-					Services: &[]string{"api", "web"},
-					Module:   "path",
-					Enabled:  config.Bool(true),
-					Condition: &oapigen.Condition{
-						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
-					},
-				},
-			},
-		},
-		{
-			name: "with_services_module_input",
-			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
-				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
-				ModuleInput: &config.ServicesModuleInputConfig{
-					ServicesMonitorConfig: config.ServicesMonitorConfig{
-						Regexp:             config.String("^api$"),
-						Datacenter:         config.String("dc"),
-						Namespace:          config.String("ns"),
-						Filter:             config.String("filter"),
-						CTSUserDefinedMeta: map[string]string{"key": "value"},
-					},
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "task",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
-					},
-					ModuleInput: &oapigen.ModuleInput{
-						Services: &oapigen.ServicesModuleInput{
-							Regexp: config.String("^api$"),
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "with_consul_kv_module_input",
-			taskConfig: config.TaskConfig{
-				Name:      config.String("task"),
-				Services:  []string{"api", "web"},
-				Module:    config.String("path"),
-				Enabled:   config.Bool(true),
-				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
-				ModuleInput: &config.ConsulKVModuleInputConfig{
-					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
-						Path:       config.String("fake-path"),
-						Recurse:    config.Bool(false),
-						Datacenter: config.String("dc"),
-						Namespace:  config.String("ns"),
-					},
-				},
-			},
-			expectedResponse: TaskResponse{
-				RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
-				Task: &oapigen.Task{
-					Name:    "task",
-					Module:  "path",
-					Enabled: config.Bool(true),
-					Condition: &oapigen.Condition{
-						Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
-					},
-					ModuleInput: &oapigen.ModuleInput{
-						ConsulKv: &oapigen.ConsulKVModuleInput{
-							Path:       "fake-path",
-							Recurse:    config.Bool(false),
-							Datacenter: config.String("dc"),
-							Namespace:  config.String("ns"),
-						},
-					},
-					Services: &[]string{"api", "web"},
-				},
-			},
+		taskConfig: config.TaskConfig{},
+		expectedResponse: TaskResponse{
+			RequestId: "e9926514-79b8-a8fc-8761-9b6aaccf1e15",
+			Task:      &oapigen.Task{},
 		},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := taskResponseFromTaskConfig(tc.taskConfig, "e9926514-79b8-a8fc-8761-9b6aaccf1e15")
-			assert.Equal(t, actual, tc.expectedResponse)
-		})
-	}
+	actual := taskResponseFromTaskConfig(tc.taskConfig, "e9926514-79b8-a8fc-8761-9b6aaccf1e15")
+	assert.Equal(t, tc.expectedResponse, actual)
 }

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -47,6 +47,289 @@ func TestTaskRequest_String(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
+	cases := []struct {
+		name            string
+		taskConfig      config.TaskConfig
+		expectedRequest TaskRequest
+	}{
+		{
+			name: "minimum_required_only",
+			taskConfig: config.TaskConfig{
+				Name:    config.String("test-name"),
+				Module:  config.String("path"),
+				Enabled: config.Bool(true),
+				Condition: &config.ServicesConditionConfig{
+					ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api", "web"}},
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "test-name",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					Services: &oapigen.ServicesCondition{Names: &[]string{"api", "web"}},
+				},
+			},
+		},
+		{
+			name: "basic_fields_filled",
+			taskConfig: config.TaskConfig{
+				Description:  config.String("test-description"),
+				Name:         config.String("test-name"),
+				Providers:    []string{"test-provider-1", "test-provider-2"},
+				Services:     []string{"api", "web"},
+				Module:       config.String("path"),
+				TFVersion:    config.String(""),
+				Version:      config.String("test-version"),
+				BufferPeriod: config.DefaultBufferPeriodConfig(),
+				Enabled:      config.Bool(true),
+				Condition:    config.EmptyConditionConfig(),
+				ModuleInput:  config.EmptyModuleInputConfig(),
+			},
+			expectedRequest: TaskRequest{
+				Name:        "test-name",
+				Module:      "path",
+				Version:     config.String("test-version"),
+				Description: config.String("test-description"),
+				BufferPeriod: &oapigen.BufferPeriod{
+					Enabled: config.Bool(true),
+					Max:     config.String("20s"),
+					Min:     config.String("5s"),
+				},
+				Enabled:     config.Bool(true),
+				Condition:   &oapigen.Condition{},
+				ModuleInput: &oapigen.ModuleInput{},
+				Services:    &[]string{"api", "web"},
+				Providers:   &[]string{"test-provider-1", "test-provider-2"},
+			},
+		},
+		{
+			name: "with_services_condition_regexp",
+			taskConfig: config.TaskConfig{
+				Name:    config.String("task"),
+				Module:  config.String("path"),
+				Enabled: config.Bool(true),
+				Condition: &config.ServicesConditionConfig{
+					ServicesMonitorConfig: config.ServicesMonitorConfig{
+						Regexp:             config.String("^web.*"),
+						Datacenter:         config.String("dc"),
+						Namespace:          config.String("ns"),
+						Filter:             config.String("filter"),
+						CTSUserDefinedMeta: map[string]string{"key": "value"},
+					},
+					UseAsModuleInput: config.Bool(false),
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "task",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					Services: &oapigen.ServicesCondition{
+						Regexp:           config.String("^web.*"),
+						UseAsModuleInput: config.Bool(false),
+					},
+				},
+			},
+		},
+		{
+			name: "with_services_condition_names",
+			taskConfig: config.TaskConfig{
+				Name:    config.String("task"),
+				Module:  config.String("path"),
+				Enabled: config.Bool(true),
+				Condition: &config.ServicesConditionConfig{
+					ServicesMonitorConfig: config.ServicesMonitorConfig{
+						Names:              []string{"api", "web"},
+						Datacenter:         config.String(""),
+						Namespace:          config.String(""),
+						Filter:             config.String(""),
+						CTSUserDefinedMeta: map[string]string{},
+					},
+					UseAsModuleInput: config.Bool(false),
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "task",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					Services: &oapigen.ServicesCondition{
+						Names:            &[]string{"api", "web"},
+						UseAsModuleInput: config.Bool(false),
+					},
+				},
+			},
+		},
+		{
+			name: "with_catalog_services_condition",
+			taskConfig: config.TaskConfig{
+				Name:    config.String("task"),
+				Module:  config.String("path"),
+				Enabled: config.Bool(true),
+				Condition: &config.CatalogServicesConditionConfig{
+					CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{
+						Regexp:           config.String(".*"),
+						UseAsModuleInput: config.Bool(true),
+						Datacenter:       config.String("dc2"),
+						Namespace:        config.String("ns2"),
+						NodeMeta: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "task",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					CatalogServices: &oapigen.CatalogServicesCondition{
+						Regexp:           ".*",
+						UseAsModuleInput: config.Bool(true),
+						Datacenter:       config.String("dc2"),
+						Namespace:        config.String("ns2"),
+						NodeMeta: &oapigen.CatalogServicesCondition_NodeMeta{
+							AdditionalProperties: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with_consul_kv_condition",
+			taskConfig: config.TaskConfig{
+				Name:     config.String("task"),
+				Services: []string{"api", "web"},
+				Module:   config.String("path"),
+				Enabled:  config.Bool(true),
+				Condition: &config.ConsulKVConditionConfig{
+					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
+						Path:       config.String("key-path"),
+						Recurse:    config.Bool(true),
+						Datacenter: config.String("dc2"),
+						Namespace:  config.String("ns2"),
+					},
+					UseAsModuleInput: config.Bool(true),
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:     "task",
+				Services: &[]string{"api", "web"},
+				Module:   "path",
+				Enabled:  config.Bool(true),
+				Condition: &oapigen.Condition{
+					ConsulKv: &oapigen.ConsulKVCondition{
+						Path:             "key-path",
+						Recurse:          config.Bool(true),
+						Datacenter:       config.String("dc2"),
+						Namespace:        config.String("ns2"),
+						UseAsModuleInput: config.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "with_schedule_condition",
+			taskConfig: config.TaskConfig{
+				Name:      config.String("task"),
+				Services:  []string{"api", "web"},
+				Module:    config.String("path"),
+				Enabled:   config.Bool(true),
+				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
+			},
+			expectedRequest: TaskRequest{
+				Name:     "task",
+				Services: &[]string{"api", "web"},
+				Module:   "path",
+				Enabled:  config.Bool(true),
+				Condition: &oapigen.Condition{
+					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+				},
+			},
+		},
+		{
+			name: "with_services_module_input",
+			taskConfig: config.TaskConfig{
+				Name:      config.String("task"),
+				Module:    config.String("path"),
+				Enabled:   config.Bool(true),
+				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
+				ModuleInput: &config.ServicesModuleInputConfig{
+					ServicesMonitorConfig: config.ServicesMonitorConfig{
+						Regexp:             config.String("^api$"),
+						Datacenter:         config.String("dc"),
+						Namespace:          config.String("ns"),
+						Filter:             config.String("filter"),
+						CTSUserDefinedMeta: map[string]string{"key": "value"},
+					},
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "task",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+				},
+				ModuleInput: &oapigen.ModuleInput{
+					Services: &oapigen.ServicesModuleInput{
+						Regexp: config.String("^api$"),
+					},
+				},
+			},
+		},
+		{
+			name: "with_consul_kv_module_input",
+			taskConfig: config.TaskConfig{
+				Name:      config.String("task"),
+				Services:  []string{"api", "web"},
+				Module:    config.String("path"),
+				Enabled:   config.Bool(true),
+				Condition: &config.ScheduleConditionConfig{Cron: config.String("*/10 * * * * * *")},
+				ModuleInput: &config.ConsulKVModuleInputConfig{
+					ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
+						Path:       config.String("fake-path"),
+						Recurse:    config.Bool(false),
+						Datacenter: config.String("dc"),
+						Namespace:  config.String("ns"),
+					},
+				},
+			},
+			expectedRequest: TaskRequest{
+				Name:    "task",
+				Module:  "path",
+				Enabled: config.Bool(true),
+				Condition: &oapigen.Condition{
+					Schedule: &oapigen.ScheduleCondition{Cron: "*/10 * * * * * *"},
+				},
+				ModuleInput: &oapigen.ModuleInput{
+					ConsulKv: &oapigen.ConsulKVModuleInput{
+						Path:       "fake-path",
+						Recurse:    config.Bool(false),
+						Datacenter: config.String("dc"),
+						Namespace:  config.String("ns"),
+					},
+				},
+				Services: &[]string{"api", "web"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := TaskRequestFromTaskConfig(tc.taskConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedRequest, actual)
+		})
+	}
+}
+
 func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 	cases := []struct {
 		name               string
@@ -679,7 +962,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := taskResponseFromTaskConfig(tc.taskConfig, "e9926514-79b8-a8fc-8761-9b6aaccf1e15")
-			assert.Equal(t, actual, tc.expectedResponse)
+			assert.Equal(t, tc.expectedResponse, actual)
 		})
 	}
 }

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -323,7 +323,7 @@ func TestRequest_TaskRequestFromTaskConfig(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := TaskRequestFromTaskConfig(tc.taskConfig)
+			actual, err := TaskRequestFromTaskRequestConfig(tc.taskConfig)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedRequest, actual)
 		})
@@ -962,7 +962,7 @@ func TestTaskResponse_taskResponseFromTaskConfig(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := taskResponseFromTaskConfig(tc.taskConfig, "e9926514-79b8-a8fc-8761-9b6aaccf1e15")
-			assert.Equal(t, tc.expectedResponse, actual)
+			assert.Equal(t, actual, tc.expectedResponse)
 		})
 	}
 }

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -138,7 +138,15 @@ func (c *taskCreateCommand) Run(args []string) int {
 	c.UI.Info(fmt.Sprintf("Inspecting changes to resource if creating task '%s'...\n", taskName))
 	c.UI.Output("Generating plan that Consul Terraform Sync will use Terraform to execute\n")
 
-	taskReq := api.TaskRequestFromTaskRequestConfig(*taskConfig)
+	taskReq, err := api.TaskRequestFromTaskConfig(*taskConfig)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: unable to convert task file %s to request", taskFile))
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
 	taskResp, err := client.CreateTask(context.Background(), api.RunOptionInspect, taskReq)
 
 	if err != nil {

--- a/controller/server.go
+++ b/controller/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/event"
 	"github.com/pkg/errors"
+	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
 func (rw *ReadWrite) Config() config.Config {
@@ -173,8 +174,12 @@ func (rw *ReadWrite) Tasks(ctx context.Context) ([]config.TaskConfig, error) {
 
 func configFromDriverTask(t *driver.Task) config.TaskConfig {
 	vars := make(map[string]string)
+
+	// value can be anything so marshal it to equivalent json
+	// and store json as the string value in the map
 	for k, v := range t.Variables() {
-		vars[k] = v.AsString()
+		b, _ := ctyjson.Marshal(v, v.Type())
+		vars[k] = string(b)
 	}
 
 	var bpConf config.BufferPeriodConfig

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -67,7 +67,9 @@ func TestServer_TaskCreate(t *testing.T) {
 
 		actual, err := ctrl.TaskCreate(ctx, taskConf)
 		assert.NoError(t, err)
-		assert.Equal(t, configFromDriverTask(driverTask), actual)
+		conf, err := configFromDriverTask(driverTask)
+		assert.NoError(t, err)
+		assert.Equal(t, conf, actual)
 
 		_, ok := ctrl.drivers.Get("task")
 		assert.True(t, ok, "task should have a driver")

--- a/driver/task.go
+++ b/driver/task.go
@@ -91,7 +91,11 @@ func NewTask(conf TaskConfig) (*Task, error) {
 	// Load all variables from passed in variable files
 	loadedVars := make(hcltmpl.Variables)
 	for _, vf := range conf.VarFiles {
-		tfvars, err := tftmpl.LoadModuleVariables(vf)
+		f, err := os.Open(vf)
+		if err != nil {
+			return nil, err
+		}
+		tfvars, err := tftmpl.LoadModuleVariables(vf, f)
 		if err != nil {
 			return nil, err
 		}

--- a/e2e/test_modules/with_tfvars_file/main.tf
+++ b/e2e/test_modules/with_tfvars_file/main.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    # Provider source is used for Terraform discovery and installation of
+    # providers. Declare source for all providers required by the module.
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.1.0"
+    }
+  }
+}
+
+resource "local_file" "obj" {
+  content  = join(",", var.sample.tags, [for key, value in var.sample.user_meta : "${key}=${value}"])
+  filename = var.filename
+}

--- a/e2e/test_modules/with_tfvars_file/variables.tf
+++ b/e2e/test_modules/with_tfvars_file/variables.tf
@@ -1,0 +1,49 @@
+# Required var.services declaration
+variable "services" {
+  description = "Consul services monitored by Consul Terraform Sync"
+  # Optional attributes of services
+  type = map(
+    object({
+      id        = string
+      name      = string
+      kind      = string
+      address   = string
+      port      = number
+      meta      = map(string)
+      tags      = list(string)
+      namespace = string
+      status    = string
+
+      node                  = string
+      node_id               = string
+      node_address          = string
+      node_datacenter       = string
+      node_tagged_addresses = map(string)
+      node_meta             = map(string)
+
+      cts_user_defined_meta = map(string)
+    })
+  )
+}
+
+variable "filename" {
+  type    = string
+  default = "test.txt"
+}
+
+variable "sample" {
+  type = object({
+    user_meta = map(string)
+    tags      = list(string)
+  })
+
+
+  default = {
+    user_meta = {
+      name            = "unknown"
+      age             = "unknown"
+      day_of_the_week = "unknown"
+    }
+    tags = ["happy", "sad"]
+  }
+}

--- a/templates/tftmpl/module_variables.go
+++ b/templates/tftmpl/module_variables.go
@@ -3,7 +3,6 @@ package tftmpl
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
@@ -15,8 +14,9 @@ import (
 )
 
 // LoadModuleVariables loads Terraform input variables from a file.
-func LoadModuleVariables(filePath string) (hcltmpl.Variables, error) {
-	content, err := ioutil.ReadFile(filePath)
+func LoadModuleVariables(filePath string, reader io.Reader) (hcltmpl.Variables, error) {
+	content, err := io.ReadAll(reader)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR covers the following enhancements and fixes:

1) configFromDriverTask would panic when a variable was provided that was not of type string:

https://github.com/hashicorp/consul-terraform-sync/blob/fe685da4621d396c46fa44fea27db0aca35f1573/controller/server.go#L172-L175

This was because the value could be of any type, not just a string. If a non string type is used with `.AsString()` this function will panic.

2) Create task CLI should handle the conversion of terraform variable files included in a task definition into 
map[string]string for remote requests.

### Example

**Example Task with Terraform varfiles:**

``` hcl
task {
  name           = "api-task"
  description    = "Writes the service name, id, and IP address to a file"
  module         = "./variables-module"
  providers      = ["local"]
  services       = ["web"]
  variable_files = ["/Users/mwilkerson/dev/michael-cts-example/filename.tfvars","/Users/mwilkerson/dev/michael-cts-example/obj.tfvars"]
  enabled = true
}
```

**Example Terraform varfiles:**
``` hcl
# fielname.tfvars
filename = "michael.txt"
```

```hcl
#obj.tfvars
sample = {
  user_meta = {
    name            = "amanda"
    age             = "32"
    day_of_the_week = "Monday"
  }
  tags = ["cool", "great"]
}
````

**Example Converted Request**
``` json
    Task: {
      "description": "Writes the service name, id, and IP address to a file",
      "enabled": true,
      "module": "./variables-module",
      "name": "api-task",
      "providers": [
        "local"
      ],
      "services": [
        "web"
      ],
      "variables": {
        "filename": "\"michael.txt\"",
        "sample": "{\"tags\":[\"cool\",\"great\"],\"user_meta\":{\"age\":\"32\",\"day_of_the_week\":\"Monday\",\"name\":\"amanda\"}}"
      }
    }
```

part of #522
