### PR TITLE
Use custom dependency for validating template

### DIFF
--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -602,7 +602,7 @@ func validateTemplate(t *hcat.Template, clients hcat.Looker) error {
 	}
 	t.Execute(recaller)
 	// Mark that template needs to be re-run
-	t.Notify(nil)
+	t.Notify(notifier.NewValidationDep(t.ID()))
 	return err
 }
 

--- a/templates/tftmpl/notifier/notifier.go
+++ b/templates/tftmpl/notifier/notifier.go
@@ -2,10 +2,21 @@ package notifier
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/hcat/dep"
 )
+
+// ValidationDep is a dependency used to indicate that Notify was called
+// as part of validating the template.
+type ValidationDep string
+
+// NewValidationDep creates a new ValidationDep where the value is the ID
+// of the template passed to it and the current time.
+func NewValidationDep(id string) ValidationDep {
+	return ValidationDep(fmt.Sprintf("%s-%s", id, time.Now().String()))
+}
 
 // logDependency logs details about the dependencies that the notifiers
 // receive
@@ -36,6 +47,10 @@ func logDependency(logger logging.Logger, dependency interface{}) {
 		}
 		logger.Debug("received dependency",
 			"variable", "consul_kv", "recurse", true, "keys", keys)
+
+	case ValidationDep:
+		logger.Debug("received dependency for validating template")
+
 	default:
 		logger.Debug("received unknown dependency",
 			"variable", fmt.Sprintf("%T", dependency))


### PR DESCRIPTION
Using nil was having unintended consequences in the cases using
catalog-service condition when there are no services to start with.