### PR TITLE
Update bulk services function to skip health check

### DIFF
--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -128,7 +128,7 @@ func serviceRegistered(tb testing.TB, srv *testutil.TestServer, serviceID string
 // Bulk add test data for seeding consul
 func AddServices(t testing.TB, srv *testutil.TestServer, svcs []testutil.TestService) {
 	for _, s := range svcs {
-		RegisterConsulServiceHealth(t, srv, s, 0, testutil.HealthPassing)
+		RegisterConsulService(t, srv, s, 0)
 	}
 }
 


### PR DESCRIPTION
Adding a health check after the service is registered triggers an
additional event in tests, which causes intermittent failures.

I found this is the cause for some of our flaking tests where the event count is greater than the expected count. From what I could tell, no test using this method relies on the assumption that a health check is created.