### PR TITLE
Final updates for "source", "src", and "include"

### DIFF
--- a/api/representation.go
+++ b/api/representation.go
@@ -82,7 +82,7 @@ func (tr TaskRequest) ToTaskConfig() (config.TaskConfig, error) {
 		tc.Services = *tr.Task.Services
 	}
 
-	// Convert source input
+	// Convert module input
 	if tr.Task.ModuleInput != nil {
 		inputs := make(config.ModuleInputConfigs, 0)
 		if tr.Task.ModuleInput.Services != nil {

--- a/config/condition.go
+++ b/config/condition.go
@@ -19,7 +19,7 @@ type ConditionConfig interface {
 
 // EmptyConditionConfig sets an unconfigured condition with a non-null value
 func EmptyConditionConfig() ConditionConfig {
-	return &NoMonitorConfig{}
+	return &NoConditionConfig{}
 }
 
 // conditionToTypeFunc is a decode hook function to decode a ConditionConfig

--- a/config/condition_no.go
+++ b/config/condition_no.go
@@ -1,43 +1,43 @@
 package config
 
-// NoMonitorConfig is used to set a non-null value to a task's condition
+// NoConditionConfig is used to set a non-null value to a task's condition
 // configuration block when it is unconfigured.
-type NoMonitorConfig struct{}
+type NoConditionConfig struct{}
 
-func (c *NoMonitorConfig) VariableType() string {
+func (c *NoConditionConfig) VariableType() string {
 	return ""
 }
 
 // Copy returns a deep copy of this configuration.
-func (c *NoMonitorConfig) Copy() MonitorConfig {
+func (c *NoConditionConfig) Copy() MonitorConfig {
 	if c == nil {
 		return nil
 	}
-	return &NoMonitorConfig{}
+	return &NoConditionConfig{}
 }
 
 // Merge combines all values in this configuration with the values in the other
 // configuration, with values in the other configuration taking precedence.
 // Maps and slices are merged, most other values are overwritten. Complex
 // structs define their own merge functionality.
-func (c *NoMonitorConfig) Merge(o MonitorConfig) MonitorConfig {
+func (c *NoConditionConfig) Merge(o MonitorConfig) MonitorConfig {
 	if c == nil {
 		return nil
 	}
-	return &NoMonitorConfig{}
+	return &NoConditionConfig{}
 }
 
 // Finalize ensures there no nil pointers.
-func (c *NoMonitorConfig) Finalize() {
+func (c *NoConditionConfig) Finalize() {
 }
 
 // Validate validates the values and required options. This method is recommended
 // to run after Finalize() to ensure the configuration is safe to proceed.
-func (c *NoMonitorConfig) Validate() error {
+func (c *NoConditionConfig) Validate() error {
 	return nil
 }
 
 // GoString defines the printable version of this struct.
-func (c *NoMonitorConfig) GoString() string {
+func (c *NoConditionConfig) GoString() string {
 	return "{}"
 }

--- a/config/monitor_no.go
+++ b/config/monitor_no.go
@@ -1,7 +1,7 @@
 package config
 
-// NoMonitorConfig is used to set a non-null value to a task's source input or
-// condition configuration block when it is unconfigured.
+// NoMonitorConfig is used to set a non-null value to a task's condition
+// configuration block when it is unconfigured.
 type NoMonitorConfig struct{}
 
 func (c *NoMonitorConfig) VariableType() string {

--- a/config/task.go
+++ b/config/task.go
@@ -56,9 +56,8 @@ type TaskConfig struct {
 	// TODO: Add validation
 	Variables map[string]string
 
-	// Version is the version of source the task will use. For the Terraform
-	// driver, this is the module version. The latest version will be used as
-	// the default if omitted.
+	// Version is the module version for the task to use. The latest version
+	// will be used as the default if omitted.
 	Version *string `mapstructure:"version"`
 
 	// The Terraform client version to use for the task when configured with CTS

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -791,7 +791,7 @@ func TestTasksConfig_Validate(t *testing.T) {
 				{
 					Name:      String("task2"),
 					Services:  []string{"serviceC"},
-					Module:    String("sourceC"),
+					Module:    String("path"),
 					Providers: []string{"providerC"},
 				},
 			},
@@ -807,7 +807,7 @@ func TestTasksConfig_Validate(t *testing.T) {
 				}, {
 					Name:      String("task"),
 					Services:  []string{"serviceA"},
-					Module:    String("source2"),
+					Module:    String("path"),
 					Providers: []string{"providerA"},
 				},
 			},

--- a/examples/reference-example/example-config.hcl
+++ b/examples/reference-example/example-config.hcl
@@ -15,7 +15,7 @@ consul {
 task {
   name = "my-task"
   description = "automate services for website X"
-  source = "namespace/example/module"
+  module = "namespace/example/module"
   version = "1.1.0"
   providers = ["myprovider"]
   services = ["web", "api"]

--- a/examples/reference-example/sync-tasks/my-task/main.tf
+++ b/examples/reference-example/sync-tasks/my-task/main.tf
@@ -30,7 +30,7 @@ provider "myprovider" {
 
 # automate services for website X
 module "my-task" {
-  source   = "namespace/example/module"
+  module   = "namespace/example/module"
   version  = "1.1.0"
   services = var.services
 

--- a/examples/runnable-example/config.hcl
+++ b/examples/runnable-example/config.hcl
@@ -7,7 +7,7 @@ consul {
 task {
   name = "example-task"
   description = "Writes the service name, id, and IP address to a file"
-  source = "./example-module"
+  module = "./example-module"
   providers = ["local"]
   services = ["web", "api"]
   variable_files = []

--- a/examples/runnable-example/example-module/README.md
+++ b/examples/runnable-example/example-module/README.md
@@ -26,7 +26,7 @@ example.hcl
 task {
   name = "example-task"
   description = "Writes the service name, id, and IP address to a file"
-  source = "../../example-module"
+  module = "../../example-module"
   providers = ["local"]
   services = ["web", "api"]
   variable_files = [/path/to/task-example.tfvars]


### PR DESCRIPTION
Previously, deprecated configurations regarding "source", "src", "included" were
updated in the templates, driver, and e2e directory.

This is the final search across the whole CTS repo for this language

Commits:
 - Rename "source", "src", and "include"
 - Rename NoMonitorConfig => NoConditionConfig to adjust for change to support multiple `module_input` blocks