### PR TITLE
Updates to cli ux

### DIFF
--- a/api/task_lifecycle_client.go
+++ b/api/task_lifecycle_client.go
@@ -156,7 +156,7 @@ func (d *TaskLifecycleHTTPClient) Do(req *http.Request) (*http.Response, error) 
 			if err = decoder.Decode(&errResp); err != nil {
 				return nil, err
 			}
-			errMsg = fmt.Sprintf("%s, Request ID: %s", errResp.Error.Message, errResp.RequestId)
+			errMsg = fmt.Sprintf("%s, see logs for more details (Request ID: %s)", errResp.Error.Message, errResp.RequestId)
 		} else {
 			b, err := io.ReadAll(resp.Body)
 			if err != nil {
@@ -166,10 +166,9 @@ func (d *TaskLifecycleHTTPClient) Do(req *http.Request) (*http.Response, error) 
 		}
 
 		if errMsg == "" {
-			return nil, fmt.Errorf("request returned %d status code", resp.StatusCode)
+			return nil, errors.New(resp.Status)
 		} else {
-			return nil, fmt.Errorf("request returned %d status code with error: %s",
-				resp.StatusCode, errMsg)
+			return nil, fmt.Errorf("%s: %s", resp.Status, errMsg)
 		}
 	}
 

--- a/command/cli.go
+++ b/command/cli.go
@@ -52,8 +52,7 @@ type CLI struct {
 	signalCh chan os.Signal
 
 	// stopCh is an internal channel used to trigger a shutdown of the CLI.
-	stopCh  chan struct{}
-	stopped bool
+	stopCh chan struct{}
 }
 
 // NewCLI creates a new CLI object with the given stdout and stderr streams.

--- a/command/commands.go
+++ b/command/commands.go
@@ -3,6 +3,7 @@ package command
 import (
 	"os"
 
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/mitchellh/cli"
 )
 
