### PR TITLE
Output TFC run URL in approval prompt

### DIFF
--- a/command/task_create.go
+++ b/command/task_create.go
@@ -161,6 +161,9 @@ func (c *taskCreateCommand) Run(args []string) int {
 	b, _ := json.MarshalIndent(taskResp.Task, "    ", "  ")
 	c.UI.Output(fmt.Sprintf("Task: %s\n", string(b)))
 	c.UI.Output(fmt.Sprintf("Plan: \n%s", *taskResp.Run.Plan))
+	if taskResp.Run.TfcRunUrl != nil {
+		c.UI.Output(fmt.Sprintf("Terraform Cloud Run URL: %s\n", *taskResp.Run.TfcRunUrl))
+	}
 
 	if !*c.autoApprove {
 		if exitCode, approved := c.meta.requestUserApprovalCreate(taskName); !approved {


### PR DESCRIPTION
Outputting the URL to the TFC speculative plan if returned by the API.

TFC Inspect:
```
==> Inspecting changes to resource if creating task 'mkam_test_task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

    Request ID: d23a047c-771b-c25c-5393-3b7c92c419c7
    Task: {
      "condition": {
        "services": {
          "names": [
            "api",
            "web"
          ],
          "use_as_module_input": true
        }
      },
      "module": "mkam/hello/cts",
      "name": "mkam_test_task"
    }

    Plan:
Terraform v1.1.4
on linux_amd64
Configuring remote state backend...
Initializing Terraform configuration...
{"@level":"info","@message":"Terraform 1.1.4","@module":"terraform.ui","@timestamp":"2022-01-27T21:58:55.218688Z","terraform":"1.1.4","type":"version","ui":"1.0"}
...
{"@level":"warn","@message":"Warning: Value for undeclared variable","@module":"terraform.ui","@timestamp":"2022-01-27T21:58:56.168822Z","diagnostic":{"severity":"warning","summary":"Value for undeclared variable","detail":"The root module does not declare a variable named \"local\" but a value was found in file \"/terraform/terraform.tfvars\". If you meant to use this value, add a \"variable\" block to the configuration.\n\nTo silence these warnings, use TF_VAR_... environment variables to provide certain \"global\" settings to all configurations in your organization. To reduce the verbosity of these warnings, use the -compact-warnings option."},"type":"diagnostic"}

    Terraform Cloud Run URL: https://app.terraform.io/app/<my-org>/workspaces/mkam_test_task/runs/run-123

==> Creating the task will perform the actions described above.

```