### PR TITLE
Clarify that infrastructure is not destroyed on task deletion

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -229,6 +229,7 @@ func (m *meta) requestUserApprovalEnable(taskName string) (int, bool) {
 func (m *meta) requestUserApprovalDelete(taskName string) (int, bool) {
 	m.UI.Info(fmt.Sprintf("Do you want to delete '%s'?", taskName))
 	m.UI.Output(" - This action cannot be undone.")
+	m.UI.Output(" - Deleting a task will not destroy the infrastructure managed by the task.")
 	m.UI.Output(" - If the task is not running, it will be deleted immediately.")
 	m.UI.Output(" - If the task is running, it will be deleted once it has completed.")
 	return m.requestUserApproval(taskName, "deleting")

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -51,6 +51,7 @@ Example:
   $ consul-terraform-sync task delete my_task
   ==> Do you want to delete 'my_task'?
        - This action cannot be undone.
+       - Deleting a task will not destroy the infrastructure managed by the task.
        - If the task is not running, it will be deleted immediately.
        - If the task is running, it will be deleted once it has completed.
       Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.


### PR DESCRIPTION
Made it the second bullet point since I didn't want it overlooked!
```
 consul-terraform-sync task delete test-task
==> Do you want to delete 'test-task'?
     - This action cannot be undone.
     - Deleting a task will not destroy the infrastructure managed by the task.
     - If the task is not running, it will be deleted immediately.
     - If the task is running, it will be deleted once it has completed.
    Only 'yes' will be accepted to approve, enter 'no' or leave blank to reject.

Enter a value: yes

==> Marking task 'test-task' for deletion...

==> Task 'test-task' has been marked for deletion and will be deleted when not running.
```