### PR TITLE
Replace CTS config Services blocks to DeprecatedServices in backend

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ type Config struct {
 	Vault              *VaultConfig              `mapstructure:"vault"`
 	Driver             *DriverConfig             `mapstructure:"driver"`
 	Tasks              *TaskConfigs              `mapstructure:"task"`
-	Services           *ServiceConfigs           `mapstructure:"service"`
+	DeprecatedServices *ServiceConfigs           `mapstructure:"service"`
 	TerraformProviders *TerraformProviderConfigs `mapstructure:"terraform_provider"`
 	BufferPeriod       *BufferPeriodConfig       `mapstructure:"buffer_period"`
 	TLS                *CTSTLSConfig             `mapstructure:"tls"`
@@ -83,7 +83,7 @@ func DefaultConfig() *Config {
 		Consul:             consul,
 		Driver:             DefaultDriverConfig(),
 		Tasks:              DefaultTaskConfigs(),
-		Services:           DefaultServiceConfigs(),
+		DeprecatedServices: DefaultServiceConfigs(),
 		TerraformProviders: DefaultTerraformProviderConfigs(),
 		BufferPeriod:       DefaultBufferPeriodConfig(),
 		TLS:                DefaultCTSTLSConfig(),
@@ -106,7 +106,7 @@ func (c *Config) Copy() *Config {
 		Vault:              c.Vault.Copy(),
 		Driver:             c.Driver.Copy(),
 		Tasks:              c.Tasks.Copy(),
-		Services:           c.Services.Copy(),
+		DeprecatedServices: c.DeprecatedServices.Copy(),
 		TerraformProviders: c.TerraformProviders.Copy(),
 		BufferPeriod:       c.BufferPeriod.Copy(),
 		TLS:                c.TLS.Copy(),
@@ -163,8 +163,8 @@ func (c *Config) Merge(o *Config) *Config {
 		r.Tasks = r.Tasks.Merge(o.Tasks)
 	}
 
-	if o.Services != nil {
-		r.Services = r.Services.Merge(o.Services)
+	if o.DeprecatedServices != nil {
+		r.DeprecatedServices = r.DeprecatedServices.Merge(o.DeprecatedServices)
 	}
 
 	if o.TerraformProviders != nil {
@@ -236,14 +236,14 @@ func (c *Config) Finalize() {
 	}
 	c.Tasks.Finalize(c.BufferPeriod, *c.WorkingDir)
 
-	if c.Services == nil {
-		c.Services = DefaultServiceConfigs()
+	if c.DeprecatedServices == nil {
+		c.DeprecatedServices = DefaultServiceConfigs()
 	}
-	if len(*c.Services) > 0 {
+	if len(*c.DeprecatedServices) > 0 {
 		logger := logging.Global().Named(logSystemName).Named(taskSubsystemName)
 		logger.Warn(serviceBlockLogMsg)
 	}
-	c.Services.Finalize()
+	c.DeprecatedServices.Finalize()
 
 	if c.TerraformProviders == nil {
 		c.TerraformProviders = DefaultTerraformProviderConfigs()
@@ -270,7 +270,7 @@ func (c *Config) Validate() error {
 		return err
 	}
 
-	if err := c.Services.Validate(); err != nil {
+	if err := c.DeprecatedServices.Validate(); err != nil {
 		return err
 	}
 
@@ -344,7 +344,7 @@ func (c *Config) GoString() string {
 		"Vault:%s, "+
 		"Driver:%s, "+
 		"Tasks:%s, "+
-		"Services:%s, "+
+		"Services (deprecated):%s, "+
 		"TerraformProviders:%s, "+
 		"BufferPeriod:%s,"+
 		"TLS:%s"+
@@ -357,7 +357,7 @@ func (c *Config) GoString() string {
 		c.Vault.GoString(),
 		c.Driver.GoString(),
 		c.Tasks.GoString(),
-		c.Services.GoString(),
+		c.DeprecatedServices.GoString(),
 		c.TerraformProviders.GoString(),
 		c.BufferPeriod.GoString(),
 		c.TLS.GoString(),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,7 +83,7 @@ var (
 				},
 			},
 		},
-		Services: &ServiceConfigs{
+		DeprecatedServices: &ServiceConfigs{
 			{
 				Name:        String("serviceA"),
 				Description: String("descriptionA"),
@@ -336,15 +336,15 @@ func TestConfig_Finalize(t *testing.T) {
 	(*expected.Tasks)[0].BufferPeriod.Max = TimeDuration(60 * time.Second)
 	(*expected.Tasks)[0].Variables = map[string]string{}
 	(*expected.Tasks)[0].WorkingDir = String("working/task")
-	(*expected.Services)[0].ID = String("serviceA")
-	(*expected.Services)[0].Namespace = String("")
-	(*expected.Services)[0].Datacenter = String("")
-	(*expected.Services)[0].Filter = String("")
-	(*expected.Services)[0].CTSUserDefinedMeta = map[string]string{}
-	(*expected.Services)[1].ID = String("serviceB")
-	(*expected.Services)[1].Datacenter = String("")
-	(*expected.Services)[1].Filter = String("")
-	(*expected.Services)[1].CTSUserDefinedMeta = map[string]string{}
+	(*expected.DeprecatedServices)[0].ID = String("serviceA")
+	(*expected.DeprecatedServices)[0].Namespace = String("")
+	(*expected.DeprecatedServices)[0].Datacenter = String("")
+	(*expected.DeprecatedServices)[0].Filter = String("")
+	(*expected.DeprecatedServices)[0].CTSUserDefinedMeta = map[string]string{}
+	(*expected.DeprecatedServices)[1].ID = String("serviceB")
+	(*expected.DeprecatedServices)[1].Datacenter = String("")
+	(*expected.DeprecatedServices)[1].Filter = String("")
+	(*expected.DeprecatedServices)[1].CTSUserDefinedMeta = map[string]string{}
 
 	c := longConfig.Copy()
 	c.Finalize()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -229,10 +229,10 @@ func newDriverTask(conf *config.Config, taskConfig *config.TaskConfig,
 		return nil, nil
 	}
 
-	meta := conf.Services.CTSUserDefinedMeta(taskConfig.DeprecatedServices)
+	meta := conf.DeprecatedServices.CTSUserDefinedMeta(taskConfig.DeprecatedServices)
 	services := make([]driver.Service, len(taskConfig.DeprecatedServices))
 	for si, service := range taskConfig.DeprecatedServices {
-		services[si] = getService(conf.Services, service, meta)
+		services[si] = getService(conf.DeprecatedServices, service, meta)
 	}
 
 	providers := make(driver.TerraformProviderBlocks, len(taskConfig.Providers))

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -661,18 +661,6 @@ func singleTaskConfig() *config.Config {
 				Version:            config.String("v1"),
 			},
 		},
-		Services: &config.ServiceConfigs{
-			{
-				ID:          config.String("serviceA_id"),
-				Name:        config.String("serviceA"),
-				Description: config.String("descriptionA"),
-			}, {
-				ID:          config.String("serviceB_id"),
-				Name:        config.String("serviceB"),
-				Namespace:   config.String("teamB"),
-				Description: config.String("descriptionB"),
-			},
-		},
 		TerraformProviders: &config.TerraformProviderConfigs{{
 			"X": map[string]interface{}{},
 			handler.TerraformProviderFake: map[string]interface{}{


### PR DESCRIPTION
Mark service blocks config as deprecated to discourage further usage in code until removal. Also served as an easy way to audit usage of service block config field in tests.

 - Rename `Services` with `DeprecatedServices`
 - Remove unnecessary test references to `Services`