### PR TITLE
Fix E2E test - TF module sleep usage

### DIFF
--- a/e2e/test_modules/delayed_module/variables.tf
+++ b/e2e/test_modules/delayed_module/variables.tf
@@ -25,5 +25,5 @@ variable "services" {
 variable "delay" {
   description = "duration of time to delay before completing"
   type        = string
-  default     = "5s"
+  default     = "5"
 }


### PR DESCRIPTION
When run locally (on a Mac, bash shell), the `sleep 5s` command in the TF module does not run, only `sleep <value>` is supported. Since the default for the sleep command is seconds, the `s` is being removed.

Reference [1]:
```
Please note that the sleep command in BSD family of operating systems (such as FreeBSD) or macOS/mac OS X does NOT take any suffix arguments (m/h/d). It only takes arguments in seconds. So syntax for sleep command for Unix like system is:
sleep NUMBER
```
[1] https://www.cyberciti.biz/faq/linux-unix-sleep-bash-scripting/