### PR TITLE
Wait for task to be inactive before running

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -534,6 +534,7 @@ func (rw *ReadWrite) waitForTaskInactive(ctx context.Context, name string) error
 			if !rw.drivers.IsActive(name) {
 				return nil
 			}
+			time.Sleep(100 * time.Microsecond)
 		}
 	}
 }

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -146,13 +146,10 @@ func (rw *ReadWrite) runDynamicTask(ctx context.Context, d driver.Driver) error 
 		return nil
 	}
 
-	if rw.drivers.IsActive(taskName) {
-		// The driver is currently active with the task, initiated by an ad-hoc run.
-		// There may be updates for other tasks, so we'll continue checking
-		rw.logger.Trace("task is active", taskNameLogKey, taskName)
-		return nil
+	err := rw.waitForTaskInactive(ctx, taskName)
+	if err != nil {
+		return err
 	}
-
 	complete, err := rw.checkApply(ctx, d, true, false)
 	if err != nil {
 		return err
@@ -461,6 +458,11 @@ func (rw *ReadWrite) runTask(ctx context.Context, d driver.Driver) error {
 		return nil
 	}
 
+	err := rw.waitForTaskInactive(ctx, taskName)
+	if err != nil {
+		return err
+	}
+
 	rw.drivers.SetActive(taskName)
 	defer rw.drivers.SetInactive(taskName)
 
@@ -502,20 +504,12 @@ func (rw *ReadWrite) runTask(ctx context.Context, d driver.Driver) error {
 // If a task is active and running, it will wait until the task has completed before
 // proceeding with the deletion.
 func (rw *ReadWrite) deleteTask(ctx context.Context, name string) error {
-WAIT:
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			// wait for task to not be running
-			if !rw.drivers.IsActive(name) {
-				break WAIT
-			}
-		}
+	err := rw.waitForTaskInactive(ctx, name)
+	if err != nil {
+		return err
 	}
 
-	err := rw.drivers.Delete(name)
+	err = rw.drivers.Delete(name)
 	if err != nil {
 		rw.logger.Error("unable to delete task", taskNameLogKey, name, "error", err)
 		return err
@@ -523,6 +517,25 @@ WAIT:
 	rw.store.Delete(name)
 	rw.logger.Debug("task deleted", taskNameLogKey, name)
 	return nil
+}
+
+func (rw *ReadWrite) waitForTaskInactive(ctx context.Context, name string) error {
+	// Check first if inactive, return early and don't log
+	if !rw.drivers.IsActive(name) {
+		return nil
+	}
+	// Check continuously in a loop until inactive
+	rw.logger.Debug("waiting for task to become inactive", taskNameLogKey, name)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			if !rw.drivers.IsActive(name) {
+				return nil
+			}
+		}
+	}
 }
 
 // EnableTestMode is a helper for testing which tasks were triggered and

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -502,6 +502,87 @@ func TestE2E_ConfigStreamlining_Deprecations(t *testing.T) {
 	validateServices(t, true, []string{"api"}, resourcesPath)
 }
 
+// TestE2E_TriggerTaskWhenActive tests making changes to monitored dependencies
+// while a task is running. It verifies:
+//
+// 1. a change to the same task will trigger the task after the run completes
+// 2. a change to a different task runs immediately
+// 3. a change after the task completes will still trigger the task to run
+//
+// https://github.com/hashicorp/consul-terraform-sync/issues/732
+func TestE2E_TriggerTaskWhenActive(t *testing.T) {
+	// Start CTS with multiple tasks
+	activeTaskName := "active_task"
+	activeTaskConfig := fmt.Sprintf(`
+	task {
+		name = "%s"
+		providers = ["local"]
+		module = "./test_modules/delayed_module"
+		condition "services" {
+			names = ["api"]
+		}
+	}
+	`, activeTaskName)
+
+	inactiveTaskName := "inactive_task"
+	inactiveTaskConfig := fmt.Sprintf(`
+	task {
+		name = "%s"
+		providers = ["local"]
+		module = "./test_modules/local_instances_file"
+		condition "services" {
+			names = ["web"]
+		}
+	}
+	`, inactiveTaskName)
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "trigger_when_active")
+	cts := ctsSetup(t, srv, tempDir, activeTaskConfig, inactiveTaskConfig)
+
+	// Trigger the task with the long-running module so that it becomes active
+	firstRegister := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-1"}, defaultWaitForRegistration)
+
+	// Trigger the task again while still running
+	time.Sleep(1 * time.Second) // waiting for task to start, module sleeps for 5 seconds
+	activeRegister := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-2"}, defaultWaitForRegistration)
+
+	// Trigger the other task while the other task is running
+	inactiveRegister := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "web", ID: "web-1"}, defaultWaitForRegistration)
+
+	// Other task should complete without waiting for first task to complete
+	api.WaitForEvent(t, cts, inactiveTaskName, inactiveRegister, defaultWaitForEvent)
+	count := eventCount(t, inactiveTaskName, cts.Port())
+	assert.Equal(t, 2, count, "unexpected number of events")
+
+	// First run of task should eventually complete
+	api.WaitForEvent(t, cts, activeTaskName, firstRegister, defaultWaitForEvent)
+	count = eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 2, count, "unexpected number of events")
+
+	// Second run of task should occur after first one completes
+	api.WaitForEvent(t, cts, activeTaskName, activeRegister, defaultWaitForEvent)
+	count = eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 3, count, "unexpected number of events")
+
+	// Trigger first task again, check for event
+	now := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-3"}, defaultWaitForRegistration)
+	api.WaitForEvent(t, cts, activeTaskName, now, defaultWaitForEvent)
+	count = eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 4, count, "unexpected number of events")
+}
+
 // testInvalidTaskConfig tests that task creation fails with the given task configuration.
 // Creation is tested both at CTS startup and with the CLI create command.
 func testInvalidTaskConfig(t *testing.T, testName, taskName, taskConfig, errMsg string) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -511,6 +511,7 @@ func TestE2E_ConfigStreamlining_Deprecations(t *testing.T) {
 //
 // https://github.com/hashicorp/consul-terraform-sync/issues/732
 func TestE2E_TriggerTaskWhenActive(t *testing.T) {
+	setParallelism(t)
 	// Start CTS with multiple tasks
 	activeTaskName := "active_task"
 	activeTaskConfig := fmt.Sprintf(`
@@ -587,6 +588,76 @@ func TestE2E_TriggerTaskWhenActive(t *testing.T) {
 	count = eventCount(t, activeTaskName, cts.Port())
 	assert.Equal(t, 4, count, "unexpected number of events")
 	validateServices(t, true, []string{"api-1", "api-2", "api-3"}, resourcesPath)
+}
+
+// TestE2E_TriggerTaskWhenActiveMultipleTimes tests that after triggering
+// an active task multiple times, the next run will render with the latest
+// information from Consul. It also checks that there will only be one event
+// even though there were multiple changes, as the template has already
+// rendered with the latest information so there are no subsequent changes.
+//
+// Note: This does not use buffer period.
+//
+// https://github.com/hashicorp/consul-terraform-sync/issues/732
+func TestE2E_TriggerTaskWhenActiveMultipleTimes(t *testing.T) {
+	setParallelism(t)
+
+	activeTaskName := "active_task"
+	activeTaskConfig := fmt.Sprintf(`
+	task {
+		name = "%s"
+		providers = ["local"]
+		module = "./test_modules/delayed_module"
+		condition "services" {
+			names = ["api"]
+		}
+	}
+	`, activeTaskName)
+
+	srv := testutils.NewTestConsulServer(t, testutils.TestConsulServerConfig{
+		HTTPSRelPath: "../testutils",
+	})
+	defer srv.Stop()
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "trigger_when_active_multiple")
+	cts := ctsSetup(t, srv, tempDir, activeTaskConfig)
+
+	// Trigger the task with the long-running module so that it becomes active
+	firstRegister := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-1"}, defaultWaitForRegistration)
+
+	// Register a new instance while the task is still running
+	time.Sleep(1 * time.Second) // waiting for task to start, module sleeps for 5 seconds
+	activeRegister := time.Now()
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-2"}, defaultWaitForRegistration)
+
+	// Deregister the newly added instance
+	testutils.DeregisterConsulService(t, srv, "api-2")
+
+	// Register a different instance
+	testutils.RegisterConsulService(t, srv,
+		testutil.TestService{Name: "api", ID: "api-3"}, defaultWaitForRegistration)
+
+	// First run of task should eventually complete
+	api.WaitForEvent(t, cts, activeTaskName, firstRegister, defaultWaitForEvent)
+	count := eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 2, count, "unexpected number of events")
+	resourcesPath := filepath.Join(tempDir, activeTaskName, resourcesDir)
+	validateServices(t, true, []string{"api-1"}, resourcesPath)
+	validateServices(t, false, []string{"api-2", "api-3"}, resourcesPath)
+
+	// Second run of task completes with latest services info
+	api.WaitForEvent(t, cts, activeTaskName, activeRegister, defaultWaitForEvent)
+	count = eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 3, count, "unexpected number of events")
+	validateServices(t, true, []string{"api-1", "api-3"}, resourcesPath)
+	validateServices(t, false, []string{"api-2"}, resourcesPath)
+
+	// Subsequent triggers should not create an event
+	time.Sleep(defaultWaitForNoEvent + (5 * time.Second)) // accounting for 5s delay in module
+	count = eventCount(t, activeTaskName, cts.Port())
+	assert.Equal(t, 3, count, "unexpected number of events")
 }
 
 // testInvalidTaskConfig tests that task creation fails with the given task configuration.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -563,16 +563,21 @@ func TestE2E_TriggerTaskWhenActive(t *testing.T) {
 	api.WaitForEvent(t, cts, inactiveTaskName, inactiveRegister, defaultWaitForEvent)
 	count := eventCount(t, inactiveTaskName, cts.Port())
 	assert.Equal(t, 2, count, "unexpected number of events")
+	inactivePath := filepath.Join(tempDir, inactiveTaskName, resourcesDir)
+	validateServices(t, true, []string{"web-1"}, inactivePath)
 
 	// First run of task should eventually complete
 	api.WaitForEvent(t, cts, activeTaskName, firstRegister, defaultWaitForEvent)
 	count = eventCount(t, activeTaskName, cts.Port())
 	assert.Equal(t, 2, count, "unexpected number of events")
+	resourcesPath := filepath.Join(tempDir, activeTaskName, resourcesDir)
+	validateServices(t, true, []string{"api-1"}, resourcesPath)
 
 	// Second run of task should occur after first one completes
 	api.WaitForEvent(t, cts, activeTaskName, activeRegister, defaultWaitForEvent)
 	count = eventCount(t, activeTaskName, cts.Port())
 	assert.Equal(t, 3, count, "unexpected number of events")
+	validateServices(t, true, []string{"api-1", "api-2"}, resourcesPath)
 
 	// Trigger first task again, check for event
 	now := time.Now()
@@ -581,6 +586,7 @@ func TestE2E_TriggerTaskWhenActive(t *testing.T) {
 	api.WaitForEvent(t, cts, activeTaskName, now, defaultWaitForEvent)
 	count = eventCount(t, activeTaskName, cts.Port())
 	assert.Equal(t, 4, count, "unexpected number of events")
+	validateServices(t, true, []string{"api-1", "api-2", "api-3"}, resourcesPath)
 }
 
 // testInvalidTaskConfig tests that task creation fails with the given task configuration.


### PR DESCRIPTION
Fixes issue where a task triggering change that occurs while the task is currently running is ignored (https://github.com/hashicorp/consul-terraform-sync/issues/732). 

Prior to reverting a hcat change (https://github.com/hashicorp/consul-terraform-sync/pull/740), when using the TFC driver, this ignored run led to a bad state where the task will never be triggered by dependency changes.

**Background**
Previously (as in 0.4.3 and earlier), when any change was detected, we would try to [run all dynamic tasks](https://github.com/hashicorp/consul-terraform-sync/blob/v0.4.3/controller/readwrite.go#L79-L93) and [wait for them to complete](https://github.com/hashicorp/consul-terraform-sync/blob/v0.4.3/controller/readwrite.go#L134). If a change happened while a task was running, it would be executed after the current run had completed.

This also meant that if task_a was running, and a Consul change for task_b was made, task_b would not run until task_a was completed.

Now in 0.5.0, the watcher returns specifically what template needs updating, so we [only run the task that is monitoring the dependency change](https://github.com/hashicorp/consul-terraform-sync/blob/1ae6360e754c8dd3bb420bc9b7848e060ae236f8/controller/readwrite.go#L108-L115). We also run it as a goroutine, so there's no more waiting for the task to complete.

This has the advantage where task_b can still be triggered immediately even if task_a is currently running.

**Issue**
Because we're no longer waiting, we start a process to run the task even though it's currently running. The `runDynamicTask()` method checks that the task is active and returns without running, which is why the change is ignored completely. That `IsActive()` check was supposed to ignore runs triggered by the enable API when the task was already in progress.

**Solution**
If a task is active and currently running, wait for the task to complete and start a new run when the task becomes inactive. 

One caveat is that if a task has multiple changes while it's running, we would potentially run multiple times, even though it's not technically necessary. We still wouldn't run Terraform apply multiple times, though, because the template rendering should detect that there are no changes. This behavior is the same as we made the watcher changes, so it didn't seem necessary to optimize this now.

Fixes https://github.com/hashicorp/consul-terraform-sync/issues/732