### PR TITLE
Add basic compile test for weekly tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,33 @@ jobs:
           path: /tmp/benchmark_results
           destination: benchmark_results
 
+  compile_weekly_tests:
+    executor:
+      name: go
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - ct-modcache-v2-{{ checksum "go.mod" }}
+      - run:
+          name: Check that weekly tests can compile
+          command:
+            make compile-weekly-tests
+      - when:
+          condition:
+            or:
+              - equal: [ main, <<pipeline.git.branch>> ]
+              - matches: { pattern: "release/.+", value: <<pipeline.git.branch>> }
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                branch_pattern: main,release/.+
+      - save_cache:
+          key: ct-modcache-v2-{{ checksum "go.mod" }}
+          paths:
+            - /go/pkg/mod
+
   go-checks:
     executor:
       name: go
@@ -202,6 +229,7 @@ workflows:
     jobs:
       - go-checks
       - terraform-checks
+      - compile_weekly_tests
       - unit_integration_tests
       - e2e_tests
   weekly-benchmarks:

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,15 @@ test-benchmarks:
 	@go test -json ./e2e/benchmarks -timeout 2h -bench=. -tags e2e
 .PHONY: test-benchmarks
 
+# compile-weekly-tests is a check that our weekly-runned tests can compile. this
+# will be called on a more frequent cadence than weekly
+compile-weekly-tests:
+	@echo "==> Running compile check for weekly tests for ${NAME}"
+	@go test -run TestCompatibility_Compile ./e2e/compatibility -timeout 5m -tags '$(GOTAGS) e2e'
+	@go test -run TestBenchmarks_Compile ./e2e/benchmarks -timeout 5m -tags '$(GOTAGS) e2e'
+	@go test -run TestVaultIntegration_Compile ./... -timeout=5m -tags '$(GOTAGS) integration vault'
+.PHONY: compile-weekly-tests
+
 # delete any cruft
 clean:
 	rm -f ./e2e/terraform

--- a/e2e/benchmarks/benchmarks_test.go
+++ b/e2e/benchmarks/benchmarks_test.go
@@ -1,9 +1,11 @@
+//go:build e2e
 // +build e2e
 
 package benchmarks
 
 import (
 	"io/ioutil"
+	"testing"
 
 	"github.com/hashicorp/go-hclog"
 )
@@ -13,4 +15,12 @@ func init() {
 	hclog.SetDefault(hclog.New(&hclog.LoggerOptions{
 		Output: ioutil.Discard,
 	}))
+}
+
+// TestBenchmarks_Compile confirms that the benchmark tests are compilable.
+// Benchmark tests are only run weekly. This test is intended to run with each
+// change (vs. weekly) to do a basic check that the tests are still in a
+// compilable state.
+func TestBenchmarks_Compile(t *testing.T) {
+	// no-op
 }

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -35,6 +35,14 @@ const (
 	defaultWaitForEvent = 8 * time.Second
 )
 
+// TestCompatibility_Compile confirms that the compatibility test(s) are
+// compilable. Compatibility tests are only run weekly. This test is intended
+// to run with each change (vs. weekly) to do a basic check that the tests are
+// still in a compilable state.
+func TestCompatibility_Compile(t *testing.T) {
+	// no-op
+}
+
 func TestCompatibility_Consul(t *testing.T) {
 	// Tested only OSS GA releases for the highest patch version given a
 	// major minor version. v1.4.5 starts losing compatibility, details in

--- a/templates/hcltmpl/vault_test.go
+++ b/templates/hcltmpl/vault_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestVault_Compile confirms that the Vault integration tests are compilable.
+// Vault integration tests are only run weekly. This test is intended to run
+// with each change (vs. weekly) to do a basic check that the tests are still
+// in a compilable state.
+func TestVaultIntegration_Compile(t *testing.T) {
+	// no-op
+}
+
 func TestLoadDynamicConfig_Vault(t *testing.T) {
 	vClient, stopVault := testutils.NewTestVaultServer(t, testutils.TestVaultServerConfig{})
 	defer stopVault(t)


### PR DESCRIPTION
Some of our weekly tests have separate build tags.

This makes it easy to accidentally make a change so that they cannot compile
without noticing. Because these tests also run weekly, the issue may not be
discovered as late as a week later.

This change adds a compile check to be run in circleci when a branch is pushed
or on a merge to main.