### PR TITLE
Update Notifiers to support Module Inputs with Other Condition Types

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -571,43 +571,28 @@ func (tf *Terraform) initTaskTemplate() error {
 	return nil
 }
 
-// setNotifier TODO: update to support multiple module_inputs
-func (tf *Terraform) setNotifier(tmpl templates.Template) {
-	// Get the service count. Only one of task.services, condition "services",
-	// and source_input "services" can be configured per task
-	serviceCount := len(tf.task.Services())
-	if cond, ok := tf.task.Condition().(*config.ServicesConditionConfig); ok {
-		serviceCount = len(cond.Names)
-	}
-	for _, input := range tf.task.ModuleInputs() {
-		if services, ok := input.(*config.ServicesModuleInputConfig); ok {
-			serviceCount = len(services.Names)
-			// config validation ensures that module_input blocks only have
-			// one services type
-			break
-		}
-	}
-
-	additionalDepCount := 0
-	for _, input := range tf.task.ModuleInputs() {
-		switch input.(type) {
-		case *config.ConsulKVModuleInputConfig:
-			// If a ConsulKVModuleInputConfig is specified, then we need to add
-			// to the number of dependencies passed to the notifier, since consul-kv adds a dependency
-			additionalDepCount = 1
-		}
+// setNotifier sets a notifier on the template to ensure only the condition's
+// monitored changes (and not the module input's changes) trigger the task.
+func (tf *Terraform) setNotifier(tmpl templates.Template) error {
+	tmplFuncTotal, err := tf.countTmplFunc()
+	if err != nil {
+		return err
 	}
 
 	switch tf.task.Condition().(type) {
+	case *config.ServicesConditionConfig:
+		tf.template = notifier.NewServices(tmpl, tmplFuncTotal)
 	case *config.CatalogServicesConditionConfig:
-		tf.template = notifier.NewCatalogServicesRegistration(tmpl, serviceCount)
+		tf.template = notifier.NewCatalogServicesRegistration(tmpl, tmplFuncTotal)
 	case *config.ConsulKVConditionConfig:
-		tf.template = notifier.NewConsulKV(tmpl, serviceCount)
+		tf.template = notifier.NewConsulKV(tmpl, tmplFuncTotal)
 	case *config.ScheduleConditionConfig:
-		tf.template = notifier.NewSuppressNotification(tmpl, serviceCount+additionalDepCount)
+		tf.template = notifier.NewSuppressNotification(tmpl, tmplFuncTotal)
 	default:
-		tf.template = tmpl
+		// services list
+		tf.template = notifier.NewServices(tmpl, tmplFuncTotal)
 	}
+	return nil
 }
 
 // countTmplFunc counts the number of template functions (tmplfunc) that are

--- a/e2e/module_input_test.go
+++ b/e2e/module_input_test.go
@@ -1,0 +1,345 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
+	"github.com/hashicorp/consul/sdk/testutil"
+)
+
+const (
+	// config snippets for test cases: module and module_input fields
+	servicesInput = `
+	module = "./test_modules/local_instances_file"
+	module_input "services"{
+		// insert names or regexp field below
+		%s
+		filter = "Service.Tags not contains \"filtered\""
+		cts_user_defined_meta {
+			meta_key = "meta_value"
+		}
+	}`
+	consulKVInput = `
+	module = "./test_modules/consul_kv_file"
+	module_input "consul-kv" {
+		path = "key"
+		recurse = %t
+	}`
+)
+
+// TestModuleInput_Basic_CatalogServicesCondition exercises:
+// 1. basics of module input
+// 2. simultaneously module input with catalog-services condition
+//
+// Module input basic testing exercises:
+// - each type of module_input
+// - module_input configuration field details
+// - multiple module_inputs
+func TestModuleInput_Basic_CatalogServicesCondition(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name        string
+		tempDir     string
+		inputConfig string
+		validation  func(string, string)
+	}{
+		{
+			name:        "services regexp",
+			tempDir:     "mi_services_regexp",
+			inputConfig: fmt.Sprintf(servicesInput, `regexp = "api"`),
+			validation: func(workingDir, resourcesPath string) {
+				validateServices(t, true, []string{"api"}, resourcesPath)
+				validateServices(t, false, []string{"api-filtered"}, resourcesPath)
+				validateVariable(t, true, workingDir, "services", "meta_value")
+			},
+		},
+		{
+			name:        "services names",
+			tempDir:     "mi_services_names",
+			inputConfig: fmt.Sprintf(servicesInput, `names = ["api"]`),
+			validation: func(workingDir, resourcesPath string) {
+				validateServices(t, true, []string{"api"}, resourcesPath)
+				validateServices(t, false, []string{"api-filtered"}, resourcesPath)
+				validateVariable(t, true, workingDir, "services", "meta_value")
+			},
+		},
+		{
+			name:        "consul-kv recurse true",
+			tempDir:     "mi_consul_kv_recurse_true",
+			inputConfig: fmt.Sprintf(consulKVInput, true),
+			validation: func(workingDir, resourcesPath string) {
+				validateModuleFile(t, true, true, resourcesPath, "key", "value")
+				validateModuleFile(t, true, true, resourcesPath, "key/recurse",
+					"value-recurse")
+			},
+		},
+		{
+			name:        "consul-kv recurse false",
+			tempDir:     "mi_consul_kv_recurse_false",
+			inputConfig: fmt.Sprintf(consulKVInput, false),
+			validation: func(workingDir, resourcesPath string) {
+				validateModuleFile(t, true, true, resourcesPath, "key", "value")
+				validateModuleFile(t, true, false, resourcesPath, "key/recurse",
+					"value-recurse")
+			},
+		},
+		{
+			name:    "multiple",
+			tempDir: "mi_multiple",
+			inputConfig: fmt.Sprintf(servicesInput+consulKVInput,
+				`names = ["api"]`, false),
+			validation: func(workingDir, resourcesPath string) {
+				// services validation
+				validateServices(t, true, []string{"api"}, resourcesPath)
+				validateServices(t, false, []string{"api-filtered"}, resourcesPath)
+				validateVariable(t, true, workingDir, "services", "meta_value")
+				// consul-kv validation
+				validateModuleFile(t, true, true, resourcesPath, "key", "value")
+				validateModuleFile(t, true, false, resourcesPath, "key/recurse",
+					"value-recurse")
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc // rebind tc into this lexical scope for parallel use
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run table tests in parallel as they can take a lot of time
+
+			// set up Consul
+			srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+				HTTPSRelPath: "../testutils",
+			})
+			defer srv.Stop()
+
+			// set up task config with module & module_input
+			taskName := "module_input_task"
+			config := fmt.Sprintf(`task {
+				name = "%s"
+				condition "catalog-services" {
+					regexp = ["web"]
+					use_as_module_input = false
+				}
+				%s
+			}`, taskName, tc.inputConfig)
+
+			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tc.tempDir)
+			cts := ctsSetup(t, srv, tempDir, config)
+
+			// Test module_inputs basic behavior
+			// 0. Confirm baseline: no resources have been created
+			// 1. Confirm module_input don't trigger tasks: register a change
+			//    only affecting module inputs. Confirm no resources are created.
+			// 2. Confirm module_input templating & resources: register a change
+			//    to trigger conditions. Confirm changes for module_input
+			//    changes in step 1
+
+			// 0. Confirm no resources have been created
+			workingDir := fmt.Sprintf("%s/%s", tempDir, taskName)
+			resourcesPath := filepath.Join(workingDir, resourcesDir)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 1. Register stuff that the module_input monitors (for all test
+			// cases). Confirm no resources created.
+			service := testutil.TestService{ID: "api", Name: "api"}
+			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+			service = testutil.TestService{ID: "api-filtered", Name: "api", Tags: []string{"filtered"}}
+			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+
+			srv.SetKVString(t, "key", "value")
+			srv.SetKVString(t, "key/recurse", "value-recurse")
+
+			time.Sleep(defaultWaitForNoEvent)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 2. Register "web" service to trigger condition. Confirm that
+			// module_input's monitored stuff from step 1 happened
+			now := time.Now()
+			service = testutil.TestService{ID: "web", Name: "web"}
+			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+			api.WaitForEvent(t, cts, taskName, now, defaultWaitForEvent)
+
+			tc.validation(workingDir, resourcesPath)
+		})
+	}
+}
+
+// TestModuleInput_ServicesCondition generally exercises different variations
+// of services condition block with different types of module_input blocks
+func TestModuleInput_ServicesCondition(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name        string
+		tempDir     string
+		condField   string
+		inputConfig string
+		validate    func(string)
+	}{
+		{
+			name:        "regex cond consul-kv module_input",
+			tempDir:     "services_regex_mi_consul_kv",
+			condField:   `regexp = "api"`,
+			inputConfig: fmt.Sprintf(consulKVInput, true),
+			validate: func(resourcesPath string) {
+				validateModuleFile(t, true, true, resourcesPath, "key", "value")
+				validateModuleFile(t, true, true, resourcesPath, "key/recurse",
+					"value-recurse")
+			},
+		},
+		{
+			name:        "names cond consul-kv module_input",
+			tempDir:     "services_names_mi_consul_k",
+			condField:   `names = ["api"]`,
+			inputConfig: fmt.Sprintf(consulKVInput, true),
+			validate: func(resourcesPath string) {
+				validateModuleFile(t, true, true, resourcesPath, "key", "value")
+				validateModuleFile(t, true, true, resourcesPath, "key/recurse",
+					"value-recurse")
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc // rebind tc into this lexical scope for parallel use
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run table tests in parallel as they can take a lot of time
+
+			// set up Consul
+			srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+				HTTPSRelPath: "../testutils",
+			})
+			defer srv.Stop()
+
+			// set up task config with condition field, module, & module_input
+			taskName := "module_input_task"
+			config := fmt.Sprintf(`task {
+				name = "%s"
+				condition "services" {
+					%s
+					use_as_module_input = true
+				}
+				%s
+			}`, taskName, tc.condField, tc.inputConfig)
+
+			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tc.tempDir)
+			cts := ctsSetup(t, srv, tempDir, config)
+
+			// Test module_input behavior with Services Cond
+			// 0. Confirm baseline: no resources have been created
+			// 1. Confirm module_input don't trigger tasks: register a change
+			//    only affecting module inputs. Confirm no resources are created.
+			// 2. Confirm module_input templating & resources: register a change
+			//    to trigger conditions. Confirm changes for module_input
+			//    changes in step 1
+
+			// 0. Confirm no resources have been created
+			workingDir := fmt.Sprintf("%s/%s", tempDir, taskName)
+			resourcesPath := filepath.Join(workingDir, resourcesDir)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 1. Register stuff that the module_input monitors (for all test
+			// cases). Confirm no resources created.
+			srv.SetKVString(t, "key", "value")
+			srv.SetKVString(t, "key/recurse", "value-recurse")
+
+			time.Sleep(defaultWaitForNoEvent)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 2. Register "api" service to trigger condition. Confirm that
+			// module_input's monitored stuff from step 1 happened
+			now := time.Now()
+			service := testutil.TestService{ID: "api", Name: "api"}
+			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+			api.WaitForEvent(t, cts, taskName, now, defaultWaitForEvent)
+
+			tc.validate(resourcesPath)
+		})
+	}
+}
+
+// TestModuleInput_ConsulKVCondition generally exercises the consul-kv condition
+// block with different types of module_input blocks
+func TestModuleInput_ConsulKVCondition(t *testing.T) {
+	t.Parallel()
+
+	testcases := []struct {
+		name        string
+		tempDir     string
+		inputConfig string
+		validate    func(string, string)
+	}{
+		{
+			name:        "services",
+			tempDir:     "consul_kv_mi_services",
+			inputConfig: fmt.Sprintf(servicesInput, `regexp = "api"`),
+			validate: func(workingDir, resourcesPath string) {
+				validateServices(t, true, []string{"api"}, resourcesPath)
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc // rebind tc into this lexical scope for parallel use
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // Run table tests in parallel as they can take a lot of time
+
+			// set up Consul
+			srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+				HTTPSRelPath: "../testutils",
+			})
+			defer srv.Stop()
+
+			// set up task config with module & module_input
+			taskName := "module_input_task"
+			config := fmt.Sprintf(`task {
+				name = "%s"
+				condition "consul-kv" {
+					path = "key"
+					use_as_module_input = false
+				}
+				%s
+			}`, taskName, tc.inputConfig)
+
+			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tc.tempDir)
+			cts := ctsSetup(t, srv, tempDir, config)
+
+			// Test module_input behavior with Consul KV Cond
+			// 0. Confirm baseline: no resources have been created
+			// 1. Confirm module_input don't trigger tasks: register a change
+			//    only affecting module inputs. Confirm no resources are created.
+			// 2. Confirm module_input templating & resources: register a change
+			//    to trigger conditions. Confirm changes for module_input
+			//    changes in step 1
+
+			// 0. Confirm no resources have been created
+			workingDir := fmt.Sprintf("%s/%s", tempDir, taskName)
+			resourcesPath := filepath.Join(workingDir, resourcesDir)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 1. Register stuff that the module_input monitors (for all test
+			// cases). Confirm no resources created.
+			service := testutil.TestService{ID: "api", Name: "api"}
+			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
+
+			time.Sleep(defaultWaitForNoEvent)
+			testutils.CheckDir(t, false, resourcesPath)
+
+			// 2. Register kv pair to trigger condition. Confirm that
+			// module_input's monitored stuff from step 1 happened
+			now := time.Now()
+			srv.SetKVString(t, "key", "value")
+			api.WaitForEvent(t, cts, taskName, now, defaultWaitForEvent)
+
+			tc.validate(workingDir, resourcesPath)
+		})
+	}
+}

