### PR TITLE
Deprecate events payload 'source' field for new 'module' field

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -569,6 +569,7 @@ func TestJsonResponse(t *testing.T) {
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
 								Source:    "./test_modules/local_instances_file",
+								Module:    "./test_modules/local_instances_file",
 							},
 						},
 						{
@@ -584,6 +585,7 @@ func TestJsonResponse(t *testing.T) {
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
 								Source:    "./test_modules/local_instances_file",
+								Module:    "./test_modules/local_instances_file",
 							},
 						},
 					},

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -268,7 +268,7 @@ func (rw *ReadWrite) checkApply(ctx context.Context, d driver.Driver, retry, onc
 	ev, err := event.NewEvent(taskName, &event.Config{
 		Providers: task.ProviderNames(),
 		Services:  task.ServiceNames(),
-		Source:    task.Source(),
+		Module:    task.Source(),
 	})
 	if err != nil {
 		return false, fmt.Errorf("error creating event for task %s: %s",
@@ -399,7 +399,7 @@ func (rw *ReadWrite) runTask(ctx context.Context, d driver.Driver) error {
 	ev, err := event.NewEvent(taskName, &event.Config{
 		Providers: task.ProviderNames(),
 		Services:  task.ServiceNames(),
-		Source:    task.Source(),
+		Module:    task.Source(),
 	})
 	if err != nil {
 		logger.Error("error initializing run task event", "error", err)

--- a/controller/server.go
+++ b/controller/server.go
@@ -142,7 +142,7 @@ func (rw *ReadWrite) TaskUpdate(ctx context.Context, updateConf config.TaskConfi
 		ev, err := event.NewEvent(taskName, &event.Config{
 			Providers: task.ProviderNames(),
 			Services:  task.ServiceNames(),
-			Source:    task.Source(),
+			Module:    task.Source(),
 		})
 		if err != nil {
 			err = errors.Wrap(err, fmt.Sprintf("error creating task update"+

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -747,6 +747,7 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 		wd, err := os.Getwd()
 		assert.NoError(t, err)
 		source := filepath.Join(wd, "./test_modules/local_instances_file")
+		assert.Equal(t, source, e.Config.Module)
 		assert.Equal(t, source, e.Config.Source)
 
 		if taskName == fakeSuccessTaskName {

--- a/event/event.go
+++ b/event/event.go
@@ -37,7 +37,12 @@ type Error struct {
 type Config struct {
 	Providers []string `json:"providers"`
 	Services  []string `json:"services"`
-	Source    string   `json:"source"`
+
+	// Source was deprecated in v0.5. Use Module instead. External packages
+	// should use Module except for tests
+	Source string `json:"source"`
+	// Module introduced in 0.5
+	Module string `json:"module"`
 }
 
 // NewEvent configures a new event with a task name and any relevant information
@@ -50,6 +55,12 @@ func NewEvent(taskName string, config *Config) (*Event, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Set deprecated 'source' field if not set
+	if config != nil && config.Source == "" {
+		config.Source = config.Module
+	}
+
 	return &Event{
 		ID:       uuid,
 		TaskName: taskName,
@@ -88,6 +99,23 @@ func (e *Event) End(err error) {
 }
 
 // GoString defines the printable version of this struct.
+func (c *Config) GoString() string {
+	if c == nil {
+		return "(*Config)(nil)"
+	}
+
+	return fmt.Sprintf("&Config{"+
+		"Providers:%s, "+
+		"Services:%s, "+
+		"Module:%s"+
+		"}",
+		c.Providers,
+		c.Services,
+		c.Module,
+	)
+}
+
+// GoString defines the printable version of this struct.
 func (e *Event) GoString() string {
 	if e == nil {
 		return "(*Event)(nil)"
@@ -108,6 +136,6 @@ func (e *Event) GoString() string {
 		e.StartTime,
 		e.EndTime,
 		e.EventError,
-		e.Config,
+		e.Config.GoString(),
 	)
 }


### PR DESCRIPTION
Closes: https://github.com/hashicorp/consul-terraform-sync/issues/569

This is part of the work to rename 'source' to 'module'. This PR adds the new 'module' field but leaves the 'source' field as is for now. Later at an announced time, 'source' field will be removed.

Future work: renaming driver for various 'source' language.

Note: I kept the 'source' variable name the same i.e. `Config.Source` rather than following other deprecation patterns to rename the field to `Config.DeprecatedSource`. My thought was that it might be potentially a breaking change since users might use the `Config{}` to unmarshall JSON? Feedback appreciated. Thank you