### PR TITLE
Update delete command output

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -229,6 +229,8 @@ func (m *meta) requestUserApprovalEnable(taskName string) (int, bool) {
 func (m *meta) requestUserApprovalDelete(taskName string) (int, bool) {
 	m.UI.Info(fmt.Sprintf("Do you want to delete '%s'?", taskName))
 	m.UI.Output(" - This action cannot be undone.")
+	m.UI.Output(" - If the task is not running, it will be deleted immediately.")
+	m.UI.Output(" - If the task is running, it will be deleted once it has completed.")
 	return m.requestUserApproval(taskName, "deleting")
 }
 

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -49,15 +49,17 @@ Options:
 Example:
 
   $ consul-terraform-sync task delete my_task
-	==> Do you want to delete 'my_task'?
-		- This action cannot be undone.
-	Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
+  ==> Do you want to delete 'my_task'?
+       - This action cannot be undone.
+       - If the task is not running, it will be deleted immediately.
+       - If the task is running, it will be deleted once it has completed.
+      Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.
 
-	Enter a value: yes
+  Enter a value: yes
 
-	==> Marking task 'my_task' for deletion...
+  ==> Marking task 'my_task' for deletion...
 
-	==> Task 'my_task' is marked for deletion and will be deleted when not running.
+  ==> Task 'my_task' has been marked for deletion and will be deleted when not running.
 `, strings.Join(c.meta.helpOptions, "\n"))
 	return strings.TrimSpace(helpText)
 }
@@ -113,7 +115,8 @@ func (c *taskDeleteCommand) Run(args []string) int {
 		return ExitCodeError
 	}
 
-	c.UI.Info(fmt.Sprintf("Task '%s' is marked for deletion and will be deleted when not running.", taskName))
+	c.UI.Info(fmt.Sprintf("Task '%s' has been marked for deletion "+
+		"and will be deleted when not running.", taskName))
 
 	return ExitCodeOK
 }

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -300,7 +300,7 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			input:    "yes\n",
 			outputContains: []string{
 				fmt.Sprintf("Do you want to delete '%s'?", dbTaskName),
-				fmt.Sprintf("Task '%s' is marked for deletion", dbTaskName)},
+				fmt.Sprintf("Task '%s' has been marked for deletion", dbTaskName)},
 			expectErr:     false,
 			expectDeleted: true,
 		},
@@ -310,7 +310,7 @@ func TestE2E_DeleteTaskCommand(t *testing.T) {
 			input:    "",
 			args:     []string{"-auto-approve"},
 			outputContains: []string{
-				fmt.Sprintf("Task '%s' is marked for deletion", dbTaskName)},
+				fmt.Sprintf("Task '%s' has been marked for deletion", dbTaskName)},
 			expectErr:     false,
 			expectDeleted: true,
 		},

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -358,7 +358,7 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 		subcmd = append(deleteCmd, n)
 		out, err = runSubcommand(t, "", subcmd...)
 		require.NoError(t, err, fmt.Sprintf("command '%s' failed:\n %s", subcmd, out))
-		require.Contains(t, out, fmt.Sprintf("Task '%s' is marked for deletion", n))
+		require.Contains(t, out, fmt.Sprintf("Task '%s' has been marked for deletion", n))
 
 		s := fmt.Sprintf("http://localhost:%d/%s/status/tasks/%s", cts.Port(), "v1", n)
 		resp := testutils.RequestHTTP(t, http.MethodGet, s, "")


### PR DESCRIPTION
Add more information on how a task is deleted to the approval prompt and change 'is marked' to 'has been marked', per the very helpful suggestions by @jherschman!

```
$ consul-terraform-sync task delete test-task
==> Do you want to delete 'test-task'?
     - This action cannot be undone.
     - If the task is not running, it will be deleted immediately.
     - If the task is running, it will be deleted once it has completed.
    Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.

Enter a value: yes

==> Marking task 'test-task' for deletion...

==> Task 'test-task' has been marked for deletion and will be deleted when not running.
```