### PR TITLE
Rename "source" and "include" related wording in e2e directory

### DIFF
--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -609,7 +609,7 @@ func TestE2E_TaskEndpoints_InvalidSchema(t *testing.T) {
 	cts := ctsSetup(t, srv, tempDir,
 		moduleTaskConfig(initialTaskName, "./test_modules/local_instances_file"))
 
-	// Create a task with invalid source field (boolean instead of string)
+	// Create a task with invalid module field (boolean instead of string)
 	u := fmt.Sprintf("http://localhost:%d/v1/tasks", cts.Port())
 
 	taskName := "created-task"
@@ -754,9 +754,9 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 		assert.Equal(t, []string{"api"}, e.Config.Services)
 		wd, err := os.Getwd()
 		assert.NoError(t, err)
-		source := filepath.Join(wd, "./test_modules/local_instances_file")
-		assert.Equal(t, source, e.Config.Module)
-		assert.Equal(t, source, e.Config.Source)
+		module := filepath.Join(wd, "./test_modules/local_instances_file")
+		assert.Equal(t, module, e.Config.Module)
+		assert.Equal(t, module, e.Config.Source)
 
 		if taskName == fakeSuccessTaskName {
 			assert.True(t, e.Success)

--- a/e2e/condition_catalog_service_test.go
+++ b/e2e/condition_catalog_service_test.go
@@ -25,15 +25,13 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 	setParallelism(t)
 
 	cases := []struct {
-		name        string
-		tempDirName string
-		resource    string
-		taskConf    string
-		include     bool
+		name             string
+		resource         string
+		taskConf         string
+		useAsModuleInput bool
 	}{
 		{
-			"use_as_module_input=true",
-			"cs_condition_registration_include",
+			"use_as_module_input_true",
 			"api_tags.txt",
 			`task {
 	name = "catalog_task"
@@ -47,8 +45,7 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 			true,
 		},
 		{
-			"use_as_module_input=false",
-			"cs_condition_registration",
+			"use_as_module_input_false",
 			"api-1.txt",
 			`task {
 	name = "catalog_task"
@@ -66,7 +63,7 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			testCatalogServicesRegistration(t, tc.taskConf, "catalog_task",
-				tc.tempDirName, tc.resource, tc.include)
+				"cs_condition_registration_use_", tc.resource, tc.useAsModuleInput)
 		})
 	}
 }
@@ -326,7 +323,7 @@ func testCatalogServicesRegistration(t *testing.T, taskConf, taskName,
 	})
 	defer srv.Stop()
 
-	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tempDirName)
+	tempDir := fmt.Sprintf("%s%s%t", tempDirPrefix, tempDirName, useAsModuleInput)
 	cts := ctsSetup(t, srv, tempDir, taskConf)
 
 	// Test that task is triggered on service registration and deregistration

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -56,26 +56,26 @@ func TestCondition_Services(t *testing.T) {
 		useAsModuleInput bool
 	}{
 		{
-			"regexp & includes true",
-			"services_cond_regexp_include",
+			"regexp - use true",
+			"services_cond_regexp_use",
 			regexpConfig,
 			true,
 		},
 		{
-			"regexp & includes false",
-			"services_cond_regexp_include_false",
+			"regexp - use false",
+			"services_cond_regexp_use_false",
 			regexpConfig,
 			false,
 		},
 		{
-			"names & includes true",
-			"services_cond_names_include",
+			"names - use true",
+			"services_cond_names_use",
 			namesConfig,
 			true,
 		},
 		{
-			"names & includes false",
-			"services_cond_names_include_false",
+			"names - use false",
+			"services_cond_names_use_false",
 			namesConfig,
 			false,
 		},

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -50,10 +50,10 @@ func TestCondition_Services(t *testing.T) {
 	}`
 
 	cases := []struct {
-		name              string
-		taskName          string
-		taskConfig        string
-		sourceIncludesVar bool
+		name             string
+		taskName         string
+		taskConfig       string
+		useAsModuleInput bool
 	}{
 		{
 			"regexp & includes true",
@@ -92,7 +92,7 @@ func TestCondition_Services(t *testing.T) {
 
 			tempDir := fmt.Sprintf("%s%s", tempDirPrefix, tc.taskName)
 
-			config := fmt.Sprintf(tc.taskConfig, tc.taskName, tc.sourceIncludesVar)
+			config := fmt.Sprintf(tc.taskConfig, tc.taskName, tc.useAsModuleInput)
 			cts := ctsSetup(t, srv, tempDir, config)
 
 			// Test that regex filter is filtering service registration information and
@@ -138,8 +138,8 @@ func TestCondition_Services(t *testing.T) {
 			require.Equal(t, eventCountExpected, eventCountNow,
 				"event count did not increment once. task was not triggered as expected")
 			resourcesPath := filepath.Join(workingDir, resourcesDir)
-			validateServices(t, tc.sourceIncludesVar, []string{"api-web-1"}, resourcesPath)
-			validateVariable(t, tc.sourceIncludesVar, workingDir, "services", "my_meta_value")
+			validateServices(t, tc.useAsModuleInput, []string{"api-web-1"}, resourcesPath)
+			validateVariable(t, tc.useAsModuleInput, workingDir, "services", "my_meta_value")
 
 			// 3. Add a second node to the service "api-web"
 			now = time.Now()
@@ -150,7 +150,7 @@ func TestCondition_Services(t *testing.T) {
 			eventCountExpected++
 			require.Equal(t, eventCountExpected, eventCountNow,
 				"event count did not increment once. task was not triggered as expected")
-			validateServices(t, tc.sourceIncludesVar, []string{"api-web-1", "api-web-2"}, resourcesPath)
+			validateServices(t, tc.useAsModuleInput, []string{"api-web-1", "api-web-2"}, resourcesPath)
 
 			// 4. Register a matched service "api-web" with tag_a
 			now = time.Now()

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -140,15 +140,16 @@ task {
 `, webTaskName))
 }
 