@@ -14,6 +15,9 @@ const (
 // Commands returns the mapping of CLI commands for CTS. The meta
 // parameter lets you set meta options for all commands.
 func Commands() map[string]cli.CommandFactory {
+	// Disable logging, we want to control what is output
+	logging.DisableLogging()
+
 	m := meta{
 		UI: &cli.PrefixedUi{
 			InfoPrefix:   "==> ",

--- a/command/commands.go
+++ b/command/commands.go
@@ -6,6 +6,11 @@ import (
 	"github.com/mitchellh/cli"
 )
 
+const (
+	errCreatingRequest = "Error: unable to create request"
+	errCreatingClient  = "Error: unable to create client"
+)
+
 // Commands returns the mapping of CLI commands for CTS. The meta
 // parameter lets you set meta options for all commands.
 func Commands() map[string]cli.CommandFactory {

--- a/command/meta.go
+++ b/command/meta.go
@@ -178,7 +178,7 @@ func (m *meta) taskLifecycleClient() (*api.TaskLifecycleClient, error) {
 // approved a given action. If the user did not approve (false is returned) or
 // if there is an error in processing the user input, an exit code is provided.
 func (m *meta) requestUserApproval(taskName, action string) (int, bool) {
-	m.UI.Output("Only 'yes' will be accepted to approve.\n")
+	m.UI.Output("Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject\n")
 	v, err := m.UI.Ask("Enter a value:")
 	m.UI.Output("")
 
@@ -198,10 +198,7 @@ func (m *meta) requestUserApproval(taskName, action string) (int, bool) {
 // if the user approved.
 func (m *meta) requestUserApprovalEnable(taskName string) (int, bool) {
 	m.UI.Info("Enabling the task will perform the actions described above.")
-	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
-	m.UI.Output(" - This action cannot be undone.")
-	m.UI.Output(" - Consul-Terraform-Sync cannot guarantee Terraform will perform")
-	m.UI.Output("   these exact actions if monitored services have changed.\n")
+	m.terraformApprovalWarning(taskName)
 	return m.requestUserApproval(taskName, "enabling")
 }
 
@@ -219,11 +216,16 @@ func (m *meta) requestUserApprovalDelete(taskName string) (int, bool) {
 // if the user approved.
 func (m *meta) requestUserApprovalCreate(taskName string) (int, bool) {
 	m.UI.Info("Creating the task will perform the actions described above.")
+	m.terraformApprovalWarning(taskName)
+	return m.requestUserApproval(taskName, "creating")
+}
+
+// terraformApprovalWarning prints out a standard warning for approving a terraform plan
+func (m *meta) terraformApprovalWarning(taskName string) {
 	m.UI.Output(fmt.Sprintf("Do you want to perform these actions for '%s'?", taskName))
 	m.UI.Output(" - This action cannot be undone.")
 	m.UI.Output(" - Consul-Terraform-Sync cannot guarantee Terraform will perform")
 	m.UI.Output("   these exact actions if monitored services have changed.\n")
-	return m.requestUserApproval(taskName, "creating")
 }
 
 // Returns true if the flags have been parsed

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -87,7 +87,8 @@ func (c *taskCreateCommand) Run(args []string) int {
 
 	// Check that a task file was provided
 	if len(taskFile) == 0 {
-		c.UI.Error("Error: no task file provided")
+		c.UI.Error(errCreatingRequest)
+		c.UI.Output("no task file provided")
 		help := fmt.Sprintf("For additional help try 'consul-terraform-sync %s --help'",
 			cmdTaskCreateName)
 		help = wordwrap.WrapString(help, width)
@@ -97,19 +98,11 @@ func (c *taskCreateCommand) Run(args []string) int {
 		return ExitCodeRequiredFlagsError
 	}
 
-	client, err := c.meta.taskLifecycleClient()
-	if err != nil {
-		c.UI.Error("Error: unable to create client")
-		msg := wordwrap.WrapString(err.Error(), uint(78))
-		c.UI.Output(msg)
-
-		return ExitCodeError
-	}
-
 	// Build a CTS config and use the config.Tasks object only
 	cfg, err := config.BuildConfig([]string{taskFile})
 	if err != nil {
-		c.UI.Error("Error: unable to read task file")
+		c.UI.Error(errCreatingRequest)
+		c.UI.Output("unable to read task file")
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
 
@@ -120,13 +113,15 @@ func (c *taskCreateCommand) Run(args []string) int {
 	// Check that we have exactly 1 task in the task config return
 	l := len(taskConfigs)
 	if l > 1 {
-		c.UI.Error(fmt.Sprintf("Error: task file %s cannot contain more "+
+		c.UI.Error(errCreatingRequest)
+		c.UI.Output(fmt.Sprintf("task file %s cannot contain more "+
 			"than 1 task, contains %d tasks", taskFile, l))
 		return ExitCodeError
 	}
 
 	if l == 0 {
-		c.UI.Error(fmt.Sprintf("Error: task file %s does not contain a task, "+
+		c.UI.Error(errCreatingRequest)
+		c.UI.Output(fmt.Sprintf("task file %s does not contain a task, "+
 			"must contain at least one task", taskFile))
 		return ExitCodeError
 	}
@@ -134,18 +129,28 @@ func (c *taskCreateCommand) Run(args []string) int {
 	taskConfig := taskConfigs[0]
 	taskName := *taskConfig.Name
 
-	// First inspect the plan
-	c.UI.Info(fmt.Sprintf("Inspecting changes to resource if creating task '%s'...\n", taskName))
-	c.UI.Output("Generating plan that Consul Terraform Sync will use Terraform to execute\n")
-
 	taskReq, err := api.TaskRequestFromTaskConfig(*taskConfig)
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error: unable to convert task file %s to request", taskFile))
+		c.UI.Error(errCreatingRequest)
+		c.UI.Output(fmt.Sprintf("task %s is invalid", taskFile))
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
 
 		return ExitCodeError
 	}
+
+	client, err := c.meta.taskLifecycleClient()
+	if err != nil {
+		c.UI.Error(errCreatingClient)
+		msg := wordwrap.WrapString(err.Error(), uint(78))
+		c.UI.Output(msg)
+
+		return ExitCodeError
+	}
+
+	// First inspect the plan
+	c.UI.Info(fmt.Sprintf("Inspecting changes to resource if creating task '%s'...\n", taskName))
+	c.UI.Output("Generating plan that Consul Terraform Sync will use Terraform to execute\n")
 
 	taskResp, err := client.CreateTask(context.Background(), api.RunOptionInspect, taskReq)
 
@@ -158,8 +163,9 @@ func (c *taskCreateCommand) Run(args []string) int {
 	}
 
 	c.UI.Output(fmt.Sprintf("Request ID: %s", taskResp.RequestId))
-	b, _ := json.MarshalIndent(taskResp.Task, "    ", "  ")
-	c.UI.Output(fmt.Sprintf("Task: %s\n", string(b)))
+	b, _ := json.MarshalIndent(taskReq, "    ", "  ")
+	c.UI.Output("Request Payload:")
+	c.UI.Output(fmt.Sprintf("%s\n", string(b)))
 	c.UI.Output(fmt.Sprintf("Plan: \n%s", *taskResp.Run.Plan))
 	if taskResp.Run.TfcRunUrl != nil {
 		c.UI.Output(fmt.Sprintf("Terraform Cloud Run URL: %s\n", *taskResp.Run.TfcRunUrl))
@@ -176,7 +182,6 @@ func (c *taskCreateCommand) Run(args []string) int {
 
 	if err != nil {
 		c.UI.Error(fmt.Sprintf("Error: unable to create '%s'", taskName))
-
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
 

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -61,7 +61,7 @@ Example:
        - Consul Terraform Sync cannot guarantee that these exact actions will be
 	     performed if monitored services have changed.
 
-      Only 'yes' will be accepted to approve.
+      Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
 
   Enter a value: yes
   

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -177,6 +177,10 @@ func (c *taskCreateCommand) Run(args []string) int {
 		}
 	}
 
+	c.UI.Info(fmt.Sprintf("Creating task %s...", taskName))
+	c.UI.Output("Note: this can take some time depending on the module size.")
+	c.UI.Output("terminating this process will not stop task creation, see CTS logs for more details\n")
+
 	// Plan approved, create new task and run now
 	taskResp, err = client.CreateTask(context.Background(), api.RunOptionNow, taskReq)
 

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -50,7 +50,7 @@ Example:
   $ consul-terraform-sync task delete my_task
 	==> Do you want to delete 'my_task'?
 		- This action cannot be undone.
-	Only 'yes' will be accepted to approve.
+	Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
 
 	Enter a value: yes
 

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -81,7 +81,8 @@ func (c *taskDeleteCommand) Run(args []string) int {
 
 	client, err := c.meta.taskLifecycleClient()
 	if err != nil {
-		c.UI.Error(fmt.Sprintf("Error: unable to create client for '%s'", taskName))
+		c.UI.Error(errCreatingClient)
+		c.UI.Output(fmt.Sprintf("client could not be created for '%s'", taskName))
 		msg := wordwrap.WrapString(err.Error(), uint(78))
 		c.UI.Output(msg)
 

--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -62,7 +62,7 @@ Example:
        - Consul Terraform Sync cannot guarantee that these exact actions will be
 	     performed if monitored services have changed.
 
-      Only 'yes' will be accepted to approve.
+      Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
 
   Enter a value: yes
 

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -637,7 +637,7 @@ func TestE2E_CreateTaskCommand_NoTaskFileProvided(t *testing.T) {
 	assert.Error(t, err)
 
 	outputContains := []string{
-		"Error: no task file provided",
+		"no task file provided",
 		"For additional help try 'consul-terraform-sync task create --help'",
 	}
 

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -331,7 +331,7 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			input:    "yes\n",
 			outputContains: []string{
 				fmt.Sprintf("Error: unable to delete '%s'", "nonexistent_task"),
-				"request returned 404 status code with error:",
+				"404 Not Found:",
 			},
 			expectErr:     true,
 			expectDeleted: true, // never existed, same as deleted
@@ -503,7 +503,7 @@ task {
 			input: "no\n",
 			outputContains: []string{
 				fmt.Sprintf("Error: unable to generate plan for '%s'", dbTaskName),
-				fmt.Sprintf("error: task with name %s already exists", dbTaskName),
+				fmt.Sprintf("task with name %s already exists", dbTaskName),
 			},
 			expectErr:    true,
 			expectStatus: true,

--- a/e2e/command_tls_test.go
+++ b/e2e/command_tls_test.go
@@ -6,11 +6,12 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
 	"github.com/hashicorp/consul-terraform-sync/command"
@@ -651,7 +652,7 @@ func getTestCommands(taskFilePath string) []testCommand {
 		{
 			name:            "task delete",
 			subcmd:          []string{"task", "delete", "-auto-approve"},
-			outputContains:  "does not exist or has not been initialized yet",
+			outputContains:  "404 Not Found:",
 			arg:             "task-no-exist",
 			isErrorExpected: true, // Accept error since we can only delete once, just want to test a connection was successful
 		},

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -87,6 +87,10 @@ func NewNullLogger() Logger {
 	return hclog.NewNullLogger()
 }
 
+func DisableLogging() {
+	hclog.Default().SetLevel(hclog.Off)
+}
+
 // WithContext stores a Logger and any provided arguments into the provided context
 // to access this logger, use the FromContext function
 func WithContext(ctx context.Context, logger Logger, args ...interface{}) context.Context {


### PR DESCRIPTION
This PR attempts to improve the UX for the `task create` CLI in a number of ways:

1. Make error "categories" and group like errors closer together in code, subsequent statements provided more details about the error. For example a group of errors related to `Error: unable to create request`
2. Make constants for common CLI error types like `Error: unable to create request` or `Error: unable to create client`
3. Make it clearer that the JSON that is returned during the `inspect` phase of the create is the `Request Payload`
4. Add `no or blank` to the accept/reject instructions to provide the user with confidence when rejecting a plan
5. Disabled logging when running the CLI. We want to control the output completely, so we don't want other parts of the code logging to the output

# Sample Output
- These are more for Jake rather than the assigned code reviewer, but feel free to look if you want.
## Error Scenarios and Output
### Error Creating Request
1. No task file provided
```
consul-terraform-sync task create
==> Error: unable to create request
    no task file provided
    For additional help try 'consul-terraform-sync task create --help'
```
2. Unable to read the task file
```
consul-terraform-sync task create -task-file="invalid.hcl"
==> Error: unable to create request
    unable to read task file
    stat invalid.hcl: no such file or directory
```
3. More than 1 task in task file, only 1 task is allowed (example includes two tasks)
```
==> Error: unable to create request
    task file task_multi.hcl cannot contain more than 1 task, contains 2 tasks
```
4. No tasks are found in task file
```
==> Error: unable to create request
    task file task_empty.hcl does not contain a task, must contain at least one task
```
5. Invalid task file
```
==> Error: unable to create request
    task task_with_invalid_vars.hcl is invalid
    open no_exist.hcl: no such file or directory
```

### Error to Create Client
Generic example
```
==> Error: unable to create client
     some error
```

### Error Unable to Generate Plan
Example: Duplicate tasks
```
==> Inspecting changes to resource if creating task 'api-task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

==> Error: unable to generate plan for 'api-task'
    400 Bad Request: task with name api-task already exists, see logs for more
details (Request ID: 678b0248-4c60-4140-c10f-7b47e8d1fad5)
```

Example: No server
``` 
==> Inspecting changes to resource if creating task 'api-task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

==> Error: unable to generate plan for 'api-task'
    Post "http://localhost:8558/v1/tasks?run=inspect": dial tcp [::1]:8558:
connect: connection refused
```

### Error Unable to Create
- Occurs after the `run=now`
- This is just an example error, it's hard to get it to fail here but not during the plan
```
==> Error: unable to create 'api-task'
   400 Bad Request: task could not be rendered
```

## New CLI Output Happy Path
- Make it clearer that the JSON that is returned during the `inspect` phase of the create is the `Request Payload`
- Add `no or blank` to the accept/reject instructions to provide the user with confidence when rejecting a plan
- Add note that task creation may take some time

### Cancel Create Task
```
==> Inspecting changes to resource if creating task 'api-task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

    Request ID: a8c8ff92-9a8a-10f6-fa2c-f1eaadfe797f
    Request Payload:
    {
      "task": {
        "buffer_period": {
          "enabled": true,
          "max": "20s",
          "min": "5s"
        },
        "description": "Writes the service name, id, and IP address to a file",
        "enabled": true,
        "module": "./example-module",
        "name": "api-task",
        "providers": [
          "local"
        ],
        "services": [
          "api"
        ]
      }
    }

    Plan:
module.api-task.local_file.consul_services: Refreshing state... [id=ebbdd1b5e0d0746766552a34120819aef5470b70]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.

==> Creating the task will perform the actions described above.
    Do you want to perform these actions for 'api-task'?
     - This action cannot be undone.
     - Consul-Terraform-Sync cannot guarantee Terraform will perform
       these exact actions if monitored services have changed.

    Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject

Enter a value: no

    Cancelled creating task 'api-task'
```

### Approve Create Task
```
. . .
==> Creating the task will perform the actions described above.
    Do you want to perform these actions for 'api-task'?
     - This action cannot be undone.
     - Consul-Terraform-Sync cannot guarantee Terraform will perform
       these exact actions if monitored services have changed.

    Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject

Enter a value: yes

==> Creating task api-task...
    Note: this can take some time depending on the module size.
    terminating this process will not stop task creation, see CTS logs for more details

==> Task 'api-task' created
    Request ID: 'ac8aa8fe-ab74-950f-ac8c-b715966db1f3'
```

part of #522 