### PR TITLE
Validate template dependency queries at task initialization

### DIFF
--- a/api/task_create.go
+++ b/api/task_create.go
@@ -78,7 +78,7 @@ func (h *TaskLifeCycleHandler) createDryRunTask(w http.ResponseWriter, r *http.R
 	// Inspect task
 	changes, plan, runUrl, err := h.ctrl.TaskInspect(ctx, taskConf)
 	if err != nil {
-		err = fmt.Errorf("error inspecting new task: %s", err)
+		logger.Error("error inspecting new task", "error", err)
 		sendError(w, r, http.StatusBadRequest, err)
 		return
 	}

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -383,13 +383,14 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 		return nil, err
 	}
 
-	timeout := time.After(5 * time.Minute)
+	timeout := time.After(1 * time.Minute)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-timeout:
-			return nil, fmt.Errorf("timed out rendering template for task '%s'", taskName)
+			logger.Error("timed out rendering template")
+			return nil, fmt.Errorf("error initializing task")
 		default:
 		}
 		ok, err := d.RenderTemplate(ctx)
@@ -401,7 +402,7 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 			// Once template rendering is finished, return
 			return d, nil
 		}
-		time.Sleep(250 * time.Millisecond) // waiting because cannot block on a dependency change
+		time.Sleep(50 * time.Millisecond) // waiting because cannot block on a dependency change
 	}
 }
 

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -373,13 +373,14 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 	d, err := rw.createNewTaskDriver(taskConfig)
 	if err != nil {
 		logger.Error("error creating new task driver", "error", err)
-		return nil, fmt.Errorf("error creating new task driver: %v", err)
+		return nil, err
 	}
 
 	// Initialize the new task
 	err = d.InitTask(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error initializing new task, %s", err)
+		logger.Error("error initializing new task", "error", err)
+		return nil, err
 	}
 
 	timeout := time.After(5 * time.Minute)
@@ -394,7 +395,7 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 		ok, err := d.RenderTemplate(ctx)
 		if err != nil {
 			logger.Error("error rendering task template")
-			return nil, fmt.Errorf("error rendering template for task '%s': %s", taskName, err)
+			return nil, err
 		}
 		if ok {
 			// Once template rendering is finished, return

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -401,6 +401,7 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 			// Once template rendering is finished, return
 			return d, nil
 		}
+		time.Sleep(250 * time.Millisecond) // waiting because cannot block on a dependency change
 	}
 }
 

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -382,10 +382,13 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 		return nil, fmt.Errorf("error initializing new task, %s", err)
 	}
 
+	timeout := time.After(5 * time.Minute)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		case <-timeout:
+			return nil, fmt.Errorf("timed out rendering template for task '%s'", taskName)
 		default:
 		}
 		ok, err := d.RenderTemplate(ctx)

