### PR TITLE
Bump tests with timing for catalog-services or services+regexp delay

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -139,7 +139,7 @@ func TestServe(t *testing.T) {
 			})
 			require.NoError(t, err)
 			go api.Serve(ctx)
-			time.Sleep(time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 
 			u := fmt.Sprintf("http://localhost:%d/%s/%s",
 				port, defaultAPIVersion, tc.path)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -134,7 +134,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 
 			port := cts.Port()
 			taskSchedule := 10 * time.Second
-			scheduledWait := taskSchedule + 5*time.Second // buffer for task to execute
+			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 			// 0. Confirm one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)


### PR DESCRIPTION
https://github.com/hashicorp/consul-terraform-sync/pull/535 added 1 second delay to Catalog Services condition and services condition with regex