### PR TITLE
Update deprecation warning logs for config streamlining

### DIFF
--- a/config/condition.go
+++ b/config/condition.go
@@ -111,3 +111,35 @@ func decodeConditionToType(data interface{}, monitor MonitorConfig) (MonitorConf
 func isConditionNil(c ConditionConfig) bool {
 	return isMonitorNil(c)
 }
+
+// bothConditionInputConfigLogMsg is the log message to warn when the user
+// configures both `source_includes_var` and `use_as_module_input` fields.
+//
+// expected value for '%s' is the condition type
+const bothConditionInputConfigLogMsg = `%s condition block is configured ` +
+	`with both the 'source_includes_var' and the 'use_as_module_input' field. ` +
+	`Defaulting to the 'use_as_module_input' value`
+
+// sourceIncludesVarLogMsg is the log message for deprecating the
+// `source_includes_var` field.
+//
+// expected value for both '%s' is the condition type
+const sourceIncludesVarLogMsg = `the 'source_includes_var' field in ` +
+	`the task's %s condition block is deprecated in v0.5.0 and will be removed in v0.8.0.
+
+Please replace 'source_includes_var' with 'use_as_module_input' in your condition configuration.
+
+We will be releasing a tool to help upgrade your configuration for this deprecation.
+
+Example upgrade:
+|    task {
+|      condition "%s" {
+|  -     source_includes_var = false
+|  +     use_as_module_input = false
+|      }
+|      ...
+|    }
+
+For more details and examples, please see:
+https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source_includes_var-field
+`

--- a/config/condition_consul_kv.go
+++ b/config/condition_consul_kv.go
@@ -85,15 +85,11 @@ func (c *ConsulKVConditionConfig) Finalize() {
 
 	logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
 	if c.DeprecatedSourceIncludesVar != nil {
-		logger.Warn("Consul-KV condition block's 'source_includes_var' " +
-			"field was marked for deprecation in v0.5.0. Please update your " +
-			"configuration to use the 'use_as_module_input' field instead")
+		logger.Warn(fmt.Sprintf(sourceIncludesVarLogMsg, consulKVType, consulKVType))
 
 		if c.UseAsModuleInput != nil {
-			logger.Warn("Consul-KV condition block is configured with "+
-				"both 'source_includes_var' and 'use_as_module_input' field. "+
-				"Defaulting to 'use_as_module_input' value",
-				"use_as_module_input", c.UseAsModuleInput)
+			logger.Warn(fmt.Sprintf(bothConditionInputConfigLogMsg, consulKVType),
+				"use_as_module_input", *c.UseAsModuleInput)
 		} else {
 			// Merge SourceIncludesVar with UseAsModuleInput. Use UseAsModuleInput onwards
 			c.UseAsModuleInput = c.DeprecatedSourceIncludesVar

--- a/config/condition_services.go
+++ b/config/condition_services.go
@@ -86,15 +86,11 @@ func (c *ServicesConditionConfig) Finalize() {
 
 	logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
 	if c.DeprecatedSourceIncludesVar != nil {
-		logger.Warn("Services condition block's 'source_includes_var' " +
-			"field was marked for deprecation in v0.5.0. Please update your " +
-			"configuration to use the 'use_as_module_input' field instead")
+		logger.Warn(fmt.Sprintf(sourceIncludesVarLogMsg, servicesType, servicesType))
 
 		if c.UseAsModuleInput != nil {
-			logger.Warn("Services condition block is configured with "+
-				"both 'source_includes_var' and 'use_as_module_input' field. "+
-				"Defaulting to 'use_as_module_input' value",
-				"use_as_module_input", c.UseAsModuleInput)
+			logger.Warn(fmt.Sprintf(bothConditionInputConfigLogMsg, servicesType),
+				"use_as_module_input", *c.UseAsModuleInput)
 		} else {
 			// Merge SourceIncludesVar with UseAsModuleInput. Use UseAsModuleInput onwards
 			c.UseAsModuleInput = c.DeprecatedSourceIncludesVar

--- a/config/config.go
+++ b/config/config.go
@@ -238,6 +238,9 @@ func (c *Config) Finalize() {
 
 	if c.Services == nil {
 		c.Services = DefaultServiceConfigs()
+	} else {
+		logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
+		logger.Warn(deprecateServiceBlockWarning)
 	}
 	c.Services.Finalize()
 
@@ -584,3 +587,34 @@ func antiboolFromEnv(list []string, def bool) *bool {
 	}
 	return Bool(def)
 }
+
+const deprecateServiceBlockWarning = `the 'service' block is deprecated ` +
+	`in v0.5.0 and will be removed in a future major version after v0.8.0.
+
+` +
+	`In order to replace the 'service' block, the associated 'services' field ` +
+	`(deprecated) should first be upgraded to 'condition "services"' or ` +
+	`'module_input "services"'. Then the configuration in the 'service' block ` +
+	`can be set in the 'condition' or 'module_input' block.` +
+	`
+
+We will be releasing a tool to help upgrade your configuration for this deprecation.
+
+Example of replacing service block information in condition block:
+|  - service {
+|  -   name       = "api"
+|  -   datacenter = "dc2"
+|  - }
+|
+|    task {
+|      condition "services" {
+|        names      = ["api"]
+|  +     datacenter = "dc2"
+|      }
+|      ...
+|    }
+
+More complex cases with 'service' blocks can require splitting a task into multiple tasks.
+For more details and additional examples, please see:
+https://consul.io/docs/nia/release-notes/0-5-0#deprecate-service-block
+`

--- a/config/monitor_catalog_services.go
+++ b/config/monitor_catalog_services.go
@@ -119,15 +119,11 @@ func (c *CatalogServicesMonitorConfig) Finalize() {
 
 	logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
 	if c.DeprecatedSourceIncludesVar != nil {
-		logger.Warn("Catalog-service condition block's 'source_includes_var' " +
-			"field was marked for deprecation in v0.5.0. Please update your " +
-			"configuration to use the 'use_as_module_input' field instead")
+		logger.Warn(fmt.Sprintf(sourceIncludesVarLogMsg, catalogServicesType, catalogServicesType))
 
 		if c.UseAsModuleInput != nil {
-			logger.Warn("Catalog-service condition block is configured with "+
-				"both 'source_includes_var' and 'use_as_module_input' field. "+
-				"Defaulting to 'use_as_module_input' value",
-				"use_as_module_input", c.UseAsModuleInput)
+			logger.Warn(fmt.Sprintf(bothConditionInputConfigLogMsg, catalogServicesType),
+				"use_as_module_input", *c.UseAsModuleInput)
 		} else {
 			// Merge SourceIncludesVar with UseAsModuleInput. Use UseAsModuleInput onwards
 			c.UseAsModuleInput = c.DeprecatedSourceIncludesVar

--- a/config/task.go
+++ b/config/task.go
@@ -242,11 +242,10 @@ func (c *TaskConfig) Finalize(globalBp *BufferPeriodConfig, wd string) {
 		c.Module = String("")
 	}
 	if c.DeprecatedSource != nil && *c.DeprecatedSource != "" {
-		logger.Warn("Task's 'source' field was marked for deprecation in v0.5.0. " +
-			"Please update your configuration to use the 'module' field instead")
+		logger.Warn(sourceFieldLogMsg)
 		if *c.Module != "" {
-			logger.Warn("Task's 'source' and 'module' field were both "+
-				"configured. Defaulting to 'module' value", "module", c.Module)
+			logger.Warn("the task block's 'source' and 'module' field were both "+
+				"configured. Defaulting to the 'module' value", "module", *c.Module)
 		} else {
 			// Merge Source with Module and use Module onwards
 			c.Module = c.DeprecatedSource
@@ -570,3 +569,23 @@ func (c *TaskConfig) validateCondition() error {
 	}
 	return nil
 }
+
+// sourceFieldLogMsg is the log message for deprecating the `source` field.
+const sourceFieldLogMsg = `the 'source' field in the task block is deprecated ` +
+	`in v0.5.0 and will be removed in a future major version after v0.8.0.
+
+Please replace 'source' with 'module' in your task configuration.
+
+We will be releasing a tool to help upgrade your configuration for this deprecation.
+
+Example upgrade:
+|    task {
+|  -   source =  "path/to/module"
+|  +   module =  "path/to/module"
+|      ...
+|    }
+
+For more details and examples, please see:
+https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source-field
+`
+

--- a/config/task.go
+++ b/config/task.go
@@ -298,9 +298,7 @@ func (c *TaskConfig) Finalize(globalBp *BufferPeriodConfig, wd string) {
 
 	if c.DeprecatedSourceInputs != nil {
 		if len(*c.DeprecatedSourceInputs) > 0 {
-			logger.Warn("Task's 'source_input' block was marked for " +
-				"deprecation in v0.5.0. Please update your configuration to " +
-				"use 'module_input' instead.")
+			logger.Warn(sourceInputBlockLogMsg)
 			c.ModuleInputs = c.ModuleInputs.Merge(c.DeprecatedSourceInputs)
 		}
 
@@ -587,5 +585,27 @@ Example upgrade:
 
 For more details and examples, please see:
 https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source-field
+`
+
+// sourceInputBlockLogMsg is the log message for deprecating the `source_input`
+// block.
+const sourceInputBlockLogMsg = `the 'source_input' block in the task ` +
+	`block is deprecated in v0.5.0 and will be removed in v0.8.0.
+
+Please replace 'source_input' with 'module_input' in your task configuration.
+
+We will be releasing a tool to help upgrade your configuration for this deprecation.
+
+Example upgrade:
+|    task {
+|  -   source_input "<input-type>" {
+|  +   module_input "<input-type>" {
+|        ...
+|      }
+|      ...
+|    }
+
+For more details and examples, please see:
+https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source_input-block
 `
 

--- a/config/task.go
+++ b/config/task.go
@@ -236,6 +236,8 @@ func (c *TaskConfig) Finalize(globalBp *BufferPeriodConfig, wd string) {
 
 	if c.Services == nil {
 		c.Services = []string{}
+	} else {
+		logger.Warn(servicesFieldLogMsg)
 	}
 
 	if c.Module == nil {
@@ -609,3 +611,25 @@ For more details and examples, please see:
 https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source_input-block
 `
 
+// servicesFieldLogMsg is the log message for deprecating the `services` field.
+const servicesFieldLogMsg = `the 'services' field in the task block is deprecated ` +
+	`in v0.5.0 and will be removed in a future major version after v0.8.0.
+
+Please replace 'services' in your task configuration with one of the options below:
+ * condition "services": if there is _no_ preexisting condition block configured in your task
+ * module_input "services": if there is a preexisting condition block configured in your task
+
+We will be releasing a tool to help upgrade your configuration for this deprecation.
+
+Example upgrade for a task with no preexisting condition block:
+|    task {
+|  -   services = ["api", "web"]
+|  +   condition "services" {
+|  +     names = ["api", "web"]
+|  +   }
+|      ...
+|    }
+
+For more details and additional examples, please see:
+https://consul.io/docs/nia/release-notes/0-5-0#deprecate-services-field
+`


### PR DESCRIPTION
Update: the link to consul.io docs in the example outputs are still only in staging. Here's an example consul.io link: https://consul-2poy7q5me-hashicorp.vercel.app/docs/nia/release-notes/0-5-0

source_includes_var example:

```
2022-02-03T18:23:15.205-0500 [WARN]  config.task: the 'source_includes_var' field in the task's consul-kv condition block is deprecated in v0.5.0 and will be removed in v0.8.0.

Please replace 'source_includes_var' with 'use_as_module_input' in your condition configuration.

We will be releasing a tool to help upgrade your configuration for this deprecation.

Example upgrade:
|    task {
|      condition "consul-kv" {
|  -     source_includes_var = false
|  +     use_as_module_input = false
|      }
|      ...
|    }

For more details and examples, please see:
https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source_includes_var-field
```

source_input example:
```
2022-02-03T18:24:59.466-0500 [WARN]  config.task: the 'source' field in the task block is deprecated in v0.5.0 and will be removed in a future major version after v0.8.0.

Please replace 'source' with 'module' in your task configuration.

We will be releasing a tool to help upgrade your configuration for this deprecation.

Example upgrade:
|    task {
|  -   source =  "path/to/module"
|  +   module =  "path/to/module"
|      ...
|    }

For more details and examples, please see:
https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source-field
```

source example:
```
2022-02-03T18:24:59.466-0500 [WARN]  config.task: the 'source' field in the task block is deprecated in v0.5.0 and will be removed in a future major version after v0.8.0.

Please replace 'source' with 'module' in your task configuration.

We will be releasing a tool to help upgrade your configuration for this deprecation.

Example upgrade:
|    task {
|  -   source =  "path/to/module"
|  +   module =  "path/to/module"
|      ...
|    }

For more details and examples, please see:
https://consul.io/docs/nia/release-notes/0-5-0#deprecate-source-field
```

services field example:
```
2022-02-03T18:16:50.395-0500 [WARN]  config.task: the 'services' field in the task block is deprecated in v0.5.0 and will be removed in a future major version after v0.8.0.

Please replace 'services' in your task configuration with one of the options below:
 * condition "services": if there is _no_ preexisting condition block configured in your task
 * module_input "services": if there is a preexisting condition block configured in your task

We will be releasing a tool to help upgrade your configuration for this deprecation.

Example upgrade for a task with no preexisting condition block:
|    task {
|  -   services = ["api", "web"]
|  +   condition "services" {
|  +     names = ["api", "web"]
|  +   }
|      ...
|    }

For more details and additional examples, please see:
https://consul.io/docs/nia/release-notes/0-5-0#deprecate-services-field
```

service block example:
```
2022-02-03T18:16:50.395-0500 [WARN]  config.task: the 'service' block is deprecated in v0.5.0 and will be removed in a future major version after v0.8.0.

In order to replace the 'service' block, the associated 'services' field (deprecated) should first be upgraded to 'condition "services"' or 'module_input "services"'. Then the configuration in the 'service' block can be set in the 'condition' or 'module_input' block.

We will be releasing a tool to help upgrade your configuration for this deprecation.

Example of replacing service block information in condition block:
|  - service {
|  -   name       = "api"
|  -   datacenter = "dc2"
|  - }
|
|    task {
|      condition "services" {
|        names      = ["api"]
|  +     datacenter = "dc2"
|      }
|      ...
|    }

More complex cases with 'service' blocks can require splitting a task into multiple tasks.
For more details and additional examples, please see:
https://consul.io/docs/nia/release-notes/0-5-0#deprecate-service-block
```