### PR TITLE
Remove unnecessary template.Notify() calls in overrider

### DIFF
--- a/templates/tftmpl/notifier/catalog_services_registration.go
+++ b/templates/tftmpl/notifier/catalog_services_registration.go
@@ -39,6 +39,7 @@ func (n *CatalogServicesRegistration) Override() {
 	defer n.mu.Unlock()
 	if !n.once {
 		n.once = true
+		// prevents hanging
 		n.Template.Notify(nil)
 	}
 }

--- a/templates/tftmpl/notifier/consul_kv.go
+++ b/templates/tftmpl/notifier/consul_kv.go
@@ -31,7 +31,6 @@ func (n *ConsulKV) Override() {
 
 	if !n.once {
 		n.once = true
-		n.Template.Notify(nil)
 	}
 }
 

--- a/templates/tftmpl/notifier/notifier.go
+++ b/templates/tftmpl/notifier/notifier.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Overrider is short-term solution to override the notifier's once value and
-// send a notification if once is not complete (i.e. true)
+// send a notification (depending on the condition) if once is not complete
+// (i.e. true)
 //
 // This handles an edge-case with the Create Task API where pre-existing
 // dependencies don't cause Notify() for newly created tasks which causes

--- a/templates/tftmpl/notifier/services.go
+++ b/templates/tftmpl/notifier/services.go
@@ -34,7 +34,6 @@ func (n *Services) Override() {
 
 	if !n.once {
 		n.once = true
-		n.Template.Notify(nil)
 	}
 }
 

--- a/templates/tftmpl/notifier/suppress_notification.go
+++ b/templates/tftmpl/notifier/suppress_notification.go
@@ -39,7 +39,6 @@ func (n *SuppressNotification) Override() {
 
 	if !n.once {
 		n.once = true
-		n.Template.Notify(nil)
 	}
 }
 


### PR DESCRIPTION
This is only needed by catalog-service to get out of hanging. Other conditions
don't need this call.

It also causes schedule condition to unnecessarily called
terraform-apply on the first scheduled run after a new task is created
(via API/CLI) because the task thinks there are changes.

Related to #704 