-// appendModuleTask adds a task configuration with the given name and source, along with any additional
+// appendModuleTask adds a task configuration with the given name and module, along with any additional
 // task configurations (e.g., condition, providers) provided with the opts parameter
-func (c hclConfig) appendModuleTask(name string, source string, opts ...string) hclConfig {
-	return c.appendString(moduleTaskConfig(name, source, opts...))
+func (c hclConfig) appendModuleTask(name string, module string, opts ...string) hclConfig {
+	return c.appendString(moduleTaskConfig(name, module, opts...))
 }
 
-// moduleTaskConfig generates a task configuration string with the given name and source, along with any
-// additional task configurations (e.g., condition, providers) provided with the opts parameter
-func moduleTaskConfig(name string, source string, opts ...string) string {
+// moduleTaskConfig generates a task configuration string with the given name
+// and module, along with any additional task configurations (e.g., condition,
+// providers) provided with the opts parameter
+func moduleTaskConfig(name string, module string, opts ...string) string {
 	var optsConfig string
 	if len(opts) > 0 {
 		optsConfig = "\n" + strings.Join(opts, "\n")
@@ -162,7 +163,7 @@ task {
 	module = "%s"
 	%s
 }
-`, name, source, optsConfig)
+`, name, module, optsConfig)
 }
 
 func baseConfig(wd string) hclConfig {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -344,7 +344,7 @@ func TestE2E_FilterStatus(t *testing.T) {
 			"_default",
 			`task {
 				name = "%s"
-				source = "./test_modules/null_resource"
+				module = "./test_modules/null_resource"
 				services = ["api", "unhealthy-service"]
 			}
 			`,
@@ -362,7 +362,7 @@ func TestE2E_FilterStatus(t *testing.T) {
 			"_w_filter",
 			`task {
 				name = "%s"
-				source = "./test_modules/null_resource"
+				module = "./test_modules/null_resource"
 				services = ["api", "unhealthy-service"]
 			}
 			service {

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -278,8 +278,8 @@ func validateServices(t *testing.T, expected bool, services []string, servicesPa
 //
 // e.g., checking that the module created a file for a Consul KV entry where the filename is the key and the
 // content is the value
-func validateModuleFile(t *testing.T, srcIncludesVar, expected bool, resourcesPath, name, expectedContent string) {
-	if !srcIncludesVar {
+func validateModuleFile(t *testing.T, useAsModuleInput, expected bool, resourcesPath, name, expectedContent string) {
+	if !useAsModuleInput {
 		// module will not generate files based on the module input variables,
 		// nothing to validate
 		return

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -272,15 +272,15 @@ func validateServices(t *testing.T, expected bool, services []string, servicesPa
 	}
 }
 
-// validateModuleFile checks whether a file dependent on a source input variable was created or not by the module.
-// If the file exists, then the content of the file is checked as well. If source_includes_var is set to false,
+// validateModuleFile checks whether a file dependent on a module input variable was created or not by the module.
+// If the file exists, then the content of the file is checked as well. If use_as_module_input is set to false,
 // then no file is expected to be created so no checks will be made. Assumes the file has a .txt extension.
 //
 // e.g., checking that the module created a file for a Consul KV entry where the filename is the key and the
 // content is the value
 func validateModuleFile(t *testing.T, srcIncludesVar, expected bool, resourcesPath, name, expectedContent string) {
 	if !srcIncludesVar {
-		// module will not generate files based on the source input variables,
+		// module will not generate files based on the module input variables,
 		// nothing to validate
 		return
 	}


### PR DESCRIPTION
Context:
- "SourceIncludesVar" deprecated - results in some of the "include" wording losing context: [#568](https://github.com/hashicorp/consul-terraform-sync/issues/568)
- "Source" wording to refer to Terraform module is deprecated: [#566](https://github.com/hashicorp/consul-terraform-sync/issues/566), [#567](https://github.com/hashicorp/consul-terraform-sync/issues/567)

This PR removes this deprecated language from the the e2e directory

Future work:
- Rename deprecated language in remaining directories