### PR TITLE
Removed `http.Server` write timeout, will now not timeout

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -137,12 +137,11 @@ func NewAPI(conf APIConfig) (*API, error) {
 	}
 
 	api.srv = &http.Server{
-		Addr:         fmt.Sprintf(":%d", api.port),
-		WriteTimeout: time.Second * 15,
-		ReadTimeout:  time.Second * 15,
-		IdleTimeout:  time.Second * 60,
-		Handler:      r,
-		TLSConfig:    t,
+		Addr:        fmt.Sprintf(":%d", api.port),
+		ReadTimeout: time.Second * 15,
+		IdleTimeout: time.Second * 60,
+		Handler:     r,
+		TLSConfig:   t,
 		ErrorLog: logger.StandardLogger(&hclog.StandardLoggerOptions{
 			InferLevels: false,
 			ForceLevel:  hclog.Warn,


### PR DESCRIPTION
When initially taking on this task, I was going to increase the timeout to some average large value, however after some investigation I decided to instead remove the timeout alltogether.

## The Investigation
It was expected that setting the writeTimeout would cause a connection to terminate upon timeout expiration, however, this is not the case. What actually happens is that the underlying connection is closed, but, the server doesn't return an error until the connection is accessed again (i.e. when calling a ResponseWriter()).

### Example 1: Error Returned
WriteTimeout = 15 seconds

User makes an API call to Create Task

Server receives request and creates the task, it takes 40 seconds to complete, then the ResponseWriter is called

A timeout occurred, so the client receives an error, but not until ResponseWriter is called

So the client sits there for 40 seconds, even though the timeout occurred at 15 seconds, still receiving the error

### Example 2: No Error Returned
WriteTimeout = 50 seconds

User makes an API call to Create Task

Server receives request and creates the task, it takes 40 seconds to complete, then the ResponseWriter is called

No timeout occurs, so the user receives a valid response

## Decision
The error provided to the client after waiting the full creation duration isn't meaningful, when it would make more sense to return the valid response at this point. I think connection health and sanity (connection limits, connection durations, timeouts, etc.) are things we should revisit eventually, but I don't feel it's necessary for 0.5.0. I also don't feel it's urgent given the current scope of CTS.