### PR TITLE
[RDX-272] Enable security-scan and update build.yml for release/0.4.x branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,10 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:    
       # Push events on main branch
-      # - main
+      - main
       # Push events to branches matching refs/heads/release/**
-      # - 'release/**'
-      - 'clabry-update-crt'
+      - 'release/**'
+
 
 env:
   PKG_NAME: "consul-terraform-sync"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,10 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:    
       # Push events on main branch
-      - main
+      # - main
       # Push events to branches matching refs/heads/release/**
-      - 'release/**'
+      # - 'release/**'
+      - 'clabry-update-crt'
 
 env:
   PKG_NAME: "consul-terraform-sync"
@@ -26,7 +27,7 @@ jobs:
         run: |
           make version
           echo "::set-output name=product-version::$(make version)"
-
+  
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-latest
@@ -62,31 +63,37 @@ jobs:
           echo "::set-output name=ldflags::"-s -w -X \'$project/version.Name=${{ env.PKG_NAME }}\' \
           -X \'$project/version.GitCommit=$sha\' \
           -X \'$project/version.GitDescribe=v$(make version base=1)\'""
-    
-  build-386:
+  build:
     needs: [get-product-version, set-ld-flags]
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [ linux, freebsd, windows ]
-        goarch: [ "386" ]
-        go: [ "1.16" ]
+        include:
+          - {go: "1.16", goos: "linux", goarch: "386"}
+          - {go: "1.16", goos: "linux", goarch: "amd64"}
+          - {go: "1.16", goos: "linux", goarch: "arm"}
+          - {go: "1.16", goos: "linux", goarch: "arm64"}
+          - {go: "1.16", goos: "freebsd", goarch: "386"}
+          - {go: "1.16", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.16", goos: "windows", goarch: "386"}
+          - {go: "1.16", goos: "windows", goarch: "amd64"}
+          - {go: "1.16", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      DOCKER_CLI_EXPERIMENTAL: enabled
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup go
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
+
       - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
         run: |
           mkdir dist out
           go build -o dist/ \
@@ -113,24 +120,29 @@ jobs:
           deb_depends: "openssl"
           rpm_depends: "openssl"
 
+      - name: Set Package Names
+        if: ${{ matrix.goos == 'linux' }}
+        run: |
+          echo "RPM_PACKAGE=$(basename out/*.rpm)" >> $GITHUB_ENV
+          echo "DEB_PACKAGE=$(basename out/*.deb)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.goos == 'linux' }}
         with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_i386.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_i386.deb
+          name: ${{ env.RPM_PACKAGE }}
+          path: out/${{ env.RPM_PACKAGE }}
 
       - uses: actions/upload-artifact@v2
         if: ${{ matrix.goos == 'linux' }}
         with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.i386.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.i386.rpm
+          name: ${{ env.DEB_PACKAGE }}
+          path: out/${{ env.DEB_PACKAGE }}
 
-  build-amd64:
+  build-darwin:
     needs: [get-product-version, set-ld-flags]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       matrix:
-        goos: [linux, freebsd, solaris, windows]
+        goos: [darwin]
         goarch: ["amd64"]
         go: ["1.16"]
       fail-fast: true
@@ -140,7 +152,6 @@ jobs:
     env:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
-      DOCKER_CLI_EXPERIMENTAL: enabled
       LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
 
     steps:
@@ -152,200 +163,8 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - name: Build
-        run: |
-          mkdir dist out
-          go build -o dist/ \
-            -ldflags "${{ env.LD_FLAGS }}" \
-            -tags "${{ env.GO_TAGS }}"
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-      - name: Package
-        if: ${{ matrix.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
-        with:
-          name: ${{ github.event.repository.name }}
-          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          maintainer: "HashiCorp"
-          homepage: "https://github.com/hashicorp/consul-terraform-sync"
-          license: "MPL-2.0"
-          binary: "dist/${{ env.PKG_NAME }}"
-          deb_depends: "openssl"
-          rpm_depends: "openssl"
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
-        with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
-        with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.x86_64.rpm
-
-  build-arm:
-    needs: [get-product-version, set-ld-flags]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux]
-        goarch: [arm]
-        go: ["1.16"]
-      fail-fast: true
-
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      DOCKER_CLI_EXPERIMENTAL: enabled
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Build
-        run: |
-          mkdir dist out
-          go build -o dist/ \
-            -ldflags "${{ env.LD_FLAGS }}" \
-            -tags "${{ env.GO_TAGS }}"
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-      - name: Package
-        if: ${{ matrix.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
-        with:
-          name: ${{ github.event.repository.name }}
-          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          maintainer: "HashiCorp"
-          homepage: "https://github.com/hashicorp/consul-terraform-sync"
-          license: "MPL-2.0"
-          binary: "dist/${{ env.PKG_NAME }}"
-          deb_depends: "openssl"
-          rpm_depends: "openssl"
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_armhf.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_armhf.deb
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
-
-  build-arm64:
-    needs: [get-product-version, set-ld-flags]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        goos: [linux]
-        goarch: [arm64]
-        go: ["1.16"]
-      fail-fast: true
-
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      DOCKER_CLI_EXPERIMENTAL: enabled
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Build
-        run: |
-          mkdir dist out
-          go build -o dist/ \
-            -ldflags "${{ env.LD_FLAGS }}" \
-            -tags "${{ env.GO_TAGS }}"
-          zip -r -j out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip dist/
-      - uses: actions/upload-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
-
-      - name: Package
-        if: ${{ matrix.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
-        with:
-          name: ${{ github.event.repository.name }}
-          description: "Consul Terraform Sync is a service-oriented tool for managing network infrastructure near real-time."
-          arch: ${{ matrix.goarch }}
-          version: ${{ needs.get-product-version.outputs.product-version }}
-          maintainer: "HashiCorp"
-          homepage: "https://github.com/hashicorp/consul-terraform-sync"
-          license: "MPL-2.0"
-          binary: "dist/${{ env.PKG_NAME }}"
-          deb_depends: "openssl"
-          rpm_depends: "openssl"
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
-        with:
-          name: ${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goarch }}.deb
-          path: out/${{ github.event.repository.name }}_${{ needs.get-product-version.outputs.product-version }}_arm*.deb
-
-      - uses: actions/upload-artifact@v2
-        if: ${{ matrix.goos == 'linux' }}
-        with:
-          name: ${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.${{ matrix.goarch }}.rpm
-          path: out/${{ github.event.repository.name }}-${{ needs.get-product-version.outputs.product-version }}.*.rpm
-
-  build-darwin:
-    needs: [get-product-version, set-ld-flags]
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        goos: [ darwin ]
-        goarch: [ "amd64" ]
-        go: [ "1.16" ]
-      fail-fast: true
-
-    name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
-
-    env:
-      GOOS: ${{ matrix.goos }}
-      GOARCH: ${{ matrix.goarch }}
-      LD_FLAGS: ${{ needs.set-ld-flags.outputs.ldflags }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Build
+        env: 
+          GO_TAGS: "${{ env.GO_TAGS }} netcgo"
         run: |
           mkdir dist out
           go build -o dist/ \
@@ -358,31 +177,21 @@ jobs:
           path: out/${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-docker:
+    name: Docker ${{ matrix.arch }} build
     needs:
       - get-product-version
-      - build-arm64
-      - build-386
-      - build-amd64
-      - build-arm
+      - build
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: ["arm", "arm64", "386", "amd64"]
-    name: Docker ${{ matrix.arch }} build
     env:
       repo: ${{github.event.repository.name}}
       version: ${{needs.get-product-version.outputs.product-version}}
 
     steps:
       - uses: actions/checkout@v2
-
-      # download arm/arm64/386/amd64 binaries from build jobs
-      - uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_linux_${{ matrix.arch }}.zip
-
-      # build docker image
-      - name: Docker build (Action)
+      - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:
           version: ${{env.version}}

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -10,10 +10,7 @@ project "consul-terraform-sync" {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
     release_branches = [
-      "main",
-      "release/0.2.x",
-      "release/0.3.x",
-      "release/0.4.x"
+      "clabry-update-crt"
     ]
   }
 }
@@ -41,8 +38,36 @@ event "upload-dev" {
   }
 }
 
-event "notarize-darwin-amd64" {
+event "security-scan-binaries" {
   depends = ["upload-dev"]
+  action "security-scan-binaries" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-binaries"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "security-scan-containers" {
+  depends = ["security-scan-binaries"]
+  action "security-scan-containers" {
+    organization = "hashicorp"
+    repository = "crt-workflows-common"
+    workflow = "security-scan-containers"
+    config = "security-scan.hcl"
+  }
+
+  notification {
+    on = "fail"
+  }
+}
+
+event "notarize-darwin-amd64" {
+  depends = ["security-scan-containers"]
   action "notarize-darwin-amd64" {
     organization = "hashicorp"
     repository = "crt-workflows-common"

--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -9,9 +9,7 @@ project "consul-terraform-sync" {
   github {
     organization = "hashicorp"
     repository = "consul-terraform-sync"
-    release_branches = [
-      "clabry-update-crt"
-    ]
+    release_branches = ["release/0.4.x"]
   }
 }
 

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -1,0 +1,13 @@
+container {
+	dependencies = true
+	alpine_secdb = false
+	secrets      = true
+}
+
+binary {
+	secrets      = true
+	go_modules   = true
+	osv          = true
+	oss_index    = true
+	nvd          = true
+}


### PR DESCRIPTION
What this PR does is it updates the `build.yml` to the `release/0.4.x` branch to make the workflow a bit more drier and matches the current convention that's in [crt-core-helloworld.](https://github.com/hashicorp/crt-core-helloworld/blob/main/.github/workflows/build.yml)

This updates the build to follow a matrix approach, cleans up the linux-packaging, and making the workflow more abstract and easier to read. 

I also noticed that this branch did not have `security-scanner`, that was added as well :) 

If there are any questions or if anything is not clear, please feel free to ask! ❤️  

Test are passing [here.](https://github.com/hashicorp/crt-workflows-common/actions/runs/1780547448)
