### PR TITLE
Increase default API timeout in tests

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -33,7 +33,7 @@ const (
 	// liberal default times to wait
 	defaultWaitForRegistration = 8 * time.Second
 	defaultWaitForEvent        = 8 * time.Second
-	defaultWaitForAPI          = 20 * time.Second
+	defaultWaitForAPI          = 30 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
 	defaultWaitForNoEvent = 6 * time.Second
@@ -109,10 +109,10 @@ func TestE2ERestartSync(t *testing.T) {
 	config := baseConfig().appendConsulBlock(srv).appendTerraformBlock(tempDir).appendDBTask()
 	config.write(t, configPath)
 
-	runSyncStop(t, configPath, 8*time.Second)
+	runSyncStop(t, configPath, defaultWaitForAPI)
 
 	// rerun sync. confirm no errors e.g. recreating workspaces
-	runSyncStop(t, configPath, 8*time.Second)
+	runSyncStop(t, configPath, defaultWaitForAPI)
 
 	delete()
 }


### PR DESCRIPTION
The Terraform applies in CircleCI are sometimes taking longer than
expected, which is failing tests that start with multiple tasks.

Manual backport of https://github.com/hashicorp/consul-terraform-sync/pull/386