### PR TITLE
Feature 522 set bufferperiod

### DIFF
--- a/api/task_create.go
+++ b/api/task_create.go
@@ -11,7 +11,6 @@ import (
 )
 
 // CreateTask creates a task
-// TODO: handle setting the bufferPeriod of the driver
 func (h *TaskLifeCycleHandler) CreateTask(w http.ResponseWriter, r *http.Request, params oapigen.CreateTaskParams) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/controller/server.go
+++ b/controller/server.go
@@ -40,8 +40,8 @@ func (rw *ReadWrite) TaskCreate(ctx context.Context, taskConfig config.TaskConfi
 		return config.TaskConfig{}, err
 	}
 
-	// TODO: Set the buffer period
-	// d.SetBufferPeriod()
+	// Set the buffer period
+	d.SetBufferPeriod()
 
 	// Add the task driver to the driver list only after successful create
 	err = rw.drivers.Add(*taskConfig.Name, d)
@@ -70,8 +70,7 @@ func (rw *ReadWrite) TaskCreateAndRun(ctx context.Context, taskConfig config.Tas
 		return config.TaskConfig{}, err
 	}
 
-	// TODO: Set the buffer period
-	// d.SetBufferPeriod()
+	d.SetBufferPeriod()
 
 	// Add the task driver to the driver list only after successful create and run
 	err = rw.drivers.Add(*taskConfig.Name, d)

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -59,6 +59,7 @@ func TestServer_TaskCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		mockD := new(mocksD.Driver)
+		mockD.On("SetBufferPeriod").Return()
 		mockDriver(ctx, mockD, driverTask)
 		ctrl.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
@@ -122,6 +123,7 @@ func TestServer_TaskCreateAndRun(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		mockD := new(mocksD.Driver)
+		mockD.On("SetBufferPeriod").Return()
 		task, err := driver.NewTask(driver.TaskConfig{
 			Enabled: true,
 			Name:    "task",
@@ -148,6 +150,7 @@ func TestServer_TaskCreateAndRun(t *testing.T) {
 
 	t.Run("disabled task", func(t *testing.T) {
 		mockD := new(mocksD.Driver)
+		mockD.On("SetBufferPeriod").Return()
 		task, err := driver.NewTask(driver.TaskConfig{
 			Enabled: false,
 			Name:    "task",

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -571,7 +571,7 @@ func (tf *Terraform) initTaskTemplate() error {
 	tf.setNotifier(tmpl)
 
 	err = tf.watcher.Register(tf.template)
-	if err != nil && err != hcat.RegistryErr {
+	if err != nil && err != hcat.ErrRegistry {
 		tf.logger.Error("unable to register template", taskNameLogKey, tf.task.Name(), "error", err)
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749
+	github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749 h1:C8lv/IeZio2CqvTBUM/5q5O0N2hF6OSZFEvbfpenpTQ=
-github.com/hashicorp/hcat v0.2.1-0.20220124222903-f099b707b749/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830 h1:UN+sa9ksfSCgoih45eJDHXXoFVhY3hHh5qXc1qo09Qw=
+github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=


### PR DESCRIPTION
This PR adds the SetBufferPeriod function back into the Create Task CLI/API flow. This was removed because a bug in hcat was causing this not to work as expected. WIth the latest hcat this has been resolved.

A buffer period is defined as
``` json
        "buffer_period": {
            "enabled": true,
            "min": "10s",
            "max": "60s"
        }
```

### Min values tests
I manually tested the `min` was being honoured using the following scenarios and verified it worked as expected:
1) Created a task without a task buffer_period, confirmed it used the CTS configuration as default
    - Confirmed it works with a disabled buffer_period configured in CTS
    - Confirmed it works with an enabled buffer_period configured in CTS
2) Created a task with a task buffer_period, confirmed it used the tasks buffer period
   - confirmed it works with a disabled buffer_period configured in CTS
   - confirmed it works with an enabled buffer_period configured in CTS

### Max value tests
I manually tested the `max` was being honoured using the following scenarios and verified it worked as expected:
Flapped a service (register/deregistering) continuously and verified that the task triggered at the `max` time value, regardless of continuous flapping
- Note when I tested this initially a bug in hcat was causing this not to be honoured, that is why an hcat upgrade is included in this PR

### Further Work not in scope of this PR
Currently there are no e2e tests verifying buffer_period behaviour. In the future these should be added to test the Create Task workflow, as well as tasks defined via the CTS configuration file

part of #522 