### PR TITLE
validate task.Variables

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -100,6 +100,7 @@ var (
 				Services:    []string{"serviceA", "serviceB", "serviceC"},
 				Providers:   []string{"X"},
 				Module:      String("Y"),
+				Variables:   make(map[string]string),
 				Condition: &CatalogServicesConditionConfig{
 					CatalogServicesMonitorConfig{
 						Regexp:           String(".*"),
@@ -235,11 +236,13 @@ func TestFromPath(t *testing.T) {
 				},
 				Tasks: &TaskConfigs{
 					{
-						Name:     String("taskA"),
-						Services: []string{"serviceA", "serviceB"},
+						Name:      String("taskA"),
+						Services:  []string{"serviceA", "serviceB"},
+						Variables: make(map[string]string),
 					}, {
-						Name:     String("taskB"),
-						Services: []string{"serviceC", "serviceD"},
+						Name:      String("taskB"),
+						Services:  []string{"serviceC", "serviceD"},
+						Variables: make(map[string]string),
 					},
 				},
 			},
@@ -272,6 +275,7 @@ func TestFromPath(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			c, err := fromPath(tc.path)
+
 			if tc.expected == nil {
 				assert.Error(t, err)
 				return
@@ -279,6 +283,13 @@ func TestFromPath(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, c)
+
+			// TODO: remove when tasks.Variables supported by config file
+			if c.Tasks != nil {
+				for i := range *c.Tasks {
+					(*c.Tasks)[i].Variables = make(map[string]string)
+				}
+			}
 			assert.Equal(t, *tc.expected, *c)
 		})
 	}
@@ -365,6 +376,7 @@ func TestConfig_Validate(t *testing.T) {
 		Module:      String("Z"),
 		Condition:   EmptyConditionConfig(),
 		ModuleInput: EmptyModuleInputConfig(),
+		Variables:   make(map[string]string),
 	})
 	*validMultiTask.TerraformProviders = append(*validMultiTask.TerraformProviders,
 		&TerraformProviderConfig{"Y": map[string]interface{}{}})

--- a/config/task.go
+++ b/config/task.go
@@ -53,7 +53,6 @@ type TaskConfig struct {
 	VarFiles []string `mapstructure:"variable_files"`
 
 	// TODO: Not supported by config file yet
-	// TODO: Add validation
 	Variables map[string]string
 
 	// Version is the version of source the task will use. For the Terraform
@@ -385,7 +384,9 @@ func (c *TaskConfig) Validate() error {
 		pNames[name] = true
 	}
 
-	// TODO validate c.Variables
+	if c.Variables == nil {
+		return fmt.Errorf("variables cannot be nil")
+	}
 
 	if err := c.BufferPeriod.Validate(); err != nil {
 		return err

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -723,9 +723,10 @@ func TestTaskConfig_Validate(t *testing.T) {
 		{
 			"valid: no cond: services configured",
 			&TaskConfig{
-				Name:     String("task"),
-				Services: []string{"api"},
-				Module:   String("path"),
+				Name:      String("task"),
+				Services:  []string{"api"},
+				Module:    String("path"),
+				Variables: make(map[string]string),
 			},
 			true,
 		},
@@ -747,8 +748,9 @@ func TestTaskConfig_Validate(t *testing.T) {
 		{
 			"valid: cs-cond: cond.regexp configured & no services",
 			&TaskConfig{
-				Name:   String("task"),
-				Module: String("path"),
+				Name:      String("task"),
+				Module:    String("path"),
+				Variables: make(map[string]string),
 				Condition: &CatalogServicesConditionConfig{
 					CatalogServicesMonitorConfig{
 						Regexp: String(".*"),
@@ -761,8 +763,9 @@ func TestTaskConfig_Validate(t *testing.T) {
 		{
 			"valid: services cond: no services",
 			&TaskConfig{
-				Name:   String("task"),
-				Module: String("path"),
+				Name:      String("task"),
+				Module:    String("path"),
+				Variables: make(map[string]string),
 				Condition: &ServicesConditionConfig{
 					ServicesMonitorConfig: ServicesMonitorConfig{
 						Regexp: String(".*"),
@@ -806,6 +809,7 @@ func TestTaskConfig_Validate(t *testing.T) {
 				Name:      String("task"),
 				Module:    String("path"),
 				Services:  []string{"api"},
+				Variables: make(map[string]string),
 				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
 			},
 			true,
@@ -815,6 +819,7 @@ func TestTaskConfig_Validate(t *testing.T) {
 			&TaskConfig{
 				Name:      String("task"),
 				Module:    String("path"),
+				Variables: make(map[string]string),
 				Condition: &ScheduleConditionConfig{String("* * * * * * *")},
 				ModuleInput: &ServicesModuleInputConfig{
 					ServicesMonitorConfig{Regexp: String(".*")}},
@@ -903,6 +908,7 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Services:  []string{"serviceA", "serviceB"},
 					Module:    String("path"),
 					Providers: []string{"providerA", "providerB"},
+					Variables: make(map[string]string),
 				},
 			},
 			isValid: true,
@@ -914,12 +920,14 @@ func TestTasksConfig_Validate(t *testing.T) {
 					Services:  []string{"serviceA", "serviceB"},
 					Module:    String("path"),
 					Providers: []string{"providerA", "providerB"},
+					Variables: make(map[string]string),
 				},
 				{
 					Name:      String("task2"),
 					Services:  []string{"serviceC"},
 					Module:    String("sourceC"),
 					Providers: []string{"providerC"},
+					Variables: make(map[string]string),
 				},
 			},
 			isValid: true,


### PR DESCRIPTION
- validate that task.Variables map is initialized
- do not support task.Variables map as part of the config file

part of #522 