### PR TITLE
Initialize disabled tasks

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -161,12 +161,6 @@ func (tf *Terraform) InitTask(ctx context.Context) error {
 	tf.mu.Lock()
 	defer tf.mu.Unlock()
 
-	if !tf.task.IsEnabled() {
-		tf.logger.Trace(
-			"task disabled. skip initializing", taskNameLogKey, tf.task.Name())
-		return nil
-	}
-
 	return tf.initTask(ctx)
 }
 

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -257,8 +257,8 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 	t.Parallel()
 	// Test enabling and disabling a task
-	// 1. Start with disabled task. Confirm task not initialized, resources not
-	//    created
+	// 1. Start with disabled task. Confirm task is initialized, but
+	//    not run (resources not created)
 	// 2. API to inspect enabling task. Confirm plan looks good, resources not
 	//    created, and task not actually enabled.
 	// 3. API to actually enable task. Confirm resources are created
@@ -272,12 +272,14 @@ func TestE2E_TaskEndpoints_UpdateEnableDisable(t *testing.T) {
 
 	cts := ctsSetup(t, srv, tempDir, disabledTaskConfig(tempDir))
 
-	// Confirm that terraform files were not generated for a disabled task
-	files := testutils.CheckDir(t, true, fmt.Sprintf("%s/%s", tempDir, "disabled_task"))
-	require.Equal(t, len(files), 0)
+	// Confirm that terraform files were generated for a disabled task
+	taskPath := filepath.Join(tempDir, disabledTaskName)
+	files := testutils.CheckDir(t, true, taskPath)
+	require.Greater(t, len(files), 0)
+	testutils.CheckFile(t, true, taskPath, "terraform.tfvars.tmpl")
 
 	// Confirm that resources were not created
-	resourcesPath := filepath.Join(tempDir, disabledTaskName, resourcesDir)
+	resourcesPath := filepath.Join(taskPath, resourcesDir)
 	testutils.CheckDir(t, false, resourcesPath)
 
 	// Update Task API: enable task with inspect run option

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -179,6 +179,8 @@ func TestE2E_EnableTaskCommand(t *testing.T) {
 			eventCountNow = eventCount(t, disabledTaskName, cts.Port())
 			require.Equal(t, eventCountBase+1, eventCountNow,
 				"event count did not increment once. task was not triggered as expected")
+			resourcesPath := filepath.Join(tempDir, disabledTaskName, resourcesDir)
+			validateServices(t, true, []string{"api", "api-1", "web"}, resourcesPath)
 		})
 	}
 }


### PR DESCRIPTION
Removed the restriction where only enabled tasks were initialized. This solves a bug that occurs only in the case where a task is initially disabled and then enabled for the first time, which was introduced during a previous refactor. It also has the advantage of catching initialization errors earlier at start up or creation instead of when it is first enabled.

**Bug Details:**
After enabling a task that was initially disabled (setting `enabled=false` in either the config file or in a create task API request), the task was not executing when there were changes in Consul and logging `template was notified for update but the template ID does not match any task`.

The cause of this is that hcat is returning template IDs to the controller and the controller then uses a mapping of the template IDs to task names to determine which task to run (see https://github.com/hashicorp/consul-terraform-sync/pull/535). However, when a task is disabled, the initialization is skipped so there is no template ID, thus no entry in the map.

**Change Details:**
- Updated e2e test for enabling a task so that the test now catches the bug (see failure [here](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/2979/workflows/ef249b62-58f4-41dd-84d6-f88d14a9b2da/jobs/7373))
- Removed check for enabled tasks in the Terraform driver init task method

An alternative fix was to add the template ID to the map in `rw.TaskUpdate()`. We'll potentially have to do something like this in the future when we implement updating tasks fully where the template and template ID may change. However, removing the init restriction seemed like a better general fix, as it made a task disabled initially less of a special case, and also had the added benefit of quicker feedback if the init failed.