### PR TITLE
Revert back to validating template with hcat templates

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -527,11 +527,11 @@ func (tf *Terraform) initTaskTemplate() error {
 	wd := tf.task.WorkingDir()
 	tmplFullpath := filepath.Join(wd, tftmpl.TFVarsTmplFilename)
 	tfvarsFilepath := filepath.Join(wd, tftmpl.TFVarsFilename)
+	logger := tf.logger.With(taskNameLogKey, tf.task.Name())
 
 	content, err := tf.fileReader(tmplFullpath)
 	if err != nil {
-		tf.logger.Error(
-			"unable to read for task", taskNameLogKey, tf.task.Name(), "error", err)
+		logger.Error("unable to read for task", "error", err)
 		return err
 	}
 
@@ -573,16 +573,18 @@ func (tf *Terraform) initTaskTemplate() error {
 
 	err = tf.watcher.Register(tf.template)
 	if err != nil && err != hcat.ErrRegistry {
-		tf.logger.Error("unable to register template", taskNameLogKey, tf.task.Name(), "error", err)
+		logger.Error("unable to register template", "error", err)
 		return err
 	}
 
+	logger.Debug("validating template")
 	err = validateTemplate(tmpl, tf.watcher.Clients())
 	if err != nil {
 		tf.watcher.Deregister(tf.template)
-		tf.logger.Error("error validating template", taskNameLogKey, tf.task.Name(), "error", err)
+		logger.Error("error validating template", "error", err)
 		return errors.Wrap(err, "unable to retrieve data from Consul")
 	}
+	logger.Debug("template validation complete")
 
 	return nil
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -571,20 +571,19 @@ func (tf *Terraform) initTaskTemplate() error {
 
 	tf.setNotifier(tmpl)
 
+	logger.Debug("validating template")
+	err = validateTemplate(tmpl, tf.watcher.Clients())
+	if err != nil {
+		logger.Error("error validating template", "error", err)
+		return errors.Wrap(err, "unable to retrieve data from Consul")
+	}
+	logger.Debug("template validation complete")
+
 	err = tf.watcher.Register(tf.template)
 	if err != nil && err != hcat.ErrRegistry {
 		logger.Error("unable to register template", "error", err)
 		return err
 	}
-
-	logger.Debug("validating template")
-	err = validateTemplate(tmpl, tf.watcher.Clients())
-	if err != nil {
-		tf.watcher.Deregister(tf.template)
-		logger.Error("error validating template", "error", err)
-		return errors.Wrap(err, "unable to retrieve data from Consul")
-	}
-	logger.Debug("template validation complete")
 
 	return nil
 }

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -590,19 +590,20 @@ func (tf *Terraform) initTaskTemplate() error {
 
 // validateTemplate verifies that executing the fetch requests of
 // a template's dependencies does not error.
-func validateTemplate(t templates.Template, clients hcat.Looker) error {
-	var outer_err error
+func validateTemplate(t *hcat.Template, clients hcat.Looker) error {
+	var err error
 	recaller := func(dep dep.Dependency) (interface{}, bool) {
-		data, _, err := dep.Fetch(clients)
-		if err != nil {
-			outer_err = err
+		data, _, fetchErr := dep.Fetch(clients)
+		if fetchErr != nil {
+			err = fetchErr
 			return nil, false
 		}
 		return data, true
 	}
 	t.Execute(recaller)
+	// Mark that template needs to be re-run
 	t.Notify(nil)
-	return outer_err
+	return err
 }
 
 // setNotifier sets a notifier on the template to ensure only the condition's

--- a/templates/hcat.go
+++ b/templates/hcat.go
@@ -23,6 +23,9 @@ const DepSizeWarning = 128
 // which implements the interfaces Templater and Renderer
 // https://github.com/hashicorp/hcat
 type Template interface {
+	// Notify has a different behavior than hcat.Template.Notify and does
+	// not mark the template as dirty unless hcat.Template.Notify is called
+	// within the implementation
 	Notify(interface{}) bool
 	Render(content []byte) (hcat.RenderResult, error)
 	Execute(hcat.Recaller) ([]byte, error)
@@ -49,10 +52,11 @@ type Watcher interface {
 	Size() int
 	Stop()
 	Sweep(notifier hcat.IDer)
-	// not used but needed to meet the hcat.Watcherer interface
-	Complete(hcat.Notifier) bool
-	Recaller(hcat.Notifier) hcat.Recaller
 	Register(ns ...hcat.Notifier) error
 	Deregister(ns ...hcat.Notifier)
 	Clients() hcat.Looker
+
+	// not used but needed to meet the hcat.Watcherer interface
+	Complete(hcat.Notifier) bool
+	Recaller(hcat.Notifier) hcat.Recaller
 }


### PR DESCRIPTION
After I had changed to using our template interface instead of directly using a hcat template for template validation (https://github.com/hashicorp/consul-terraform-sync/pull/677), I realized that our custom notifiers that implement the template interface won't mark the template as dirty with `Notify(nil)`. I considered modifying the custom notifiers, but decided to revert this back to expecting `*hcat.Template` for more predictable behavior.

Made some additional improvements that I thought of as I was debugging an issue related to this change:
- Added some debug logs around the template validation
- Moved validation before registration so that we don't have to deregister on error
- Changed the variable names of the errors in ValidateTemplate for improved clarity