### PR TITLE
Deprecate `port` CLI option

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -54,7 +54,9 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 
 	// Values provide both default values, and documentation for the default value when -help is used
 	m.port = m.flags.Int(FlagPort, config.DefaultPort,
-		fmt.Sprintf("The port to use for the Consul-Terraform-Sync API server, it is preferred to use the %s field instead", FlagHTTPAddr))
+		fmt.Sprintf("[Deprecated] The port to use for the Consul-Terraform-Sync API server, "+
+			"it is preferred to use the %s field instead", FlagHTTPAddr))
+
 	m.addr = m.flags.String(FlagHTTPAddr, api.DefaultAddress, fmt.Sprintf("The `address` and port of the CTS daemon. The value can be an IP "+
 		"address or DNS address, but it must also include the port. This can "+
 		"also be specified via the %s environment variable. The "+
@@ -126,6 +128,8 @@ func (m *meta) clientConfig() *api.ClientConfig {
 	// Let the Client determine its default first, then override with command flag values
 	c := api.DefaultClientConfig()
 	if m.isFlagParsedAndFound(FlagPort) {
+		m.UI.Warn(fmt.Sprintf("Warning: '%s' option is deprecated and will be removed in a later version. "+
+			"It is preferred to use the '%s' option instead.\n", FlagPort, FlagHTTPAddr))
 		c.Port = *m.port
 	}
 	if m.isFlagParsedAndFound(FlagHTTPAddr) {

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -71,12 +71,12 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 		},
 		{
 			"non-existing task",
-			[]string{fmt.Sprintf("-port=%d", cts.Port()), "non-existent-task"},
+			[]string{fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()), "non-existent-task"},
 			"does not exist or has not been initialized yet",
 		},
 		{
 			"out of order arguments",
-			[]string{fakeFailureTaskName, fmt.Sprintf("-port %d", cts.Port())},
+			[]string{fakeFailureTaskName, fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress())},
 			"All flags are required to appear before positional arguments",
 		},
 	}
@@ -181,7 +181,7 @@ func TestE2E_DisableTaskCommand(t *testing.T) {
 	}{
 		{
 			"happy path",
-			[]string{fmt.Sprintf("-port=%d", cts.Port()), dbTaskName},
+			[]string{fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()), dbTaskName},
 			"disable complete!",
 		},
 	}
@@ -237,11 +237,11 @@ func TestE2E_ReenableTaskTriggers(t *testing.T) {
 	//    (one new event)
 
 	// 0. disable then re-enable the task
-	subcmd := []string{"task", "disable", fmt.Sprintf("-port=%d", cts.Port()), dbTaskName}
+	subcmd := []string{"task", "disable", fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()), dbTaskName}
 	output, err := runSubcommand(t, "", subcmd...)
 	assert.NoError(t, err, output)
 
-	subcmd = []string{"task", "enable", fmt.Sprintf("-port=%d", cts.Port()), dbTaskName}
+	subcmd = []string{"task", "enable", fmt.Sprintf("-%s=%s", command.FlagHTTPAddr, cts.FullAddress()), dbTaskName}
 	output, err = runSubcommand(t, "yes\n", subcmd...)
 	assert.NoError(t, err, output)
 


### PR DESCRIPTION
**Description**
The option `-http-addr` was added to the CLI as part of implementing TLS on the CTS API (https://github.com/hashicorp/consul-terraform-sync/pull/490). This allows users to specify the whole address of the CTS API, including the port, so `-port` should be deprecated in favor of `-http-addr`.

---

Added 'deprecated' to the helper text of 'port' flag.
Switched usage of 'port' to 'http-addr' in e2e tests.

Output after the change:
```
$ $GOPATH/bin/consul-terraform-sync task disable -port=8558 example-task
==> Waiting to disable 'example-task'...

Warning: 'port' option is deprecated and will be removed in a later version. It is preferred to use the 'http-addr' option instead.

==> 'example-task' disable complete!
```