### PR TITLE
Fix issue in Get Task API for services field as condition 

### DIFF
--- a/api/representation.go
+++ b/api/representation.go
@@ -343,7 +343,8 @@ func oapigenTaskFromConfigTask(tc config.TaskConfig) oapigen.Task {
 	// `condition "services"` or `module_input "services"` is configured.
 	// Use-case: returning tasks with `services via Get Task API
 	if tc.DeprecatedServices != nil && len(tc.DeprecatedServices) > 0 {
-		if tc.Condition == nil {
+		_, noCondition := tc.Condition.(*config.NoConditionConfig)
+		if tc.Condition == nil || noCondition {
 			task.Condition.Services = &oapigen.ServicesCondition{
 				Names:            &tc.DeprecatedServices,
 				UseAsModuleInput: config.Bool(true),

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -375,8 +375,24 @@ func TestRequest_oapigenTaskFromConfigTask(t *testing.T) {
 			},
 		},
 		{
-			name: "services_field_to_condition",
+			name: "services_field_to_condition_nil",
 			taskConfig: config.TaskConfig{
+				Condition:          nil,
+				DeprecatedServices: []string{"api", "web"},
+			},
+			expected: oapigen.Task{
+				Condition: oapigen.Condition{
+					Services: &oapigen.ServicesCondition{
+						Names:            &[]string{"api", "web"},
+						UseAsModuleInput: config.Bool(true),
+					},
+				},
+			},
+		},
+		{
+			name: "services_field_to_condition_empty",
+			taskConfig: config.TaskConfig{
+				Condition:          config.EmptyConditionConfig(),
 				DeprecatedServices: []string{"api", "web"},
 			},
 			expected: oapigen.Task{

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -788,7 +788,6 @@ func TestE2E_TaskEndpoints_Get(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	// Parse response body
-	defer resp.Body.Close()
 	var r oapigen.TaskResponse
 	err := json.NewDecoder(resp.Body).Decode(&r)
 	require.NoError(t, err)


### PR DESCRIPTION
When starting up CTS with a task that has `services` field configured as the condition (i.e. no condition block is configured), then the services information should be returned in Get Task API as a `condition "services"` with the `names` field assigned to the services information.

Currently, Get Task API is returning this information in the `module_input` block instead of `condition`. 

Changes:
- Add tests to catch this (fails in circleci: [unit/integration](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/3341/workflows/4df7d191-cd9b-493f-b522-dee7e7bfa494/jobs/8922) and [e2e](https://app.circleci.com/pipelines/github/hashicorp/consul-terraform-sync/3341/workflows/4df7d191-cd9b-493f-b522-dee7e7bfa494/jobs/8921))
- Fix issue by catching nil condition's finalized value

Note: Get Task API was added within the same release