### PR TITLE
Update general API request received/completed logs from INFO to DEBUG

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -33,8 +33,8 @@ func withLogging(next http.Handler) http.Handler {
 		logger = logger.With("request_id", reqID)
 		ts := time.Now()
 
-		// Log info before calling the next handler
-		logger.Info("received request",
+		// Log request info before calling the next handler
+		logger.Debug("received request",
 			"time", ts.Format(timeFormat),
 			"remote_ip", r.RemoteAddr,
 			"uri", r.RequestURI,
@@ -51,8 +51,8 @@ func withLogging(next http.Handler) http.Handler {
 
 		next.ServeHTTP(rw, r)
 
-		// Log info on exit
-		logger.Info("request complete",
+		// Log request info on exit
+		logger.Debug("request complete",
 			"duration", fmt.Sprintf("%dus", time.Since(ts).Microseconds()),
 			"status_code", rw.statusCode)
 	})


### PR DESCRIPTION
These are logged for every API request and can clutter the logs

Use-case: currently Status API is used in Consul health checks, which can cause this message to log every 10s (or other configured interval)