### PR TITLE
Feature 522 fix watcher after delete and inspect

### DIFF
--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -221,7 +221,7 @@ func TestServer_TaskDelete(t *testing.T) {
 			func(d *driver.Drivers) {
 				mockD.On("TemplateIDs").Return(nil)
 				d.Add("success", mockD)
-				mockD.On("DeleteTask", ctx).Return()
+				mockD.On("DestroyTask", ctx).Return()
 			},
 			"",
 		}, {

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -221,6 +221,7 @@ func TestServer_TaskDelete(t *testing.T) {
 			func(d *driver.Drivers) {
 				mockD.On("TemplateIDs").Return(nil)
 				d.Add("success", mockD)
+				mockD.On("DeleteTask", ctx).Return()
 			},
 			"",
 		}, {
@@ -240,6 +241,7 @@ func TestServer_TaskDelete(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			drivers := driver.NewDrivers()
+
 			tc.setup(drivers)
 			ctrl.baseController.drivers = drivers
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,6 +32,9 @@ type Driver interface {
 	// UpdateTask supports updating certain fields of a task
 	UpdateTask(ctx context.Context, task PatchTask) (InspectPlan, error)
 
+	// DeleteTask deletes a task from the driver
+	DeleteTask(ctx context.Context)
+
 	// Task returns the task information of the driver
 	Task() *Task
 

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -32,8 +32,8 @@ type Driver interface {
 	// UpdateTask supports updating certain fields of a task
 	UpdateTask(ctx context.Context, task PatchTask) (InspectPlan, error)
 
-	// DeleteTask deletes a task from the driver
-	DeleteTask(ctx context.Context)
+	// DestroyTask destroys task dependencies so that it can be safely deleted
+	DestroyTask(ctx context.Context)
 
 	// Task returns the task information of the driver
 	Task() *Task

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -143,6 +144,12 @@ func (d *Drivers) Delete(taskName string) error {
 
 	if taskName == "" {
 		return errors.New("task name cannot be empty")
+	}
+
+	driver, ok := d.drivers[taskName]
+
+	if ok {
+		driver.DeleteTask(context.Background())
 	}
 
 	delete(d.drivers, taskName)

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
 )
 
 // Drivers wraps the map of task-name to associated driver so that the map
@@ -149,7 +151,16 @@ func (d *Drivers) Delete(taskName string) error {
 	driver, ok := d.drivers[taskName]
 
 	if ok {
-		driver.DeleteTask(context.Background())
+		driver.DestroyTask(context.Background())
+	} else {
+		logging.Global().Trace("attempted to destroy a non-existent task", taskNameLogKey, taskName)
+	}
+
+	// delete driver templates associated with task
+	for val, id := range d.driverTemplates {
+		if val == taskName {
+			delete(d.driverTemplates, id)
+		}
 	}
 
 	delete(d.drivers, taskName)

--- a/driver/drivers_test.go
+++ b/driver/drivers_test.go
@@ -3,7 +3,9 @@ package driver
 import (
 	"testing"
 
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -142,7 +144,11 @@ func TestDrivers_Delete(t *testing.T) {
 	}
 
 	drivers := NewDrivers()
-	err := drivers.Add("task_a", &Terraform{})
+
+	w := new(mocks.Watcher)
+	w.On("Deregister", mock.Anything).Return()
+
+	err := drivers.Add("task_a", &Terraform{watcher: w})
 	require.NoError(t, err)
 
 	for _, tc := range cases {

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -164,8 +164,8 @@ func (tf *Terraform) InitTask(ctx context.Context) error {
 	return tf.initTask(ctx)
 }
 
-// DeleteTask deletes the task on the driver
-func (tf *Terraform) DeleteTask(ctx context.Context) {
+// DestroyTask destroys task dependencies so that it is safe for deletion
+func (tf *Terraform) DestroyTask(ctx context.Context) {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -169,7 +169,7 @@ func (tf *Terraform) DeleteTask(ctx context.Context) {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	tf.deleteTask(ctx)
+	tf.deregisterTemplate(ctx)
 }
 
 // SetBufferPeriod sets the buffer period for the task. Do not set this when
@@ -243,6 +243,7 @@ func (tf *Terraform) InspectTask(ctx context.Context) (InspectPlan, error) {
 	}
 
 	plan, err := tf.inspectTask(ctx, true)
+	tf.deregisterTemplate(ctx)
 	return plan, err
 }
 
@@ -427,8 +428,8 @@ func (tf *Terraform) initTask(ctx context.Context) error {
 	return nil
 }
 
-// deleteTask attempts to delete and deregister the hashicat template
-func (tf *Terraform) deleteTask(ctx context.Context) {
+// deregisterTemplate attempts to deregister the hashicat template
+func (tf *Terraform) deregisterTemplate(ctx context.Context) {
 	tf.watcher.Deregister(tf.template)
 }
 
@@ -494,9 +495,6 @@ func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectP
 		return InspectPlan{}, errors.Wrap(err,
 			fmt.Sprintf("error tf-plan for '%s'", taskName))
 	}
-
-	// Delete the task once the inspection has completed
-	tf.deleteTask(ctx)
 
 	return InspectPlan{
 		ChangesPresent: c,

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -271,6 +271,9 @@ func TestUpdateTask(t *testing.T) {
 				watcher:  w,
 				logger:   logging.NewNullLogger(),
 			}
+			if tc.callInspect {
+				w.On("Deregister", mock.Anything).Return()
+			}
 
 			if tc.callInit {
 				c.On("Init", ctx).Return(nil).Once()
@@ -438,6 +441,7 @@ func TestUpdateTask_Inspect(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil)
+			w.On("Deregister", mock.Anything).Return()
 
 			tf := &Terraform{
 				task:     tc.task,

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -198,6 +198,10 @@ func fakeHandlerConfig(dir string) hclConfig {
 	return hclConfig(fmt.Sprintf(`
 working_dir = "%s"
 
+buffer_period {
+	enabled = false
+}
+
 terraform_provider "fake-sync" {
 	alias = "failure"
 	name = "failure"

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6
+	github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e
+	github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6 h1:tnssxyX1DuXJlEluppFdRBiMlhzyDrQTZDHKl/LmAvM=
-github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749 h1:C8lv/IeZio2CqvTBUM/5q5O0N2hF6OSZFEvbfpenpTQ=
+github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e h1:YgGBo8mJz6+iTaPb38YETBp4IvnRk0Lyu1URG79hC5U=
-github.com/hashicorp/hcat v0.2.1-0.20220118173847-18b777d83f4e/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6 h1:tnssxyX1DuXJlEluppFdRBiMlhzyDrQTZDHKl/LmAvM=
+github.com/hashicorp/hcat v0.2.1-0.20220120230750-5ddff017e1a6/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -29,17 +29,8 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 }
 
 // DeleteTask provides a mock function with given fields: ctx
-func (_m *Driver) DeleteTask(ctx context.Context) error {
-	ret := _m.Called(ctx)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *Driver) DeleteTask(ctx context.Context) {
+	_m.Called(ctx)
 }
 
 // InitTask provides a mock function with given fields: ctx

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -28,6 +28,20 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 	return r0
 }
 
+// DeleteTask provides a mock function with given fields: ctx
+func (_m *Driver) DeleteTask(ctx context.Context) error {
+	ret := _m.Called(ctx)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // InitTask provides a mock function with given fields: ctx
 func (_m *Driver) InitTask(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/mocks/driver/driver.go
+++ b/mocks/driver/driver.go
@@ -29,7 +29,7 @@ func (_m *Driver) ApplyTask(ctx context.Context) error {
 }
 
 // DeleteTask provides a mock function with given fields: ctx
-func (_m *Driver) DeleteTask(ctx context.Context) {
+func (_m *Driver) DestroyTask(ctx context.Context) {
 	_m.Called(ctx)
 }
 

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -16,8 +16,13 @@ type Watcher struct {
 	mock.Mock
 }
 
-// Buffer provides a mock function with given fields: _a0
-func (_m *Watcher) Buffer(_a0 hcat.Notifier) bool {
+// BufferReset provides a mock function with given fields: _a0
+func (_m *Watcher) BufferReset(_a0 hcat.Notifier) {
+	_m.Called(_a0)
+}
+
+// Buffering provides a mock function with given fields: _a0
+func (_m *Watcher) Buffering(_a0 hcat.Notifier) bool {
 	ret := _m.Called(_a0)
 
 	var r0 bool
@@ -28,11 +33,6 @@ func (_m *Watcher) Buffer(_a0 hcat.Notifier) bool {
 	}
 
 	return r0
-}
-
-// BufferReset provides a mock function with given fields: _a0
-func (_m *Watcher) BufferReset(_a0 hcat.Notifier) {
-	_m.Called(_a0)
 }
 
 // Complete provides a mock function with given fields: _a0
@@ -47,6 +47,17 @@ func (_m *Watcher) Complete(_a0 hcat.Notifier) bool {
 	}
 
 	return r0
+}
+
+// Deregister provides a mock function with given fields: ns
+func (_m *Watcher) Deregister(ns ...hcat.Notifier) {
+	_va := make([]interface{}, len(ns))
+	for _i := range ns {
+		_va[_i] = ns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, _va...)
+	_m.Called(_ca...)
 }
 
 // MarkForSweep provides a mock function with given fields: notifier

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -42,7 +42,7 @@ type Resolver interface {
 type Watcher interface {
 	Watch(context.Context, chan string) error
 	WaitCh(context.Context) <-chan error
-	Buffer(hcat.Notifier) bool
+	Buffering(hcat.Notifier) bool
 	BufferReset(hcat.Notifier)
 	MarkForSweep(notifier hcat.IDer)
 	SetBufferPeriod(min, max time.Duration, tmplIDs ...string)

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -53,4 +53,5 @@ type Watcher interface {
 	Complete(hcat.Notifier) bool
 	Recaller(hcat.Notifier) hcat.Recaller
 	Register(ns ...hcat.Notifier) error
+	Deregister(ns ...hcat.Notifier)
 }


### PR DESCRIPTION
Once a task is created via the CLI, the task doesn't update with latest var.services on Consul catalog changes.

I noticed that when a task is created with inspect, and when a task is deleted, service changes still trigger the watcher. I see the following log:

```
2022-01-18T15:14:04.169-0800 [DEBUG] ctrl: template was notified for update but the template ID does not match any task: template_id=389697c5d1a1b87d1b059e80c7c08103
```

I added Deregister functionality to hcat, and added a public method. Now inspect and delete calls will call the deregister function, which fixes the issue.

part of #522