### PR TITLE
Create instance files only after initial delay

### DIFF
--- a/e2e/test_modules/delayed_module/main.tf
+++ b/e2e/test_modules/delayed_module/main.tf
@@ -1,7 +1,8 @@
 resource "local_file" "address" {
-  for_each = var.services
-  content  = each.value.address
-  filename = "resources/${each.value.id}.txt"
+  depends_on = [local_file.greeting_services]
+  for_each   = var.services
+  content    = each.value.address
+  filename   = "resources/${each.value.id}.txt"
 }
 
 resource "local_file" "greeting_services" {


### PR DESCRIPTION
The files were being created at the same time as the resource with
the sleep, so the test was detecting a file that it didn't expect
until the event was completed.


Retried it three times in CircleCI and so far no failures!