### PR TITLE
Get Task API

### DIFF
--- a/api/oapigen/client.go
+++ b/api/oapigen/client.go
@@ -97,6 +97,9 @@ type ClientInterface interface {
 
 	// DeleteTaskByName request
 	DeleteTaskByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetTaskByName request
+	GetTaskByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) CreateTaskWithBody(ctx context.Context, params *CreateTaskParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -125,6 +128,18 @@ func (c *Client) CreateTask(ctx context.Context, params *CreateTaskParams, body 
 
 func (c *Client) DeleteTaskByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteTaskByNameRequest(c.Server, name)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetTaskByName(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetTaskByNameRequest(c.Server, name)
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +244,40 @@ func NewDeleteTaskByNameRequest(server string, name string) (*http.Request, erro
 	return req, nil
 }
 
+// NewGetTaskByNameRequest generates requests for GetTaskByName
+func NewGetTaskByNameRequest(server string, name string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/tasks/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -279,6 +328,9 @@ type ClientWithResponsesInterface interface {
 
 	// DeleteTaskByName request
 	DeleteTaskByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*DeleteTaskByNameResponse, error)
+
+	// GetTaskByName request
+	GetTaskByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*GetTaskByNameResponse, error)
 }
 
 type CreateTaskResponse struct {
@@ -327,6 +379,29 @@ func (r DeleteTaskByNameResponse) StatusCode() int {
 	return 0
 }
 
+type GetTaskByNameResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TaskResponse
+	JSONDefault  *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetTaskByNameResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetTaskByNameResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 // CreateTaskWithBodyWithResponse request with arbitrary body returning *CreateTaskResponse
 func (c *ClientWithResponses) CreateTaskWithBodyWithResponse(ctx context.Context, params *CreateTaskParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateTaskResponse, error) {
 	rsp, err := c.CreateTaskWithBody(ctx, params, contentType, body, reqEditors...)
@@ -351,6 +426,15 @@ func (c *ClientWithResponses) DeleteTaskByNameWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseDeleteTaskByNameResponse(rsp)
+}
+
+// GetTaskByNameWithResponse request returning *GetTaskByNameResponse
+func (c *ClientWithResponses) GetTaskByNameWithResponse(ctx context.Context, name string, reqEditors ...RequestEditorFn) (*GetTaskByNameResponse, error) {
+	rsp, err := c.GetTaskByName(ctx, name, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetTaskByNameResponse(rsp)
 }
 
 // ParseCreateTaskResponse parses an HTTP response from a CreateTaskWithResponse call
@@ -406,6 +490,39 @@ func ParseDeleteTaskByNameResponse(rsp *http.Response) (*DeleteTaskByNameRespons
 			return nil, err
 		}
 		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetTaskByNameResponse parses an HTTP response from a GetTaskByNameWithResponse call
+func ParseGetTaskByNameResponse(rsp *http.Response) (*GetTaskByNameResponse, error) {
+	bodyBytes, err := ioutil.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetTaskByNameResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TaskResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ErrorResponse

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -93,6 +93,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+    get:
+      summary: Gets a task by name
+      operationId: getTaskByName
+      description: Retrieves information for a single task based on the name provided
+      tags:
+        - tasks
+      parameters:
+        - name: name
+          in: path
+          description: Name of task to retrieve
+          required: true
+          schema:
+            type: string
+            example: "taskA"
+      responses:
+        '200':
+          description: Task retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskResponse'
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   schemas:

--- a/api/task.go
+++ b/api/task.go
@@ -16,6 +16,7 @@ import (
 const (
 	updateTaskSubsystemName = "updatetask"
 	createTaskSubsystemName = "createtask"
+	deleteTaskSubsystemName = "deletetask"
 	getTaskSubsystemName    = "gettask"
 
 	taskPath = "tasks"

--- a/api/task.go
+++ b/api/task.go
@@ -16,7 +16,9 @@ import (
 const (
 	updateTaskSubsystemName = "updatetask"
 	createTaskSubsystemName = "createtask"
-	taskPath                = "tasks"
+	getTaskSubsystemName    = "gettask"
+
+	taskPath = "tasks"
 
 	RunOptionInspect = "inspect"
 	RunOptionNow     = "now"

--- a/api/task_create_test.go
+++ b/api/task_create_test.go
@@ -16,45 +16,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testCreateTaskRequest = `{
-	"task": {
-		"description": "Writes the service name, id, and IP address to a file",
-		"enabled": true,
-		"name": "api-task",
-		"providers": [
-			"local"
-		],
-		"condition": {
-			"services": {"names": ["api"]}
-		},
-		"module": "./example-module"
-	}
-}`
-	testCreateTaskRequestVariables = `{
-	"task": {
-		"description": "Writes the service name, id, and IP address to a file",
-		"enabled": true,
-		"name": "api-task",
-		"providers": [
-			"local"
-		],
-		"condition": {
-			"services": {"names": ["api"]}
-		},
-		"variables":{
-			"filename": "test.txt"
-		},
-		"module": "./example-module"
-	}
-}`
-	testTaskName = "api-task"
-)
+const testTaskName = "api-task"
 
-func TestTaskLifeCycleHandler_CreateTask(t *testing.T) {
-	t.Parallel()
+var (
+	// testTaskJSON and testTaskConfig are a set of json and config for the
+	// same task "api-task"
+	testTaskJSON = fmt.Sprintf(`{
+		"task": {
+			"description": "Writes the service name, id, and IP address to a file",
+			"enabled": true,
+			"name": "%s",
+			"providers": [
+				"local"
+			],
+			"condition": {
+				"services": {"names": ["api"]}
+			},
+			"module_input": {
+				"consul_kv": {
+					"path": "key-path",
+					"recurse": true,
+					"datacenter": "dc2",
+					"namespace": "ns2"
+				}
+			},
+			"variables":{
+				"filename": "test.txt"
+			},
+			"module": "./example-module"
+		}
+	}`, testTaskName)
 
-	taskConf := config.TaskConfig{
+	testTaskConfig = config.TaskConfig{
 		Name:        config.String(testTaskName),
 		Enabled:     config.Bool(true),
 		Description: config.String("Writes the service name, id, and IP address to a file"),
@@ -62,10 +55,24 @@ func TestTaskLifeCycleHandler_CreateTask(t *testing.T) {
 		Condition: &config.ServicesConditionConfig{
 			ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api"}},
 		},
+		ModuleInputs: &config.ModuleInputConfigs{
+			&config.ConsulKVModuleInputConfig{
+				ConsulKVMonitorConfig: config.ConsulKVMonitorConfig{
+					Path:       config.String("key-path"),
+					Recurse:    config.Bool(true),
+					Datacenter: config.String("dc2"),
+					Namespace:  config.String("ns2"),
+				},
+			},
+		},
 		Providers: []string{"local"},
+		Variables: map[string]string{"filename": "test.txt"},
 	}
-	taskConfVars := *taskConf.Copy()
-	taskConfVars.Variables = map[string]string{"filename": "test.txt"}
+)
+
+func TestTaskLifeCycleHandler_CreateTask(t *testing.T) {
+	t.Parallel()
+
 	cases := []struct {
 		name       string
 		taskName   string
@@ -76,23 +83,16 @@ func TestTaskLifeCycleHandler_CreateTask(t *testing.T) {
 	}{
 		{
 			name:       "happy_path",
-			request:    testCreateTaskRequest,
+			request:    testTaskJSON,
 			run:        "",
-			mockReturn: taskConf,
+			mockReturn: testTaskConfig,
 			statusCode: http.StatusCreated,
 		},
 		{
 			name:       "happy_path_run_now",
-			request:    testCreateTaskRequest,
+			request:    testTaskJSON,
 			run:        "now",
-			mockReturn: taskConf,
-			statusCode: http.StatusCreated,
-		},
-		{
-			name:       "happy_path_with_variables",
-			request:    testCreateTaskRequestVariables,
-			run:        "now",
-			mockReturn: taskConfVars,
+			mockReturn: testTaskConfig,
 			statusCode: http.StatusCreated,
 		},
 	}
@@ -122,36 +122,18 @@ func TestTaskLifeCycleHandler_CreateTask_RunInspect(t *testing.T) {
 	t.Parallel()
 
 	// Expected ctrl mock calls and returns
-	taskName := "inspected_task"
-	request := fmt.Sprintf(`{
-	"task": {
-			"name": "%s",
-			"enabled": true,
-			"condition": {"services": {"names": ["api"]}},
-			"module": "mkam/hello/cts"
-		}
-	}`, taskName)
-	taskConf := config.TaskConfig{
-		Name:    config.String(taskName),
-		Enabled: config.Bool(true),
-		Module:  config.String("mkam/hello/cts"),
-		Condition: &config.ServicesConditionConfig{
-			ServicesMonitorConfig: config.ServicesMonitorConfig{Names: []string{"api"}},
-		},
-	}
-
 	ctrl := new(mocks.Server)
-	ctrl.On("Task", mock.Anything, taskName).Return(config.TaskConfig{}, fmt.Errorf("DNE")).
-		On("TaskInspect", mock.Anything, taskConf).Return(true, "foobar-plan", "", nil)
+	ctrl.On("Task", mock.Anything, testTaskName).Return(config.TaskConfig{}, fmt.Errorf("DNE")).
+		On("TaskInspect", mock.Anything, testTaskConfig).Return(true, "foobar-plan", "", nil)
 	handler := NewTaskLifeCycleHandler(ctrl)
 
-	resp := runTestCreateTask(t, handler, "inspect", http.StatusOK, request)
+	resp := runTestCreateTask(t, handler, "inspect", http.StatusOK, testTaskJSON)
 
 	// Check response, expect task and run
 	decoder := json.NewDecoder(resp.Body)
 	var actual TaskResponse
 	require.NoError(t, decoder.Decode(&actual))
-	expected := generateExpectedResponse(t, request)
+	expected := generateExpectedResponse(t, testTaskJSON)
 	expected.Run = &oapigen.Run{
 		Plan:           config.String("foobar-plan"),
 		ChangesPresent: config.Bool(true),
@@ -160,7 +142,7 @@ func TestTaskLifeCycleHandler_CreateTask_RunInspect(t *testing.T) {
 	ctrl.AssertExpectations(t)
 
 	// Run inspect a second time with same task, expect return 200 OK
-	runTestCreateTask(t, handler, "inspect", http.StatusOK, request)
+	runTestCreateTask(t, handler, "inspect", http.StatusOK, testTaskJSON)
 }
 
 func TestTaskLifeCycleHandler_CreateTask_BadRequest(t *testing.T) {
@@ -226,7 +208,7 @@ func TestTaskLifeCycleHandler_CreateTask_InternalError(t *testing.T) {
 	ctrl.On("TaskCreate", mock.Anything, mock.Anything).Return(config.TaskConfig{}, fmt.Errorf(errMsg))
 	handler := NewTaskLifeCycleHandler(ctrl)
 
-	resp := runTestCreateTask(t, handler, "", http.StatusInternalServerError, testCreateTaskRequest)
+	resp := runTestCreateTask(t, handler, "", http.StatusInternalServerError, testTaskJSON)
 
 	// Check response
 	decoder := json.NewDecoder(resp.Body)

--- a/api/task_delete.go
+++ b/api/task_delete.go
@@ -32,7 +32,8 @@ func (h *TaskLifeCycleHandler) DeleteTaskByName(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	writeResponse(w, r, http.StatusAccepted, oapigen.TaskResponse{
-		RequestId: requestID,
-	})
+	resp := oapigen.TaskResponse{RequestId: requestID}
+	writeResponse(w, r, http.StatusAccepted, resp)
+
+	logger.Trace("task deleted", "delete_task_response", resp)
 }

--- a/api/task_delete.go
+++ b/api/task_delete.go
@@ -15,8 +15,8 @@ func (h *TaskLifeCycleHandler) DeleteTaskByName(w http.ResponseWriter, r *http.R
 
 	ctx := r.Context()
 	requestID := requestIDFromContext(ctx)
-	logger := logging.FromContext(r.Context()).Named(createTaskSubsystemName).With("task_name", name)
-	logger.Trace("delete task request", "delete_task_request", name)
+	logger := logging.FromContext(r.Context()).Named(deleteTaskSubsystemName).With("task_name", name)
+	logger.Trace("delete task request")
 
 	// Check if task exists
 	_, err := h.ctrl.Task(ctx, name)

--- a/api/task_delete_test.go
+++ b/api/task_delete_test.go
@@ -18,7 +18,7 @@ func TestTaskLifeCycleHandler_DeleteTaskByName(t *testing.T) {
 	taskName := "task"
 	cases := []struct {
 		name       string
-		mock       func(*mocks.Server)
+		mockServer func(*mocks.Server)
 		statusCode int
 	}{
 		{
@@ -50,7 +50,7 @@ func TestTaskLifeCycleHandler_DeleteTaskByName(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := new(mocks.Server)
-			tc.mock(ctrl)
+			tc.mockServer(ctrl)
 			handler := NewTaskLifeCycleHandler(ctrl)
 
 			path := fmt.Sprintf("/v1/tasks/%s", taskName)

--- a/api/task_delete_test.go
+++ b/api/task_delete_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTaskDelete_DeleteTaskByName(t *testing.T) {
+func TestTaskLifeCycleHandler_DeleteTaskByName(t *testing.T) {
 	t.Parallel()
 	taskName := "task"
 	cases := []struct {

--- a/api/task_get.go
+++ b/api/task_get.go
@@ -8,8 +8,8 @@ import (
 
 // GetTaskByName retrieves a task's information by the task's name
 func (h *TaskLifeCycleHandler) GetTaskByName(w http.ResponseWriter, r *http.Request, name string) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 
 	ctx := r.Context()
 	requestID := requestIDFromContext(ctx)
@@ -26,4 +26,6 @@ func (h *TaskLifeCycleHandler) GetTaskByName(w http.ResponseWriter, r *http.Requ
 
 	resp := taskResponseFromTaskConfig(taskConfig, requestID)
 	writeResponse(w, r, http.StatusOK, resp)
+
+	logger.Trace("task retrieved", "get_task_response", resp)
 }

--- a/api/task_get.go
+++ b/api/task_get.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
+)
+
+// GetTaskByName retrieves a task's information by the task's name
+func (h *TaskLifeCycleHandler) GetTaskByName(w http.ResponseWriter, r *http.Request, name string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	ctx := r.Context()
+	requestID := requestIDFromContext(ctx)
+	logger := logging.FromContext(r.Context()).Named(getTaskSubsystemName).With("task_name", name)
+	logger.Trace("get task request")
+
+	// Retrieve task if it exists
+	taskConfig, err := h.ctrl.Task(ctx, name)
+	if err != nil {
+		logger.Trace("task not found", "error", err)
+		sendError(w, r, http.StatusNotFound, err)
+		return
+	}
+
+	resp := taskResponseFromTaskConfig(taskConfig, requestID)
+	writeResponse(w, r, http.StatusOK, resp)
+}

--- a/api/task_get_test.go
+++ b/api/task_get_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaskLifeCycleHandler_GetTaskByName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		mock          func(*mocks.Server)
+		statusCode    int
+		checkResponse func(*httptest.ResponseRecorder)
+	}{
+		{
+			name: "happy_path",
+			mock: func(ctrl *mocks.Server) {
+				ctrl.On("Task", mock.Anything, testTaskName).Return(testTaskConfig, nil)
+			},
+			statusCode: http.StatusOK,
+			checkResponse: func(resp *httptest.ResponseRecorder) {
+				decoder := json.NewDecoder(resp.Body)
+				var actual oapigen.TaskResponse
+				err := decoder.Decode(&actual)
+				require.NoError(t, err)
+				expected := generateExpectedResponse(t, testTaskJSON)
+				assert.Equal(t, expected, actual)
+
+			},
+		},
+		{
+			name: "not_found",
+			mock: func(ctrl *mocks.Server) {
+				ctrl.On("Task", mock.Anything, testTaskName).Return(config.TaskConfig{}, fmt.Errorf("DNE"))
+			},
+			statusCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := new(mocks.Server)
+			tc.mock(ctrl)
+			handler := NewTaskLifeCycleHandler(ctrl)
+
+			path := fmt.Sprintf("/v1/tasks/%s", testTaskName)
+			req, err := http.NewRequest(http.MethodGet, path, nil)
+			require.NoError(t, err)
+			resp := httptest.NewRecorder()
+
+			handler.GetTaskByName(resp, req, testTaskName)
+			assert.Equal(t, tc.statusCode, resp.Code)
+
+			if tc.checkResponse != nil {
+				tc.checkResponse(resp)
+			}
+		})
+	}
+}

--- a/api/task_get_test.go
+++ b/api/task_get_test.go
@@ -20,13 +20,13 @@ func TestTaskLifeCycleHandler_GetTaskByName(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		mock          func(*mocks.Server)
+		mockServer    func(*mocks.Server)
 		statusCode    int
 		checkResponse func(*httptest.ResponseRecorder)
 	}{
 		{
 			name: "happy_path",
-			mock: func(ctrl *mocks.Server) {
+			mockServer: func(ctrl *mocks.Server) {
 				ctrl.On("Task", mock.Anything, testTaskName).Return(testTaskConfig, nil)
 			},
 			statusCode: http.StatusOK,
@@ -42,7 +42,7 @@ func TestTaskLifeCycleHandler_GetTaskByName(t *testing.T) {
 		},
 		{
 			name: "not_found",
-			mock: func(ctrl *mocks.Server) {
+			mockServer: func(ctrl *mocks.Server) {
 				ctrl.On("Task", mock.Anything, testTaskName).Return(config.TaskConfig{}, fmt.Errorf("DNE"))
 			},
 			statusCode: http.StatusNotFound,
@@ -52,7 +52,7 @@ func TestTaskLifeCycleHandler_GetTaskByName(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := new(mocks.Server)
-			tc.mock(ctrl)
+			tc.mockServer(ctrl)
 			handler := NewTaskLifeCycleHandler(ctrl)
 
 			path := fmt.Sprintf("/v1/tasks/%s", testTaskName)

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -660,11 +660,8 @@ func TestE2E_TaskEndpoints_InvalidSchema(t *testing.T) {
 
 	resp := testutils.RequestHTTP(t, http.MethodPost, u, badRequest)
 	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
 	var errorResponse oapigen.ErrorResponse
-	err = json.Unmarshal(bodyBytes, &errorResponse)
+	err := json.NewDecoder(resp.Body).Decode(&errorResponse)
 	require.NoError(t, err)
 
 	assert.Contains(t, errorResponse.Error.Message, `request body has an error: doesn't match the schema: `+
@@ -713,10 +710,8 @@ func TestE2E_TaskEndpoints_DryRunTaskCreate(t *testing.T) {
 
 	// Parse response body
 	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
 	var r oapigen.TaskResponse
-	err = json.Unmarshal(bodyBytes, &r)
+	err := json.NewDecoder(resp.Body).Decode(&r)
 	require.NoError(t, err)
 	assert.NotEmpty(t, r.RequestId, "expected request ID in response")
 
@@ -785,10 +780,8 @@ func TestE2E_TaskEndpoints_Get(t *testing.T) {
 
 	// Parse response body
 	defer resp.Body.Close()
-	bodyBytes, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
 	var r oapigen.TaskResponse
-	err = json.Unmarshal(bodyBytes, &r)
+	err := json.NewDecoder(resp.Body).Decode(&r)
 	require.NoError(t, err)
 	assert.NotEmpty(t, r.RequestId, "expected request ID in response")
 


### PR DESCRIPTION
Add support for a Get Task API.

Note: this API will be used to replace the task configuration information that is deprecated in the Task Status API

Example:
`curl localhost:8558/v1/tasks/kv_task`

```
{
  "request_id": "4859e3ad-125a-bd71-ac63-0ac883a810bf",
  "task": {
    "buffer_period": {
      "enabled": true,
      "max": "20s",
      "min": "5s"
    },
    "condition": {
      "consul_kv": {
        "datacenter": "",
        "namespace": "",
        "path": "my_key",
        "recurse": false,
        "use_as_module_input": true
      }
    },
    "description": "",
    "enabled": true,
    "module": "/Users/lornasong/go/src/github.com/hashicorp/consul-terraform-sync/build/modules/consul_kv_file",
    "module_input": {
      "services": {
        "cts_user_defined_meta": {},
        "datacenter": "",
        "filter": "",
        "names": [
          "api"
        ],
        "namespace": ""
      }
    },
    "name": "kv_task",
    "providers": [],
    "services": [],
    "variables": {},
    "version": ""
  }
}
```