--- a/driver/terraform_test.go
+++ b/driver/terraform_test.go
@@ -263,6 +263,7 @@ func TestUpdateTask(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil).Once()
+			w.On("Clients").Return(nil).Once()
 			tf := &Terraform{
 				task: &Task{name: "test_task", enabled: tc.orig.Enabled, workingDir: tc.dirName,
 					logger: logging.NewNullLogger()},
@@ -370,6 +371,7 @@ func TestUpdateTask(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil).Once()
+			w.On("Clients").Return(nil).Once()
 
 			tf := &Terraform{
 				task: &Task{name: "test_task", enabled: false, workingDir: tc.dirName,
@@ -441,6 +443,7 @@ func TestUpdateTask_Inspect(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil)
+			w.On("Clients").Return(nil).Once()
 			w.On("Deregister", mock.Anything).Return()
 
 			tf := &Terraform{
@@ -576,6 +579,7 @@ func TestInitTaskTemplates(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil).Once()
+			w.On("Clients").Return(nil).Once()
 			tf := &Terraform{
 				fileReader: tc.fileReader,
 				task:       &Task{name: "test", enabled: true},
@@ -671,6 +675,7 @@ func TestDisabledTask(t *testing.T) {
 
 		w := new(mocksTmpl.Watcher)
 		w.On("Register", mock.Anything).Return(nil).Once()
+		w.On("Clients").Return(nil).Once()
 
 		dirName := "disabled-task-test"
 		deleteTemp := testutils.MakeTempDir(t, dirName)
@@ -747,6 +752,7 @@ func TestInitTask(t *testing.T) {
 
 			w := new(mocksTmpl.Watcher)
 			w.On("Register", mock.Anything).Return(nil).Once()
+			w.On("Clients").Return(nil).Once()
 
 			tf := &Terraform{
 				task:       &Task{name: "InitTaskTest", enabled: true, workingDir: dirName, logger: logging.NewNullLogger()},

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830
+	github.com/hashicorp/hcat v0.2.1-0.20220203193115-e49c6b7ee2f9
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830 h1:UN+sa9ksfSCgoih45eJDHXXoFVhY3hHh5qXc1qo09Qw=
-github.com/hashicorp/hcat v0.2.1-0.20220128005838-05438c5d8830/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220203193115-e49c6b7ee2f9 h1:C25VUacP9hzMWPh8QvQKGS4UdiCxhNdJU2XjC55+krQ=
+github.com/hashicorp/hcat v0.2.1-0.20220203193115-e49c6b7ee2f9/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -35,6 +35,22 @@ func (_m *Watcher) Buffering(_a0 hcat.Notifier) bool {
 	return r0
 }
 
+// Clients provides a mock function with given fields:
+func (_m *Watcher) Clients() hcat.Looker {
+	ret := _m.Called()
+
+	var r0 hcat.Looker
+	if rf, ok := ret.Get(0).(func() hcat.Looker); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(hcat.Looker)
+		}
+	}
+
+	return r0
+}
+
 // Complete provides a mock function with given fields: _a0
 func (_m *Watcher) Complete(_a0 hcat.Notifier) bool {
 	ret := _m.Called(_a0)

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -54,4 +54,5 @@ type Watcher interface {
 	Recaller(hcat.Notifier) hcat.Recaller
 	Register(ns ...hcat.Notifier) error
 	Deregister(ns ...hcat.Notifier)
+	Clients() hcat.Looker
 }

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -176,7 +176,7 @@ func (d *catalogServicesRegistrationQuery) ID() string {
 		opts = append(opts, fmt.Sprintf("regexp=%s", d.regexp.String()))
 	}
 	if d.dc != "" {
-		opts = append(opts, fmt.Sprintf("@%s", d.dc))
+		opts = append(opts, fmt.Sprintf("dc=%s", d.dc))
 	}
 	if d.ns != "" {
 		opts = append(opts, fmt.Sprintf("ns=%s", d.ns))

--- a/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
@@ -126,7 +126,7 @@ func TestCatalogServicesRegistrationQuery_String(t *testing.T) {
 		{
 			"datacenter",
 			[]string{"dc=dc1"},
-			"catalog.services.registration(@dc1)",
+			"catalog.services.registration(dc=dc1)",
 		},
 		{
 			"namespace",
@@ -141,7 +141,7 @@ func TestCatalogServicesRegistrationQuery_String(t *testing.T) {
 		{
 			"multiple",
 			[]string{"node-meta=k:v", "dc=dc1", "ns=namespace", "regexp=.*"},
-			"catalog.services.registration(@dc1&node-meta=k:v&ns=namespace&regexp=.*)",
+			"catalog.services.registration(dc=dc1&node-meta=k:v&ns=namespace&regexp=.*)",
 		},
 	}
 


### PR DESCRIPTION
Added a validation step after the template has been registered that executes the fetch request on all the Consul dependencies. This is intended to catch issues like invalid query parameters (setting a datacenter that does not exist, using the Consul enterprise namespace feature against an OSS Consul instance, etc.). By failing faster on invalid query parameters, it also fixes a bug in the create API workflow, as described below.

**Example Output**
```
consul-terraform-sync task create -task-file=task.hcl
==> Inspecting changes to resource if creating task 'mkam_test_task'...

    Generating plan that Consul Terraform Sync will use Terraform to execute

==> Error: unable to generate plan for 'mkam_test_task'
    request returned 400 status code with error: unable to retrieve data from
Consul: catalog.services.registration(dc=foo&regexp=api|web): Unexpected
response code: 500 (No path to datacenter), Request ID:
7bdd9a6f-3530-4314-5051-a62f349ffce8
```


**Bug Description**
If a task created via the API had an invalid query parameter, the request would hang indefinitely. This is happens because of two reasons:

 1.)  The RenderTemplate method does not error and also will never return Complete when a fetch errors. This is because it deals only with rendering the data, not how/when the data was retrieved.

 2.) The fetch error is returned to the [main Run loop](https://github.com/hashicorp/consul-terraform-sync/blob/70acf6445a49456aa922e1299833eeb1eccd6380/controller/readwrite.go#L89-L97) that is watching the dependencies, and there's not a clean way to pass this error to the API method that's processing the create.
 
 **Solution Details**
- Add a timeout for the render loop in the API task creation to prevent any future infinite looping. Chose 5 minutes arbitrarily.
- Validate a template by calling the fetch method on a template's dependencies as part of task initialization. Use latest hcat version in order to get access to Watcher's clients.


**Additional Changes**
Pardon the bit of scope creep! I wanted to fix some stuff up with the error messages and the rendering loop that I observed as I was working on this feature.
- Remove some of the error wrapping so that the end user of the API/CLI is given a more straightforward error
- Improve an error message for a failed catalog services fetch
- Add a small delay in the render template loop of the API task creation to keep down the number of render calls and log lines. This doesn't have to be a permanent solution, but it seemed like the best option for now.
