### PR TITLE
Deprecate 'services' field and 'service' block in config snippets

### DIFF
--- a/config/condition_test.go
+++ b/config/condition_test.go
@@ -35,7 +35,6 @@ func TestCondition_DecodeConfig(t *testing.T) {
 task {
 	name = "condition_task"
 	module = "..."
-	services = ["api"]
 	condition "catalog-services" {
 		regexp = ".*"
 		use_as_module_input = true
@@ -49,7 +48,7 @@ task {
 }`,
 		},
 		{
-			"no condition",
+			"no condition - deprecated",
 			false,
 			EmptyConditionConfig(),
 			"config.hcl",
@@ -101,7 +100,6 @@ task {
 task {
 	name = "condition_task"
 	module = "..."
-	services = ["api"]
 	condition "services" {
 		nonexistent_field = true
 	}
@@ -118,7 +116,6 @@ task {
 task {
 	name = "schedule_condition_task"
 	module = "..."
-	services = ["api"]
 	condition "schedule" {
 		cron = "* * * * * * *"
 	}
@@ -133,7 +130,6 @@ task {
 task {
 	name = "condition_task"
 	module = "..."
-	services = ["api"]
 	condition "catalog-services" {
 		nonexistent_field = true
 	}
@@ -148,7 +144,6 @@ task {
 task {
 	name = "condition_task"
 	module = "..."
-	services = ["api"]
 	condition "catalog-services" {
 	}
 	condition "catalog-services" {
@@ -174,7 +169,6 @@ task {
 task {
 	name = "condition_task"
 	module = "..."
-	services = ["api"]
 	condition "consul-kv" {
 		path = "key-path"
 		use_as_module_input = true
@@ -192,7 +186,6 @@ task {
 			`
 task {
 	name = "condition_task"
-	services = ["api"]
 	module = "..."
 	condition "nonexistent-condition" {
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,29 +227,35 @@ func TestFromPath(t *testing.T) {
 				},
 			},
 		}, {
-			"load dir merges tasks and services",
+			"load dir merges tasks and provider",
 			"testdata/merge",
 			&Config{
-				Services: &ServiceConfigs{
-					{
-						Name:        String("serviceA"),
-						Description: String("descriptionA"),
-					}, {
-						Name:        String("serviceB"),
-						Namespace:   String("teamB"),
-						Description: String("descriptionB"),
-					}, {
-						Name:        String("serviceC"),
-						Description: String("descriptionC"),
+				TerraformProviders: &TerraformProviderConfigs{
+					&TerraformProviderConfig{
+						"tf_providerA": map[string]interface{}{},
+					},
+					&TerraformProviderConfig{
+						"tf_providerB": map[string]interface{}{},
+					},
+					&TerraformProviderConfig{
+						"tf_providerC": map[string]interface{}{},
 					},
 				},
 				Tasks: &TaskConfigs{
 					{
-						Name:     String("taskA"),
-						Services: []string{"serviceA", "serviceB"},
+						Name: String("taskA"),
+						Condition: &ServicesConditionConfig{
+							ServicesMonitorConfig: ServicesMonitorConfig{
+								Names: []string{"serviceA", "serviceB"},
+							},
+						},
 					}, {
-						Name:     String("taskB"),
-						Services: []string{"serviceC", "serviceD"},
+						Name: String("taskB"),
+						Condition: &ServicesConditionConfig{
+							ServicesMonitorConfig: ServicesMonitorConfig{
+								Names: []string{"serviceC", "serviceD"},
+							},
+						},
 					},
 				},
 			},

--- a/config/module_input_test.go
+++ b/config/module_input_test.go
@@ -32,7 +32,6 @@ task {
 task {
 	name = "module_input_task"
 	module = "..."
-	services = ["api"]
 	condition "schedule" {
 		cron = "* * * * * * *"
 	}
@@ -63,7 +62,6 @@ task {
 task {
 	name = "module_input_task"
 	module = "..."
-	services = ["api"]
 	module_input "services" {
 		nonexistent_field = true
 	}
@@ -75,7 +73,6 @@ task {
 task {
 	name = "module_input_task"
 	module = "..."
-	services = ["api"]
 	condition "schedule" {
 		cron = "* * * * * * *"
 	}

--- a/config/testdata/merge/taskA.hcl
+++ b/config/testdata/merge/taskA.hcl
@@ -1,15 +1,10 @@
-service {
-  name = "serviceA"
-  description = "descriptionA"
-}
+terraform_provider "tf_providerA" { }
 
-service {
-  name = "serviceB"
-  namespace = "teamB"
-  description = "descriptionB"
-}
+terraform_provider "tf_providerB" { }
 
 task {
   name = "taskA"
-  services = ["serviceA", "serviceB"]
+  condition "services" {
+    names = ["serviceA", "serviceB"]
+  }
 }

--- a/config/testdata/merge/taskB.hcl
+++ b/config/testdata/merge/taskB.hcl
@@ -1,9 +1,8 @@
-service {
-  name = "serviceC"
-  description = "descriptionC"
-}
+terraform_provider "tf_providerC" { }
 
 task {
   name = "taskB"
-  services = ["serviceC", "serviceD"]
+  condition "services" {
+    names = ["serviceC", "serviceD"]
+  }
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -89,7 +89,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 					Status:    api.StatusSuccessful,
 					Enabled:   true,
 					Providers: []string{"fake-sync"},
-					Services:  []string{"api"},
+					Services:  []string{},
 					EventsURL: "/v1/status/tasks/fake_handler_success_task?include=events",
 				},
 				fakeFailureTaskName: {
@@ -97,7 +97,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 					Status:    api.StatusErrored,
 					Enabled:   true,
 					Providers: []string{"fake-sync"},
-					Services:  []string{"api"},
+					Services:  []string{},
 					EventsURL: "/v1/status/tasks/fake_handler_failure_task?include=events",
 				},
 				disabledTaskName: {
@@ -105,7 +105,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 					Status:    api.StatusUnknown,
 					Enabled:   false,
 					Providers: []string{"fake-sync"},
-					Services:  []string{"api"},
+					Services:  []string{},
 					EventsURL: "",
 				},
 			},
@@ -120,7 +120,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 					Status:    api.StatusSuccessful,
 					Enabled:   true,
 					Providers: []string{"fake-sync"},
-					Services:  []string{"api"},
+					Services:  []string{},
 					EventsURL: "/v1/status/tasks/fake_handler_success_task?include=events",
 				},
 			},
@@ -751,7 +751,6 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 
 		require.NotNil(t, e.Config)
 		assert.Equal(t, []string{"fake-sync"}, e.Config.Providers)
-		assert.Equal(t, []string{"api"}, e.Config.Services)
 		wd, err := os.Getwd()
 		assert.NoError(t, err)
 		module := filepath.Join(wd, "./test_modules/local_instances_file")

--- a/e2e/condition_catalog_service_test.go
+++ b/e2e/condition_catalog_service_test.go
@@ -35,7 +35,6 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 			"api_tags.txt",
 			`task {
 	name = "catalog_task"
-	services = ["api"]
 	module = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "^api$"
@@ -49,7 +48,6 @@ func TestCondition_CatalogServices_Registration(t *testing.T) {
 			"api-1.txt",
 			`task {
 	name = "catalog_task"
-	services = ["api"]
 	module = "./test_modules/local_instances_file"
 	condition "catalog-services" {
 		regexp = "^api$"
@@ -87,11 +85,13 @@ func TestCondition_CatalogServices_SuppressTriggers(t *testing.T) {
 			true,
 			`task {
 	name = "catalog_task"
-	services = ["api", "db"]
 	module = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "^api$|^db$"
 		use_as_module_input = true
+	}
+	module_input "services" {
+		names = ["api", "db"]
 	}
 }`,
 		},
@@ -100,11 +100,13 @@ func TestCondition_CatalogServices_SuppressTriggers(t *testing.T) {
 			false,
 			`task {
 	name = "catalog_task"
-	services = ["api", "db"]
 	module = "./test_modules/local_instances_file"
 	condition "catalog-services" {
 		regexp = "^api$|^db$"
 		use_as_module_input = false
+	}
+	module_input "services" {
+		names = ["api", "db"]
 	}
 }`,
 		},
@@ -136,7 +138,6 @@ func TestCondition_CatalogServices_UseAsModuleInput(t *testing.T) {
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "cs_condition_use")
 	conditionTask := `task {
 	name = "catalog_task"
-	services = ["api"]
 	module = "./test_modules/local_tags_file"
 	condition "catalog-services" {
 		regexp = "db|web"

--- a/e2e/condition_consul_kv_test.go
+++ b/e2e/condition_consul_kv_test.go
@@ -32,12 +32,14 @@ func newKVTaskConfig(taskName string, opts kvTaskOpts) string {
 
 	conditionTask := fmt.Sprintf(`task {
 		name = "%s"
-		services = ["web", "api"]
 		module = "%s"
 		condition "consul-kv" {
 			path = "%s"
 			use_as_module_input = %t
 			recurse = %t
+		}
+		module_input "services" {
+			names = ["web", "api"]
 		}
 	}
 	`, taskName, module, opts.path, opts.useAsModuleInput, opts.recurse)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -182,10 +182,12 @@ func TestCondition_Schedule_Dynamic(t *testing.T) {
 	taskSchedule := 10 * time.Second
 	conditionTask := fmt.Sprintf(`task {
 	name = "%s"
-	services = ["api", "web"]
 	module = "./test_modules/local_instances_file"
 	condition "schedule" {
 		cron = "*/10 * * * * * *"
+	}
+	module_input "services" {
+		names = ["api", "web"]
 	}
 }
 `, schedTaskName)

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -118,9 +118,11 @@ func dbTask() string {
 task {
 	name = "%s"
 	description = "basic read-write e2e task for api & db"
-	services = ["api", "db"]
 	providers = ["local"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+    	names = ["api", "db"]
+	}
 }`, dbTaskName)
 }
 
@@ -133,9 +135,11 @@ func (c hclConfig) appendWebTask() hclConfig {
 task {
 	name = "%s"
 	description = "basic read-write e2e task api & web"
-	services = ["api", "web"]
 	providers = ["local"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+		names = ["api", "web"]
+	}
 }
 `, webTaskName))
 }
@@ -159,8 +163,10 @@ func moduleTaskConfig(name string, module string, opts ...string) string {
 task {
 	name = "%s"
 	description = "e2e test"
-	services = ["api", "web"]
 	module = "%s"
+	condition "services" {
+		names = ["api", "web"]
+	}
 	%s
 }
 `, name, module, optsConfig)
@@ -204,26 +210,32 @@ terraform_provider "fake-sync" {
 task {
 	name = "%s"
 	description = "basic e2e task with fake handler. expected to error"
-	services = ["api"]
 	providers = ["fake-sync.failure"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+		names = ["api"]
+	}
 }
 
 task {
 	name = "%s"
 	description = "basic e2e task with fake handler. expected to not error"
-	services = ["api"]
 	providers = ["fake-sync.success"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+		names = ["api"]
+	}
 }
 
 task {
 	name = "%s"
 	description = "disabled task"
 	enabled = false
-	services = ["api"]
 	providers = ["fake-sync.success"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+		names = ["api"]
+	}
 }
 `, dir, fakeFailureTaskName, fakeSuccessTaskName, disabledTaskName))
 }
@@ -235,27 +247,11 @@ task {
 	name = "%s"
 	description = "task is configured as disabled"
 	enabled = false
-	services = ["api", "web"]
 	providers = ["local"]
 	module = "./test_modules/local_instances_file"
+	condition "services" {
+		names = ["api", "web"]
+	}
 }
 `, disabledTaskName)
-}
-
-func panosBadCredConfig() hclConfig {
-	return `log_level = "trace"
-terraform_provider "panos" {
-	hostname = "10.10.10.10"
-	api_key = "badapikey_1234"
-}
-
-task {
-	name = "panos-bad-cred-e2e-test"
-	description = "panos handler should error and stop sync after once"
-	module = "findkim/ngfw/panos"
-	version = "0.0.1-beta5"
-	providers = ["panos"]
-	services = ["web"]
-}
-`
 }

--- a/e2e/config.go
+++ b/e2e/config.go
@@ -174,21 +174,6 @@ buffer_period {
 	enabled = false
 }
 
-service {
-  name = "api"
-  description = "backend"
-}
-
-service {
-  name = "web"
-  description = "frontend"
-}
-
-service {
-    name = "db"
-    description = "database"
-}
-
 terraform_provider "local" {}
 `, wd))
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -275,7 +275,6 @@ func TestE2EValidateError(t *testing.T) {
 	conditionTask := fmt.Sprintf(`task {
 	name = "%s"
 	module = "./test_modules/incompatible_w_cts"
-	services = ["api", "db"]
 	condition "catalog-services" {
 		regexp = "^api$|^db$"
 		use_as_module_input = true
@@ -325,7 +324,9 @@ func TestE2E_FilterStatus(t *testing.T) {
 			`task {
 				name = "%s"
 				module = "./test_modules/null_resource"
-				services = ["api", "unhealthy-service"]
+				condition "services" {
+					names = ["api", "unhealthy-service"]
+				}
 			}
 			`,
 			func(t *testing.T, contents string) {
@@ -343,11 +344,10 @@ func TestE2E_FilterStatus(t *testing.T) {
 			`task {
 				name = "%s"
 				module = "./test_modules/null_resource"
-				services = ["api", "unhealthy-service"]
-			}
-			service {
-				name = "unhealthy-service"
-				filter = "Checks.Status != \"\""
+				condition "services" {
+					names = ["api", "unhealthy-service"]
+					filter = "Checks.Status != \"\""
+				}
 			}
 			`,
 			func(t *testing.T, contents string) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -416,6 +416,85 @@ func TestE2EInspectMode(t *testing.T) {
 	validateServices(t, false, []string{"web", "api"}, resourcePath)
 }
 
+// TestE2E_ConfigStreamlining_Deprecations runs the CTS binary in once mode to test a CTS config
+// with v0.5 config streamlining deprecations. This test confirms that the old
+// deprecated fields still work in v0.5.0 until removal.
+//
+// Deprecations to remove in v0.8.0
+//  - "source_input" => "module_input"
+//  - "source_includes_var" => "use_as_module_input"
+//
+// Deprecations to remove in a future major release after v0.8.0
+//  - "source" => "module"
+//  - "services" => "condition "services"" or "module_input "services""
+//  - "service" block => "condition "services"" or "module_input "services""
+func TestE2E_ConfigStreamlining_Deprecations(t *testing.T) {
+	setParallelism(t)
+
+	srv := newTestConsulServer(t)
+	defer srv.Stop()
+	srv.SetKVString(t, "key", "value")
+	srv.AddAddressableService(t, "web", testutil.HealthPassing, "1.2.3.4", 8080, []string{""})
+
+	removeAfterTaskName := "remove-after-0-8"
+	removeAfterConfig := fmt.Sprintf(`
+	task {
+		name = "%s"
+		description = "source, services, service deprecation"
+		source = "./test_modules/local_instances_file"
+		services = ["web"]
+	}
+	service {
+		name = "web"
+		cts_user_defined_meta {
+			my_meta_key = "my_meta_value"
+		}
+	}
+	`, removeAfterTaskName)
+
+	removeInTaskName := "remove-in-0-8"
+	removeInConfig := fmt.Sprintf(`
+	task {
+		name = "%s"
+		description = "source_includes_var & source_input deprecation"
+		module = "./test_modules/consul_kv_file"
+
+		condition "consul-kv" {
+			path = "key"
+			source_includes_var = true
+		}
+
+		source_input "services" {
+			names = ["api"]
+		}
+	}
+	`, removeInTaskName)
+
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "config_streamlining")
+	cleanup := testutils.MakeTempDir(t, tempDir) // delete only if no errors
+
+	config := baseConfig(tempDir).appendConsulBlock(srv).
+		appendString(removeAfterConfig).appendString(removeInConfig)
+	configPath := filepath.Join(tempDir, configFile)
+	config.write(t, configPath)
+
+	// try to run once-mode successfully
+	api.StartCTS(t, configPath, api.CTSOnceModeFlag)
+
+	// check resources for deprecations to be removed after 0.8
+	workingDir := filepath.Join(tempDir, removeAfterTaskName)
+	resourcesPath := filepath.Join(workingDir, resourcesDir)
+	validateServices(t, true, []string{"web"}, resourcesPath)
+	validateVariable(t, true, workingDir, "services", "meta_value")
+
+	// check resources for deprecations to be removed in 0.8
+	resourcesPath = filepath.Join(tempDir, removeInTaskName, resourcesDir)
+	validateModuleFile(t, true, true, resourcesPath, "key", "value")
+	validateServices(t, true, []string{"api"}, resourcesPath)
+
+	cleanup()
+}
+
 func testInvalidQueries(t *testing.T, testName, taskName, taskConfig, errMsg string) {
 	// Create tasks at start up
 	t.Run(testName, func(t *testing.T) {

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -36,7 +36,9 @@ working_dir = "%s"
 task {
 	name = "%s"
 	description = "basic read-write e2e task api only"
-	services = ["api"]
+	condition "services" {
+		names = ["api"]
+	}
 	providers = ["local"]
 	module = "./test_modules/local_instances_file"
 }

--- a/examples/reference-example/example-config.hcl
+++ b/examples/reference-example/example-config.hcl
@@ -18,7 +18,9 @@ task {
   module = "namespace/example/module"
   version = "1.1.0"
   providers = ["myprovider"]
-  services = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+  }
   variable_files = ["example.module.tfvars", "/path/to/example.module.tfvars"]
 }
 

--- a/examples/runnable-example/README.md
+++ b/examples/runnable-example/README.md
@@ -33,8 +33,8 @@ Consul-Terraform-Sync will create a `sync-tasks/example-task` directory for the 
 The module executed by the task will create a file that has information about the services. It will be created as `test.txt` by default. Note that one of the services has an additional metadata value, as specified in the `config.hcl`, which is also printed out by the module.
 ```
 $ cat sync-tasks/example-task/test.txt
-api api 127.0.0.1
-web web 127.0.0.1 test_value
+api api 127.0.0.1 api_meta
+web web 127.0.0.1 web_meta
 ```
 
 Deregister one of the services in Consul. This can be done using the Consul CLI or the Consul API.
@@ -45,5 +45,5 @@ $ consul services deregister -id=api
 Consul-Terraform-Sync will automatically detect the change and rerun the task for that service, which will in turn update the `test.txt` file with the latest information about the Consul services.
 ```
 $ cat sync-tasks/example-task/test.txt
-web web 127.0.0.1 test_value
+web web 127.0.0.1 web_meta
 ```

--- a/examples/runnable-example/config.hcl
+++ b/examples/runnable-example/config.hcl
@@ -9,7 +9,13 @@ task {
   description = "Writes the service name, id, and IP address to a file"
   module = "./example-module"
   providers = ["local"]
-  services = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+    cts_user_defined_meta = {
+      "api" = "api_meta"
+      "web" = "web_meta"
+    }
+  }
   variable_files = []
 }
 
@@ -23,13 +29,4 @@ driver "terraform" {
 }
 
 terraform_provider "local" {
-}
-
-# Optional service block for defining configuration specific
-# to a service.
-service {
-  name = "web"
-  cts_user_defined_meta = {
-    "test_key" = "test_value"
-  }
 }

--- a/examples/runnable-example/example-module/README.md
+++ b/examples/runnable-example/example-module/README.md
@@ -17,7 +17,7 @@ This module writes to a file the name, id, and IP address for all the Consul ser
 ## Usage
 | User-defined service meta | Required | Description |
 |-------------------|----------|-------------|
-| test_key | false | Test metadata that is printed out per service |
+| test_key | false | Test metadata that is printed out for the service |
 
 **User Config for Consul Terraform Sync**
 
@@ -28,7 +28,13 @@ task {
   description = "Writes the service name, id, and IP address to a file"
   module = "../../example-module"
   providers = ["local"]
-  services = ["web", "api"]
+  condition "services" {
+    names = ["web", "api"]
+    cts_user_defined_meta = {
+      "api" = "api_meta"
+      "web" = "web_meta"
+    }
+  }
   variable_files = [/path/to/task-example.tfvars]
 }
 
@@ -44,12 +50,6 @@ driver "terraform" {
 terraform_provider "local" {
 }
 
-service {
-  name = "web"
-  cts_user_defined_meta = {
-    "test_key" = "test_value"
-  }
-}
 ```
 
 **Variable file**

--- a/examples/runnable-example/example-module/main.tf
+++ b/examples/runnable-example/example-module/main.tf
@@ -11,7 +11,7 @@ terraform {
 
 resource "local_file" "consul_services" {
   content = "${join("\n", [
-    for _, service in var.services : "${service.name} ${service.id} ${service.node_address} ${lookup(service.cts_user_defined_meta, "test_key", "")}"
+    for _, service in var.services : "${service.name} ${service.id} ${service.node_address} ${lookup(service.cts_user_defined_meta, service.name, "")}"
   ])}\n"
   filename = var.filename
 }


### PR DESCRIPTION
Upgrades our config snippets containing the deprecated `services` field and `service` block with the replacement or removes it completely.

Adds a placeholder e2e test to specifically test all config streamlining related deprecations