### PR TITLE
Improve validate template signature and test names

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -589,7 +589,7 @@ func (tf *Terraform) initTaskTemplate() error {
 
 // validateTemplate verifies that executing the fetch requests of
 // a template's dependencies does not error.
-func validateTemplate(t *hcat.Template, clients hcat.Looker) error {
+func validateTemplate(t templates.Template, clients hcat.Looker) error {
 	var outer_err error
 	recaller := func(dep dep.Dependency) (interface{}, bool) {
 		data, _, err := dep.Fetch(clients)

--- a/e2e/condition_catalog_service_test.go
+++ b/e2e/condition_catalog_service_test.go
@@ -348,7 +348,7 @@ func TestCondition_CatalogServices_InvalidQueries(t *testing.T) {
 		tc := tc // rebind tc into this lexical scope for parallel use
 		taskName := "condition_catalog_services_invalid_" + tc.name
 		taskConfig := fmt.Sprintf(config, taskName, tc.queryConfig)
-		testInvalidQueries(t, tc.name, taskName, taskConfig, tc.errMsg)
+		testInvalidTaskConfig(t, tc.name, taskName, taskConfig, tc.errMsg)
 	}
 }
 

--- a/e2e/condition_consul_kv_test.go
+++ b/e2e/condition_consul_kv_test.go
@@ -404,6 +404,6 @@ func TestConditionConsulKV_InvalidQueries(t *testing.T) {
 		tc := tc // rebind tc into this lexical scope for parallel use
 		taskName := "condition_consul_kv_invalid_" + tc.name
 		taskConfig := fmt.Sprintf(config, taskName, tc.queryConfig)
-		testInvalidQueries(t, tc.name, taskName, taskConfig, tc.errMsg)
+		testInvalidTaskConfig(t, tc.name, taskName, taskConfig, tc.errMsg)
 	}
 }

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -252,6 +252,6 @@ func TestCondition_Services_InvalidQueries(t *testing.T) {
 		tc := tc // rebind tc into this lexical scope for parallel use
 		taskName := "condition_services_invalid_" + tc.name
 		taskConfig := fmt.Sprintf(config, taskName, tc.queryConfig)
-		testInvalidQueries(t, tc.name, taskName, taskConfig, tc.errMsg)
+		testInvalidTaskConfig(t, tc.name, taskName, taskConfig, tc.errMsg)
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -495,7 +495,9 @@ func TestE2E_ConfigStreamlining_Deprecations(t *testing.T) {
 	cleanup()
 }
 
-func testInvalidQueries(t *testing.T, testName, taskName, taskConfig, errMsg string) {
+// testInvalidTaskConfig tests that task creation fails with the given task configuration.
+// Creation is tested both at CTS startup and with the CLI create command.
+func testInvalidTaskConfig(t *testing.T, testName, taskName, taskConfig, errMsg string) {
 	// Create tasks at start up
 	t.Run(testName, func(t *testing.T) {
 		setParallelism(t)

--- a/e2e/module_input_test.go
+++ b/e2e/module_input_test.go
@@ -444,7 +444,7 @@ func TestModuleInput_Services_InvalidQueries(t *testing.T) {
 	for _, tc := range cases {
 		taskName := "module_input_services_invalid_" + tc.name
 		taskConfig := fmt.Sprintf(config, taskName, tc.queryConfig)
-		testInvalidQueries(t, tc.name, taskName, taskConfig, tc.errMsg)
+		testInvalidTaskConfig(t, tc.name, taskName, taskConfig, tc.errMsg)
 	}
 }
 
@@ -482,6 +482,6 @@ func TestModuleInput_ConsulKV_InvalidQueries(t *testing.T) {
 	for _, tc := range cases {
 		taskName := "module_input_consul_kv_invalid_" + tc.name
 		taskConfig := fmt.Sprintf(config, taskName, tc.queryConfig)
-		testInvalidQueries(t, tc.name, taskName, taskConfig, tc.errMsg)
+		testInvalidTaskConfig(t, tc.name, taskName, taskConfig, tc.errMsg)
 	}
 }


### PR DESCRIPTION
Some follow up improvements to the validate template changes (https://github.com/hashicorp/consul-terraform-sync/pull/662) that I realized after this merged.

- Changed to using our interface for hcat template instead of hcat.Template directly
- Renamed `testInvalidQueries` to `testInvalidTaskConfig` because this test can be used for any invalid config that fails to create, not just for invalid queries