### PR TITLE
add netcgo tag to darwin build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,6 +347,8 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Build
+        env:
+          GO_TAGS: "${{ env.GO_TAGS }} netcgo"
         run: |
           mkdir dist out
           go build -o dist/ \


### PR DESCRIPTION
This corrects a longstanding issue with DNS on mac builds that we were unable to address until migrating our build platform.