### PR TITLE
Add new configuration type ModuleInputConfigs

### DIFF
--- a/config/condition_schedule.go
+++ b/config/condition_schedule.go
@@ -16,6 +16,10 @@ type ScheduleConditionConfig struct {
 	Cron *string `mapstructure:"cron"`
 }
 
+func (c *ScheduleConditionConfig) VariableType() string {
+	return ""
+}
+
 // Copy returns a deep copy of this configuration.
 func (c *ScheduleConditionConfig) Copy() MonitorConfig {
 	if c == nil {

--- a/config/module_input.go
+++ b/config/module_input.go
@@ -18,6 +18,13 @@ type ModuleInputConfig interface {
 	MonitorConfig
 }
 
+// ModuleInputConfigs is a collection of ModuleInputConfig
+type ModuleInputConfigs []ModuleInputConfig
+
+func DefaultModuleInputConfigs() *ModuleInputConfigs {
+	return &ModuleInputConfigs{}
+}
+
 // EmptyModuleInputConfig sets un-configured module inputs with a non-null
 // value
 func EmptyModuleInputConfig() ModuleInputConfig {
@@ -112,4 +119,134 @@ func decodeModuleInputToType(data interface{}, moduleInput ModuleInputConfig) (M
 // isModuleInputNil returns true if the module input is nil and false otherwise
 func isModuleInputNil(si ModuleInputConfig) bool {
 	return isMonitorNil(si)
+}
+
+// Len is a helper method to get the length of the underlying config list
+func (c *ModuleInputConfigs) Len() int {
+	if c == nil {
+		return 0
+	}
+
+	return len(*c)
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *ModuleInputConfigs) Copy() *ModuleInputConfigs {
+	if c == nil {
+		return nil
+	}
+
+	o := make(ModuleInputConfigs, c.Len())
+	for i, t := range *c {
+		o[i] = t.Copy()
+	}
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+// Maps and slices are merged, most other values are overwritten. Complex
+// structs define their own merge functionality.
+func (c *ModuleInputConfigs) Merge(o *ModuleInputConfigs) *ModuleInputConfigs {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	*r = append(*r, *o...)
+
+	return r
+}
+
+// Finalize ensures the configuration has no nil pointers and sets default
+// values.
+func (c *ModuleInputConfigs) Finalize() {
+	if c == nil {
+		return
+	}
+
+	for _, t := range *c {
+		t.Finalize()
+	}
+}
+
+// Validate validates the values and nested values of the configuration struct.
+// It validates a task's module inputs while taking into account the task's
+// services and condition
+func (c *ModuleInputConfigs) Validate(services []string, condition ConditionConfig) error {
+	if c == nil || c.Len() == 0 {
+		// config is not required, return early
+		return nil
+	}
+
+	logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
+
+	// Confirm module_inputs's type is unique across module_inputs
+	varTypes := make(map[string]bool)
+	for _, input := range *c {
+		varType := input.VariableType()
+		if ok := varTypes[varType]; ok {
+			return fmt.Errorf("more than one 'module_input' block for the %q "+
+				"variable. variable types must be unique", varType)
+		}
+		varTypes[varType] = true
+	}
+
+	// Confirm module_input types are different from task.services variable type
+	if len(services) > 0 {
+
+		// ServicesModuleInput is the only module_input with the same variable
+		// type as task.services
+		servicesType := &ServicesModuleInputConfig{}
+
+		if ok := varTypes[servicesType.VariableType()]; ok {
+			err := fmt.Errorf("task's `services` field and `module_input "+
+				"'services'` block both monitor %q variable type. only one of "+
+				"these can be configured per task", servicesType.VariableType())
+			logger.Error("list of `services` and `module_input 'services'` "+
+				"block cannot both be configured. Consider combining the list "+
+				"into the module_input block or creating separate tasks",
+				"error", err)
+			return err
+		}
+	}
+
+	// Confirm module_input's type is different from condition
+	if condition == nil {
+		return nil
+	}
+	if ok := varTypes[condition.VariableType()]; ok {
+		err := fmt.Errorf("task's condition block and module_input block "+
+			"both monitor %q variable type. condition and module_input "+
+			"variable type must be unique", condition.VariableType())
+		logger.Error("condition and module_input block cannot monitor same "+
+			"variable type. If both are needed, consider combining the "+
+			"module_input with the condition block or creating separate tasks",
+			"error", err)
+		return err
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *ModuleInputConfigs) GoString() string {
+	if c == nil {
+		return "(*ModuleInputConfigs)(nil)"
+	}
+
+	s := make([]string, len(*c))
+	for i, t := range *c {
+		s[i] = t.GoString()
+	}
+
+	return "{" + strings.Join(s, ", ") + "}"
 }

--- a/config/module_input_test.go
+++ b/config/module_input_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -153,6 +154,344 @@ func TestModuleInput_DecodeConfig_Error(t *testing.T) {
 			config, err := decodeConfig([]byte(tc.config), testFileName)
 			require.Error(t, err)
 			require.Equal(t, tc.expected, config)
+		})
+	}
+}
+
+func TestModuleInputConfigs_Len(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		i        *ModuleInputConfigs
+		expected int
+	}{
+		{
+			"nil",
+			nil,
+			0,
+		},
+		{
+			"happy_path",
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+			},
+			2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.i.Len()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestModuleInputConfigs_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		i        *ModuleInputConfigs
+		expected *ModuleInputConfigs
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ModuleInputConfigs{},
+			&ModuleInputConfigs{},
+		},
+		{
+			"happy_path",
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{
+					ServicesMonitorConfig{
+						Regexp:     String("^web.*"),
+						Datacenter: String("dc"),
+						Namespace:  String("namespace"),
+						Filter:     String("filter"),
+						CTSUserDefinedMeta: map[string]string{
+							"key": "value",
+						},
+					},
+				},
+				&ConsulKVModuleInputConfig{
+					ConsulKVMonitorConfig{
+						Path:       String("key-path"),
+						Recurse:    Bool(true),
+						Datacenter: String("dc2"),
+						Namespace:  String("ns2"),
+					},
+				},
+			},
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{
+					ServicesMonitorConfig{
+						Regexp:     String("^web.*"),
+						Datacenter: String("dc"),
+						Namespace:  String("namespace"),
+						Filter:     String("filter"),
+						CTSUserDefinedMeta: map[string]string{
+							"key": "value",
+						},
+					},
+				},
+				&ConsulKVModuleInputConfig{
+					ConsulKVMonitorConfig{
+						Path:       String("key-path"),
+						Recurse:    Bool(true),
+						Datacenter: String("dc2"),
+						Namespace:  String("ns2"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.i.Copy()
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestModuleInputConfigs_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *ModuleInputConfigs
+		b    *ModuleInputConfigs
+		r    *ModuleInputConfigs
+	}{
+		{
+			"nil_a",
+			nil,
+			&ModuleInputConfigs{},
+			&ModuleInputConfigs{},
+		},
+		{
+			"nil_b",
+			&ModuleInputConfigs{},
+			nil,
+			&ModuleInputConfigs{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ModuleInputConfigs{},
+			&ModuleInputConfigs{},
+			&ModuleInputConfigs{},
+		},
+		{
+			"happy_path_different_type",
+			&ModuleInputConfigs{&ServicesModuleInputConfig{}},
+			&ModuleInputConfigs{&ConsulKVModuleInputConfig{}},
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+			},
+		},
+		{
+			"happy_path_same_type",
+			// will error with Validation()
+			&ModuleInputConfigs{&ServicesModuleInputConfig{}},
+			&ModuleInputConfigs{&ServicesModuleInputConfig{}},
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ServicesModuleInputConfig{},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestModuleInputConfigs_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    *ModuleInputConfigs
+		r    *ModuleInputConfigs
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&ModuleInputConfigs{},
+			&ModuleInputConfigs{},
+		},
+		{
+			"happy_path",
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+			},
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{
+					ServicesMonitorConfig{
+						Regexp:             nil,
+						Names:              []string{},
+						Datacenter:         String(""),
+						Namespace:          String(""),
+						Filter:             String(""),
+						CTSUserDefinedMeta: map[string]string{},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestModuleInputConfigs_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		services     []string
+		condition    ConditionConfig
+		moduleInputs *ModuleInputConfigs
+		valid        bool
+	}{
+		{
+			name:         "valid: nil",
+			moduleInputs: nil,
+			valid:        true,
+		},
+		{
+			name:         "valid: empty module_inputs",
+			moduleInputs: &ModuleInputConfigs{},
+			valid:        true,
+		},
+		{
+			name: "valid: happy path",
+			moduleInputs: &ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+			},
+			valid: true,
+		},
+		{
+			name:      "valid: happy path with cond-block",
+			condition: &CatalogServicesConditionConfig{},
+			moduleInputs: &ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+			},
+			valid: true,
+		},
+		{
+			name:     "valid: happy path with services list",
+			services: []string{"api"},
+			moduleInputs: &ModuleInputConfigs{
+				&ConsulKVModuleInputConfig{},
+			},
+			valid: true,
+		},
+		{
+			name: "invalid: module_inputs not unique",
+			moduleInputs: &ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+				&ConsulKVModuleInputConfig{},
+			},
+			valid: false,
+		},
+		{
+			name:     "invalid: services & services module_input configured",
+			services: []string{"api"},
+			moduleInputs: &ModuleInputConfigs{
+				&ServicesModuleInputConfig{},
+			},
+			valid: false,
+		},
+		{
+			name:      "invalid: cond & module_input same type",
+			condition: &ConsulKVConditionConfig{},
+			moduleInputs: &ModuleInputConfigs{
+				&ConsulKVModuleInputConfig{},
+			},
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.moduleInputs.Validate(tc.services, tc.condition)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestModuleInputConfigs_GoString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		i        *ModuleInputConfigs
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*ModuleInputConfigs)(nil)",
+		},
+		{
+			"configured",
+			&ModuleInputConfigs{
+				&ServicesModuleInputConfig{
+					ServicesMonitorConfig: ServicesMonitorConfig{
+						Regexp: String("^api$"),
+					},
+				},
+				&ConsulKVModuleInputConfig{
+					ConsulKVMonitorConfig: ConsulKVMonitorConfig{
+						Path: String("my/path"),
+					},
+				},
+			},
+			"{&ServicesModuleInputConfig{&ServicesMonitorConfig{Regexp:^api$, Names:[], " +
+				"Datacenter:, Namespace:, Filter:, CTSUserDefinedMeta:map[]}}, " +
+				"&ConsulKVModuleInputConfig{&ConsulKVMonitorConfig{Path:my/path, " +
+				"Recurse:false, Datacenter:, Namespace:, }}}",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.i.GoString()
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }

--- a/config/monitor.go
+++ b/config/monitor.go
@@ -12,6 +12,15 @@ type MonitorConfig interface {
 	Finalize()
 	Validate() error
 	GoString() string
+
+	// VariableType returns type of variable that a module_input or a condition
+	// block monitors. For example, `condition "services"` monitors the variable
+	// type "services.
+	//
+	// Used to ensure requirement that configured monitored variable types are
+	// unique for a given task. Must be unique across module_input, condition,
+	// and services.
+	VariableType() string
 }
 
 // isMonitorNil can be used to check if a MonitorConfig interface is nil by

--- a/config/monitor_catalog_services.go
+++ b/config/monitor_catalog_services.go
@@ -25,6 +25,10 @@ type CatalogServicesMonitorConfig struct {
 	DeprecatedSourceIncludesVar *bool `mapstructure:"source_includes_var"`
 }
 
+func (c *CatalogServicesMonitorConfig) VariableType() string {
+	return "catalog_services"
+}
+
 // Copy returns a deep copy of this configuration.
 func (c *CatalogServicesMonitorConfig) Copy() MonitorConfig {
 	if c == nil {

--- a/config/monitor_consul_kv.go
+++ b/config/monitor_consul_kv.go
@@ -18,6 +18,10 @@ type ConsulKVMonitorConfig struct {
 	Namespace  *string `mapstructure:"namespace"`
 }
 
+func (c *ConsulKVMonitorConfig) VariableType() string {
+	return "consul_kv"
+}
+
 // Copy returns a deep copy of this configuration.
 func (c *ConsulKVMonitorConfig) Copy() MonitorConfig {
 	if c == nil {

--- a/config/monitor_no.go
+++ b/config/monitor_no.go
@@ -4,6 +4,10 @@ package config
 // condition configuration block when it is unconfigured.
 type NoMonitorConfig struct{}
 
+func (c *NoMonitorConfig) VariableType() string {
+	return ""
+}
+
 // Copy returns a deep copy of this configuration.
 func (c *NoMonitorConfig) Copy() MonitorConfig {
 	if c == nil {

--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -40,6 +40,10 @@ type ServicesMonitorConfig struct {
 	CTSUserDefinedMeta map[string]string `mapstructure:"cts_user_defined_meta"`
 }
 
+func (c *ServicesMonitorConfig) VariableType() string {
+	return "services"
+}
+
 // Copy returns a deep copy of this configuration.
 func (c *ServicesMonitorConfig) Copy() MonitorConfig {
 	if c == nil {


### PR DESCRIPTION
This is the first PR out of ~3 PRs for [Expand usage of module_input / source_input block](https://github.com/hashicorp/consul-terraform-sync/issues/607)

Change: add new configuration type `ModuleInputConfigs` in order to allow multiple configuration per task

Subsequent change: update TaskConfig to replace ModuleInputConfig with ModuleInputConfigs (note plural).