### PR TITLE
Handle when CatalogService condition NodeMeta is nil in representation

### DIFF
--- a/api/representation.go
+++ b/api/representation.go
@@ -143,15 +143,18 @@ func (tr TaskRequest) ToTaskConfig() (config.TaskConfig, error) {
 			UseAsModuleInput: tr.Task.Condition.ConsulKv.UseAsModuleInput,
 		}
 	} else if tr.Task.Condition.CatalogServices != nil {
-		tc.Condition = &config.CatalogServicesConditionConfig{
+		cond := &config.CatalogServicesConditionConfig{
 			CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{
 				Regexp:           config.String(tr.Task.Condition.CatalogServices.Regexp),
 				UseAsModuleInput: tr.Task.Condition.CatalogServices.UseAsModuleInput,
 				Datacenter:       tr.Task.Condition.CatalogServices.Datacenter,
 				Namespace:        tr.Task.Condition.CatalogServices.Namespace,
-				NodeMeta:         tr.Task.Condition.CatalogServices.NodeMeta.AdditionalProperties,
 			},
 		}
+		if tr.Task.Condition.CatalogServices.NodeMeta != nil {
+			cond.NodeMeta = tr.Task.Condition.CatalogServices.NodeMeta.AdditionalProperties
+		}
+		tc.Condition = cond
 	} else if tr.Task.Condition.Schedule != nil {
 		tc.Condition = &config.ScheduleConditionConfig{
 			Cron: &tr.Task.Condition.Schedule.Cron,

--- a/api/representation_test.go
+++ b/api/representation_test.go
@@ -442,7 +442,7 @@ func TestRequest_oapigenTaskFromConfigTask(t *testing.T) {
 	}
 }
 
-func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
+func TestTaskRequest_ToTaskConfig(t *testing.T) {
 	cases := []struct {
 		name               string
 		request            *TaskRequest
@@ -601,6 +601,29 @@ func TestTaskRequest_ToRequestTaskConfig(t *testing.T) {
 							"key1": "value1",
 							"key2": "value2",
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "with_catalog_services_condition_no_nodemeta",
+			request: &TaskRequest{
+				Task: oapigen.Task{
+					Name:   "task",
+					Module: "path",
+					Condition: oapigen.Condition{
+						CatalogServices: &oapigen.CatalogServicesCondition{
+							Regexp: ".*",
+						},
+					},
+				},
+			},
+			taskConfigExpected: config.TaskConfig{
+				Name:   config.String("task"),
+				Module: config.String("path"),
+				Condition: &config.CatalogServicesConditionConfig{
+					CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{
+						Regexp: config.String(".*"),
 					},
 				},
 			},


### PR DESCRIPTION
When a task is created through Create Task API with a catalog-service condition
and no node_meta configured, node_meta is nil and leads to a panic.

Ex create task api request
```
{
    "task": {
        "condition": {
            "catalog_services": {
                "regexp": "api"
            }
        },
        "name": "ls_api_cs_2",
        "module": "lornasong/cts_file/local",
        "version": "0.0.1"
    }
}
```

Changes:
- test-case for when node meta is nil (should fail)
- handle node meta nil

Note: API representation was added within this same release