### PR TITLE
Move service propagation wait time into tmplfunc Fetch

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -264,21 +264,6 @@ func (rw *ReadWrite) checkApply(ctx context.Context, d driver.Driver, retry, onc
 		return true, nil
 	}
 
-	switch cond := task.Condition().(type) {
-	// Services condition (with regex) and catalog services condition have
-	// multiple API calls it depends on for updates. This adds an additional
-	// delay for hcat to process any new updates in the background that may be
-	// related to this task. 1 second is  used to account for Consul cluster
-	// propagation of the change at scale.
-	// https://www.hashicorp.com/blog/hashicorp-consul-global-scale-benchmark
-	case *config.ServicesConditionConfig:
-		if len(cond.Names) == 0 {
-			<-time.After(time.Second)
-		}
-	case *config.CatalogServicesConditionConfig:
-		<-time.After(time.Second)
-	}
-
 	// setup to store event information
 	ev, err := event.NewEvent(taskName, &event.Config{
 		Providers: task.ProviderNames(),
@@ -409,21 +394,6 @@ func (rw *ReadWrite) runTask(ctx context.Context, d driver.Driver) error {
 
 	rw.drivers.SetActive(taskName)
 	defer rw.drivers.SetInactive(taskName)
-
-	switch cond := task.Condition().(type) {
-	// Services condition (with regex) and catalog services condition have
-	// multiple API calls it depends on for updates. This adds an additional
-	// delay for hcat to process any new updates in the background that may be
-	// related to this task. 1 second is  used to account for Consul cluster
-	// propagation of the change at scale.
-	// https://www.hashicorp.com/blog/hashicorp-consul-global-scale-benchmark
-	case *config.ServicesConditionConfig:
-		if len(cond.Names) == 0 {
-			<-time.After(time.Second)
-		}
-	case *config.CatalogServicesConditionConfig:
-		<-time.After(time.Second)
-	}
 
 	// Create new event for task run
 	ev, err := event.NewEvent(taskName, &event.Config{

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/hcat"
 	"github.com/hashicorp/hcat/dep"
@@ -139,6 +140,25 @@ func (d *catalogServicesRegistrationQuery) Fetch(clients dep.Clients) (interface
 		LastIndex:   qm.LastIndex,
 		LastContact: qm.LastContact,
 	}
+
+	// Tasks monitoring CatalogServices will likely also monitor Services
+	// information. Without a delay, CatalogServices may have services that
+	// are not yet propagated to Services template function as healthy services
+	// since services are initially set as critical.
+	// https://www.consul.io/docs/discovery/checks#initial-health-check-status
+	//
+	// This adds an additional delay to process new Services used elsewhere for
+	// this task. 1 second is used to account for Consul cluster propagation of
+	// the change at scale. https://www.hashicorp.com/blog/hashicorp-consul-global-scale-benchmark
+	//
+	// This affects template functions that have propagation depencies on
+	// services. KV query is not affected by this because it is a different
+	// entity within Consul.
+	//
+	// Note: this creates unnecessary latency for tasks that monitor
+	// CatalogServices but not Services. Currently this use-case seems unlikely
+	// so have not implemented this complexity at this time
+	time.Sleep(1 * time.Second)
 
 	return catalogServices, rm, nil
 }


### PR DESCRIPTION
Context: `TestCondition_Schedule_Basic/module_input_services` (services regex
module_input) was flaking because when two monitored services are registered
simultaneously, the servicesRegexQuery.Fetch() would only return one of the
monitored services because the second services hadn't propagated through Consul
yet.

Previously tasks were all triggered when any dependency was updated. This likely
created a natural delay for service propagation. Recent refactors to trigger
individual tasks only when their dependency updates, removed that delay and
exposed this race condition and increased test flakiness.

Worked on together with @findkim 