### PR TITLE
Create task module no exist error

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -398,6 +398,9 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 	err = d.InitTask(ctx)
 	if err != nil {
 		logger.Error("error initializing new task", "error", err)
+		// Cleanup the task
+		d.DestroyTask(ctx)
+		logger.Debug("task destroyed", "task_name", *taskConfig.Name)
 		return nil, err
 	}
 
@@ -408,12 +411,18 @@ func (rw *ReadWrite) createTask(ctx context.Context, taskConfig config.TaskConfi
 			return nil, ctx.Err()
 		case <-timeout:
 			logger.Error("timed out rendering template")
+			// Cleanup the task
+			d.DestroyTask(ctx)
+			logger.Debug("task destroyed", "task_name", *taskConfig.Name)
 			return nil, fmt.Errorf("error initializing task")
 		default:
 		}
 		ok, err := d.RenderTemplate(ctx)
 		if err != nil {
 			logger.Error("error rendering task template")
+			// Cleanup the task
+			d.DestroyTask(ctx)
+			logger.Debug("task destroyed", "task_name", *taskConfig.Name)
 			return nil, err
 		}
 		if ok {

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -90,6 +90,7 @@ func TestServer_TaskCreate(t *testing.T) {
 	t.Run("create error", func(t *testing.T) {
 		mockD := new(mocksD.Driver)
 		mockD.On("InitTask", mock.Anything).Return(fmt.Errorf("init err"))
+		mockD.On("DestroyTask", mock.Anything).Return()
 		ctrl.drivers = driver.NewDrivers()
 		ctrl.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil

--- a/driver/drivers.go
+++ b/driver/drivers.go
@@ -157,7 +157,7 @@ func (d *Drivers) Delete(taskName string) error {
 	if ok {
 		driver.DestroyTask(context.Background())
 	} else {
-		logging.Global().Trace("attempted to destroy a non-existent task", taskNameLogKey, taskName)
+		logging.Global().Debug("attempted to destroy a non-existent task", taskNameLogKey, taskName)
 	}
 
 	// delete driver templates associated with task

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -733,7 +733,6 @@ func TestE2E_RecreateBadTask(t *testing.T) {
 	defer srv.Stop()
 	cts := ctsSetup(t, srv, tempDir, dbTask())
 
-	var taskConfig hclConfig
 	taskName := "new-task"
 	runs := []struct {
 		inputTask     string
@@ -760,11 +759,12 @@ task {
   services       = ["web"]
   enabled = true
 }`, taskName),
-			isExpectExist: false,
+			isExpectExist: true,
 		},
 	}
 	for i, run := range runs {
 		// Write task config file
+		var taskConfig hclConfig
 		taskConfig = taskConfig.appendString(run.inputTask)
 		taskFilePath := filepath.Join(tempDir, fmt.Sprintf("task_%d.hcl", i))
 		taskConfig.write(t, taskFilePath)


### PR DESCRIPTION
This PR fixes an issue where the attempted creation of a bad task, for example, one with a non existent module, would lead to the inability to then re-create or delete the task.

The cause of this was that because the validity of the module path was not checked until after the driver was created, the driver was not appropriately cleaned up before returning the error leading to a dangling watcher. This task adds cleanup steps if a task driver is successfully created, but then it errors later in the creation process

part of #522 