### PR TITLE
Update Task Status API response deprecations

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -77,7 +77,7 @@ func TestServe(t *testing.T) {
 					On("Events", mock.Anything, taskName).Return(map[string][]event.Event{}, nil)
 			},
 			http.StatusOK,
-			`{"task_b":{"task_name":"task_b","status":"unknown","enabled":true,"providers":null,"services":null,"events_url":""}}
+			`{"task_b":{"task_name":"task_b","status":"unknown","enabled":true,"events_url":"","providers":null,"services":null}}
 `,
 		}, {
 			"create task",

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -575,7 +575,6 @@ func TestJsonResponse(t *testing.T) {
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
 								Source:    "./test_modules/local_instances_file",
-								Module:    "./test_modules/local_instances_file",
 							},
 						},
 						{
@@ -591,7 +590,6 @@ func TestJsonResponse(t *testing.T) {
 								Providers: []string{"local", "null", "f5"},
 								Services:  []string{"api", "web", "db"},
 								Source:    "./test_modules/local_instances_file",
-								Module:    "./test_modules/local_instances_file",
 							},
 						},
 					},

--- a/api/task_status.go
+++ b/api/task_status.go
@@ -20,10 +20,18 @@ type TaskStatus struct {
 	TaskName  string        `json:"task_name"`
 	Status    string        `json:"status"`
 	Enabled   bool          `json:"enabled"`
-	Providers []string      `json:"providers"`
-	Services  []string      `json:"services"`
 	EventsURL string        `json:"events_url"`
 	Events    []event.Event `json:"events,omitempty"`
+
+	// Providers and Services are deprecated in v0.5. These are configuration
+	// details about the task rather than status information. Users should
+	// switch to using the Get Task API to request the task's provider and
+	// services (and more!) information.
+	//  - Providers should be removed in 0.8
+	//  - Services should be removed in a future major release after 0.8 to align
+	//  with the removal of CTS config task.services
+	Providers []string `json:"providers"`
+	Services  []string `json:"services"`
 }
 
 // taskStatusHandler handles the task status endpoint

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -306,7 +306,7 @@ func (rw *ReadWrite) checkApply(ctx context.Context, d driver.Driver, retry, onc
 	ev, err := event.NewEvent(taskName, &event.Config{
 		Providers: task.ProviderNames(),
 		Services:  task.ServiceNames(),
-		Module:    task.Module(),
+		Source:    task.Module(),
 	})
 	if err != nil {
 		return false, fmt.Errorf("error creating event for task %s: %s",
@@ -448,7 +448,7 @@ func (rw *ReadWrite) runTask(ctx context.Context, d driver.Driver) error {
 	ev, err := event.NewEvent(taskName, &event.Config{
 		Providers: task.ProviderNames(),
 		Services:  task.ServiceNames(),
-		Module:    task.Module(),
+		Source:    task.Module(),
 	})
 	if err != nil {
 		logger.Error("error initializing run task event", "error", err)

--- a/controller/server.go
+++ b/controller/server.go
@@ -142,7 +142,7 @@ func (rw *ReadWrite) TaskUpdate(ctx context.Context, updateConf config.TaskConfi
 		ev, err := event.NewEvent(taskName, &event.Config{
 			Providers: task.ProviderNames(),
 			Services:  task.ServiceNames(),
-			Module:    task.Module(),
+			Source:    task.Module(),
 		})
 		if err != nil {
 			err = errors.Wrap(err, fmt.Sprintf("error creating task update"+

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -784,7 +784,6 @@ func checkEvents(t *testing.T, taskStatuses map[string]api.TaskStatus,
 		wd, err := os.Getwd()
 		assert.NoError(t, err)
 		module := filepath.Join(wd, "./test_modules/local_instances_file")
-		assert.Equal(t, module, e.Config.Module)
 		assert.Equal(t, module, e.Config.Source)
 
 		if taskName == fakeSuccessTaskName {

--- a/event/event.go
+++ b/event/event.go
@@ -37,12 +37,7 @@ type Error struct {
 type Config struct {
 	Providers []string `json:"providers"`
 	Services  []string `json:"services"`
-
-	// Source was deprecated in v0.5. Use Module instead. External packages
-	// should use Module except for tests
-	Source string `json:"source"`
-	// Module introduced in 0.5
-	Module string `json:"module"`
+	Source    string   `json:"source"`
 }
 
 // NewEvent configures a new event with a task name and any relevant information
@@ -54,11 +49,6 @@ func NewEvent(taskName string, config *Config) (*Event, error) {
 	uuid, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, err
-	}
-
-	// Set deprecated 'source' field if not set
-	if config != nil && config.Source == "" {
-		config.Source = config.Module
 	}
 
 	return &Event{
@@ -107,11 +97,11 @@ func (c *Config) GoString() string {
 	return fmt.Sprintf("&Config{"+
 		"Providers:%s, "+
 		"Services:%s, "+
-		"Module:%s"+
+		"Source:%s"+
 		"}",
 		c.Providers,
 		c.Services,
-		c.Module,
+		c.Source,
 	)
 }
 

--- a/event/event.go
+++ b/event/event.go
@@ -24,7 +24,12 @@ type Event struct {
 	EndTime    time.Time `json:"end_time"`
 	TaskName   string    `json:"task_name"`
 	EventError *Error    `json:"error"`
-	Config     *Config   `json:"config"`
+
+	// Config is deprecated in v0.5. This is configuration details about the
+	// task rather than status information. Users should switch to using the
+	// Get Task API to request the task's config information.
+	//  - Config should be removed in 0.8
+	Config *Config `json:"config"`
 }
 
 // Error captures an event's error information
@@ -33,7 +38,8 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-// Config provides details on an event's task configuration
+// Config provides details on an event's task configuration. It is deprecated
+// in v0.5 and should be removed in 0.8
 type Config struct {
 	Providers []string `json:"providers"`
 	Services  []string `json:"services"`

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -1,8 +1,6 @@
 package event
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -84,7 +82,7 @@ func TestNewEvent(t *testing.T) {
 			&Config{
 				Providers: []string{"local"},
 				Services:  []string{"web", "api"},
-				Module:    "/my-module",
+				Source:    "/my-module",
 			},
 			false,
 		},
@@ -182,27 +180,6 @@ func TestEvent_End(t *testing.T) {
 	}
 }
 
-// TestNewEvent_DeprecatedSource checks that deprecated `source` is still set
-// auto-set by NewEvents and included in json payload
-func TestNewEvent_DeprecatedSource(t *testing.T) {
-	t.Parallel()
-
-	conf := &Config{
-		Providers: []string{"local"},
-		Services:  []string{"web", "api"},
-		Module:    "/my-module",
-	}
-
-	event, err := NewEvent("task_a", conf)
-	assert.NoError(t, err)
-
-	var buf bytes.Buffer
-	err = json.NewEncoder(&buf).Encode(event)
-	assert.NoError(t, err)
-	assert.Contains(t, buf.String(), `"source":"/my-module"`)
-	assert.Contains(t, buf.String(), `"module":"/my-module"`)
-}
-
 func businessLogic(expectError bool) (string, error) {
 	if expectError {
 		return "", errors.New("error")
@@ -233,13 +210,13 @@ func TestEvent_GoString(t *testing.T) {
 				Config: &Config{
 					Providers: []string{"local"},
 					Services:  []string{"web", "api"},
-					Module:    "/my-module",
+					Source:    "/my-module",
 				},
 			},
 			"&Event{ID:123, TaskName:happy, Success:false, " +
 				"StartTime:0001-01-01 00:00:00 +0000 UTC, " +
 				"EndTime:0001-01-01 00:00:00 +0000 UTC, EventError:&{error!}, " +
-				"Config:&Config{Providers:[local], Services:[web api], Module:/my-module}}",
+				"Config:&Config{Providers:[local], Services:[web api], Source:/my-module}}",
 		},
 	}
 
@@ -263,5 +240,4 @@ func assertEqualConfig(t *testing.T, exp, act *Config) {
 	assert.Equal(t, exp.Providers, act.Providers)
 	assert.Equal(t, exp.Services, act.Services)
 	assert.Equal(t, exp.Source, act.Source)
-	assert.Equal(t, exp.Module, act.Module)
 }


### PR DESCRIPTION
In a previous PR I deprecated `Events.Config.Source` and introduced `Events.Config.Module` as a replacement in the Task Status API response: https://github.com/hashicorp/consul-terraform-sync/pull/618

Instead, we want to deprecate `Events.Config` and additional task-config related fields from the Task Status API response. This is because they are not status information.

This information is better suited for a Get Task API, which we will introduce to replace the response deprecations.

Changes (details in commit)
 - Manually revert https://github.com/hashicorp/consul-terraform-sync/pull/618
 - Add deprecation comments