### PR TITLE
removing workflow dispatch as it is not needed (for release/0.2.x)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: build
 
 on:
-  workflow_dispatch:
   push:
     # Sequence of patterns matched against refs/heads
     branches:    


### PR DESCRIPTION
My sincere apologies for leaving this line here -- I did not realize it was used for testing purposes for the RDX team. 

This is part of the effort to maintain the build.yml files neat and up to date with the current CRT convention. 

More information can be found in PR #656 on why this line is removed. 