--- a/templates/tftmpl/notifier/catalog_services_registration_test.go
+++ b/templates/tftmpl/notifier/catalog_services_registration_test.go
@@ -58,7 +58,7 @@ func Test_CatalogServicesRegistration_Notify(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Twice()
-		n := NewCatalogServicesRegistration(tmpl, 2)
+		n := NewCatalogServicesRegistration(tmpl, 3)
 
 		// 1. first services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})
@@ -93,7 +93,7 @@ func Test_CatalogServicesRegistration_Notify(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Once()
-		n := NewCatalogServicesRegistration(tmpl, 1)
+		n := NewCatalogServicesRegistration(tmpl, 2)
 
 		// 1. services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})

--- a/templates/tftmpl/notifier/consul_kv.go
+++ b/templates/tftmpl/notifier/consul_kv.go
@@ -15,22 +15,34 @@ import (
 // It suppresses notifications for changes to other tmplfuncs.
 type ConsulKV struct {
 	templates.Template
+	logger logging.Logger
 
-	// count all dependencies needed to complete once-mode
-	once     bool
-	depTotal int
-	counter  int
-	logger   logging.Logger
+	// count all tmplfuncs needed to complete once-mode
+	once    bool
+	tfTotal int
+	counter int
 }
 
 // NewConsulKV creates a new ConsulKVNotifier.
-// serviceCount parameter: the number of services the task is configured with
-func NewConsulKV(tmpl templates.Template, serviceCount int) *ConsulKV {
+//
+// tmplFuncTotal param: the total number of monitored tmplFuncs in the template.
+// This is the number of monitored tmplfuncs needed for both the consul-kv
+// condition and any module inputs. This number is equivalent to the number of
+// hashicat dependencies.
+//
+// Examples:
+// - consul-kv: 1 tmplfunc
+// - services-regex: 1 tmplfunc
+// - services-name: len(services) tmplfuncs
+func NewConsulKV(tmpl templates.Template, tmplFuncTotal int) *ConsulKV {
+	logger := logging.Global().Named(logSystemName).Named(kvSubsystemName)
+	logger.Trace("creating notifier", "type", kvSubsystemName,
+		"tmpl_func_total", tmplFuncTotal)
+
 	return &ConsulKV{
 		Template: tmpl,
-		// expect services and either []*dep.KeyPair or *dep.KeyPair
-		depTotal: serviceCount + 1,
-		logger:   logging.Global().Named(logSystemName).Named(kvSubsystemName),
+		tfTotal:  tmplFuncTotal,
+		logger:   logger,
 	}
 }
 
@@ -54,19 +66,22 @@ func (n *ConsulKV) Notify(d interface{}) (notify bool) {
 
 	if !n.once {
 		n.counter++
-		// after all dependencies are received, notify so once-mode can complete
-		if n.counter >= n.depTotal {
+		// after a dependency is received for each tmplfunc, send notification
+		// so that once-mode can complete
+		if n.counter >= n.tfTotal {
 			n.logger.Debug("notify once-mode complete")
 			n.once = true
 			notify = true
 		}
 	}
 
+	// dependency for {{ keyExistsGet }} i.e. recurse=false
 	if _, ok := d.(*dep.KeyPair); ok {
 		n.logger.Debug("notify Consul KV pair change")
 		notify = true
 	}
 
+	// dependency for {{ keys }} i.e. recurse=true
 	if _, ok := d.([]*dep.KeyPair); ok {
 		n.logger.Debug("notify Consul KV pair list change")
 		notify = true

--- a/templates/tftmpl/notifier/consul_kv_test.go
+++ b/templates/tftmpl/notifier/consul_kv_test.go
@@ -60,7 +60,7 @@ func Test_ConsulKV_Notify_Once_Mode_Key_Pairs(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Twice()
-		n := NewConsulKV(tmpl, 2)
+		n := NewConsulKV(tmpl, 3)
 
 		// 1. first services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})
@@ -94,7 +94,7 @@ func Test_ConsulKV_Notify_Once_Mode_Key_Pairs(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Once()
-		n := NewConsulKV(tmpl, 1)
+		n := NewConsulKV(tmpl, 2)
 
 		// 1. services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})
@@ -127,7 +127,7 @@ func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Times(2)
-		n := NewConsulKV(tmpl, 2)
+		n := NewConsulKV(tmpl, 3)
 
 		// 1. first services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})
@@ -161,7 +161,7 @@ func Test_ConsulKV_Notify_Once_Mode_Single_Key(t *testing.T) {
 
 		tmpl := new(mocks.Template)
 		tmpl.On("Notify", mock.Anything).Return(true).Once()
-		n := NewConsulKV(tmpl, 1)
+		n := NewConsulKV(tmpl, 2)
 
 		// 1. services dependency does not notify
 		notify := n.Notify([]*dep.HealthService{})

--- a/templates/tftmpl/notifier/services.go
+++ b/templates/tftmpl/notifier/services.go
@@ -1,0 +1,83 @@
+package notifier
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/templates"
+	"github.com/hashicorp/hcat/dep"
+)
+
+const servicesSubsystemName = "services"
+
+// Services is a custom notifier expected to be used for a template that
+// contains {{ service }} or {{ servicesRegex }} template function (tmplfuncs)
+// for the condition and any other tmplfuncs for module inputs
+//
+// This notifier only notifies on changes to services instances information and
+// once-mode. It suppresses notifications for changes to other tmplfuncs.
+type Services struct {
+	templates.Template
+	logger logging.Logger
+
+	// count all tmplfuncs needed to complete once-mode
+	once    bool
+	tfTotal int
+	counter int
+}
+
+// NewServices creates a new Services notifier.
+//
+// tmplFuncTotal param: the total number of monitored tmplFuncs in the template.
+// This is the number of monitored tmplfuncs needed for both the services
+// condition and any module inputs. This number is equivalent to the number of
+// hashicat dependencies.
+//
+// Examples:
+// - services-regex: 1 tmplfunc
+// - services-name: len(services) tmplfuncs
+// - consul-kv: 1 tmplfunc
+func NewServices(tmpl templates.Template, tmplFuncTotal int) *Services {
+	logger := logging.Global().Named(logSystemName).Named(servicesSubsystemName)
+	logger.Trace("creating notifier", "type", servicesSubsystemName,
+		"tmpl_func_total", tmplFuncTotal)
+
+	return &Services{
+		Template: tmpl,
+		tfTotal:  tmplFuncTotal,
+		logger:   logger,
+	}
+}
+
+// Notify notifies when service instance changes: existing service instance
+// changes, service instance de/registers
+//
+// Once-mode requires a notification when all dependencies are received in order
+// to trigger CTS. Otherwise it will hang.
+func (n *Services) Notify(d interface{}) (notify bool) {
+	n.logger.Debug("received dependency change", "dependency_type", fmt.Sprintf("%T", d))
+	notify = false
+
+	if !n.once {
+		n.counter++
+		// after a dependency is received for each tmplfunc, send notification
+		// so that once-mode can complete
+		if n.counter >= n.tfTotal {
+			n.logger.Debug("notify once-mode complete")
+			n.once = true
+			notify = true
+		}
+	}
+
+	// dependency for {{ servicesRegex }} or {{ service }}
+	if _, ok := d.([]*dep.HealthService); ok {
+		n.logger.Debug("notify services change")
+		notify = true
+	}
+
+	// let the template know that its dependencies have updated so that it will
+	// re-render when trigger. this does not cause task trigger
+	n.Template.Notify(d)
+
+	return notify
+}

--- a/templates/tftmpl/notifier/services_test.go
+++ b/templates/tftmpl/notifier/services_test.go
@@ -1,0 +1,103 @@
+package notifier
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
+	"github.com/hashicorp/hcat/dep"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_Services_Notify_DaemonMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		dep    interface{}
+		notify bool
+	}{
+		{
+			"notify: services dep",
+			[]*dep.HealthService{},
+			true,
+		},
+		{
+			"don't notify: non-services dep",
+			&dep.KeyPair{Key: "k", Value: "v"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpl := new(mocks.Template)
+			tmpl.On("Notify", mock.Anything).Return(true)
+
+			n := Services{Template: tmpl, once: true, logger: logging.NewNullLogger()}
+			actual := n.Notify(tc.dep)
+			assert.Equal(t, tc.notify, actual)
+		})
+	}
+}
+
+func Test_Services_Notify_OnceMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("services-not-last", func(t *testing.T) {
+		// Test that notifier notifies at the end of once-mode, particularly
+		// for the race-condition when a non-service dependency (which normally
+		// does not notify) is received after service dependency.
+
+		// Notifier has 2 dependencies: 1 service and 1 consul-kv
+		// 1. receive services dependency, notify for service change
+		// 2. receive consul-kv dependency, notify for once-mode
+
+		tmpl := new(mocks.Template)
+		tmpl.On("Notify", mock.Anything).Return(true)
+		n := NewServices(tmpl, 2)
+
+		// 1. service dep notifies
+		notify := n.Notify([]*dep.HealthService{})
+		assert.True(t, notify, "services dep should cause notification")
+		assert.False(t, n.once, "got 1/2 deps. once-mode should not be completed")
+		assert.Equal(t, 1, n.counter, "services dep should be 1st dep")
+
+		// 2. consul-kv dep notifies because once-mode (leads to hanging if it doesn't)
+		notify = n.Notify([]*dep.KeyPair{})
+		assert.True(t, notify, "consul-kv dep should cause notification")
+		assert.True(t, n.once, "got 2/2 deps. once-mode should be completed")
+		assert.Equal(t, 2, n.counter, "consul-kv dep should be 2nd dep")
+
+		// 3. confirm that future consul-kv dep never notify
+		notify = n.Notify([]*dep.KeyPair{})
+		assert.False(t, notify, "second consul-kv dep should not have notified")
+		notify = n.Notify([]*dep.KeyPair{})
+		assert.False(t, notify, "third consul-kv dep should not have notified")
+	})
+
+	t.Run("services-last", func(t *testing.T) {
+		// Test that notifier notifies at the end of once-mode
+
+		// Notifier has 2 dependencies: 1 service and 1 consul-kv
+		// 1. receive consul-kv dependency, don't notify
+		// 2. receive services dependency, notify for once-mode / service change
+
+		tmpl := new(mocks.Template)
+		tmpl.On("Notify", mock.Anything).Return(true)
+		n := NewServices(tmpl, 2)
+
+		// 1. consul-kv dep does not notify
+		notify := n.Notify([]*dep.KeyPair{})
+		assert.False(t, notify, "consul-kv dep should not cause notification")
+		assert.False(t, n.once, "got 1/2 deps. once-mode should not be completed")
+		assert.Equal(t, 1, n.counter, "consul-kv dep should be 1st dep")
+
+		// 2. service dep notifies
+		notify = n.Notify([]*dep.HealthService{})
+		assert.True(t, notify, "services dep should cause notification")
+		assert.True(t, n.once, "got 2/2 deps. once-mode should be completed")
+		assert.Equal(t, 2, n.counter, "services dep should be 2nd dep")
+	})
+}

--- a/templates/tftmpl/notifier/suppress_notification.go
+++ b/templates/tftmpl/notifier/suppress_notification.go
@@ -26,18 +26,30 @@ type SuppressNotification struct {
 	logger logging.Logger
 
 	// count all dependencies needed to complete once-mode
-	once     bool
-	depTotal int
-	counter  int
+	once    bool
+	tfTotal int
+	counter int
 }
 
 // NewSuppressNotification creates a new SuppressNotification notifier.
-// serviceCount parameter: the number of services the task is configured with
-func NewSuppressNotification(tmpl templates.Template, dependencyCount int) *SuppressNotification {
+//
+// tmplFuncTotal param: the total number of monitored tmplFuncs in the template.
+// This is the number of monitored tmplfuncs needed for the scheduled task's
+// module inputs. This number is equivalent to the number of hashicat dependencies
+//
+// Examples:
+// - services-regex: 1 tmplfunc
+// - services-name: len(services) tmplfuncs
+// - consul-kv: 1 tmplfunc
+func NewSuppressNotification(tmpl templates.Template, tmplFuncTotal int) *SuppressNotification {
+	logger := logging.Global().Named(logSystemName).Named(supSubsystemName)
+	logger.Trace("creating notifier", "type", supSubsystemName,
+		"tmpl_func_total", tmplFuncTotal)
+
 	return &SuppressNotification{
 		Template: tmpl,
-		depTotal: dependencyCount,
-		logger:   logging.Global().Named(logSystemName).Named(supSubsystemName),
+		tfTotal:  tmplFuncTotal,
+		logger:   logger,
 	}
 }
 
@@ -46,7 +58,7 @@ func NewSuppressNotification(tmpl templates.Template, dependencyCount int) *Supp
 // task is triggered by another means.
 //
 // Once-mode requires a notification when all dependencies are received in order
-// to trigger CTS. It will hang otherwise.
+// to trigger CTS. Otherwise it will hang.
 func (n *SuppressNotification) Notify(d interface{}) (notify bool) {
 	n.logger.Debug("received dependency change", "dependency_type", fmt.Sprintf("%T", d))
 
@@ -54,16 +66,17 @@ func (n *SuppressNotification) Notify(d interface{}) (notify bool) {
 
 	if !n.once {
 		n.counter++
-		// after all dependencies are received, notify so once-mode can complete
-		if n.counter >= n.depTotal {
+		// after a dependency for each tmplfunc is received, send notification
+		// so that once-mode can complete
+		if n.counter >= n.tfTotal {
 			n.logger.Debug("notify once-mode complete")
 			n.once = true
 			notify = true
 		}
 	}
 
-	// still let the template know that its dependencies have been updated so
-	// that it will re-render when triggered, even if we do not notify watcher.
+	// let the template know that its dependencies have updated so that it will
+	// re-render when trigger. this does not cause task trigger
 	n.Template.Notify(d)
 
 	return notify


### PR DESCRIPTION
"Final" PR for [Expand usage of module_input / source_input block](https://github.com/hashicorp/consul-terraform-sync/issues/607)

Earlier PRs:
1. Added ModuleInputConfigs object. Updated config validation for supporting multiple module_input blocks ([link](https://github.com/hashicorp/consul-terraform-sync/pull/608))
2. Update TaskConfig with ModuleInputConfigs. Updated config validation for impact on conditions. Includes downstream changes to driver, controller, etc. ([link](https://github.com/hashicorp/consul-terraform-sync/pull/610))

This PR: update notifiers to handle module inputs to other types of conditions (previously only schedule condition)
- Add a Services notifier for services condition and services list to suppress module inputs
- Update other notifiers to support non-services module inputs
- Updates to driver to set Services notifier and counting of template functions
- e2e tests for module inputs