### PR TITLE
Handle missing tf state

### DIFF
--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -157,6 +157,62 @@ func TestTerraformCLIInit(t *testing.T) {
 	}
 }
 
+func TestTerraformCLIInit_HandleWorkspaceError(t *testing.T) {
+
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		initErr error
+	}{
+		{
+			"workspace failed to select",
+			errors.New(`Initializing the backend...
+
+The currently selected workspace (test-workspace) does not exist.
+This is expected behavior when the selected workspace did not have an
+existing non-empty state. Please enter a number to select a workspace:
+
+1. default
+ 
+Enter a value:
+
+Error: Failed to select workspace: input not a valid number`),
+		},
+		{
+			"workspace does not exist",
+			errors.New(`exit status 1
+
+Error: Currently selected workspace "some-task" does not exist
+
+
+`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(mocks.TerraformExec)
+			var initCount int
+			m.On("Init", mock.Anything).Return(func(context.Context, ...tfexec.InitOption) error {
+				initCount++
+				if initCount == 1 {
+					return tc.initErr
+				}
+				return nil
+			}).Twice()
+			m.On("WorkspaceNew", mock.Anything, mock.Anything).Return(nil)
+			m.On("WorkspaceSelect", mock.Anything, mock.Anything).Return(nil)
+
+			client := NewTestTerraformCLI(&TerraformCLIConfig{}, m)
+			ctx := context.Background()
+			err := client.Init(ctx)
+			assert.NoError(t, err)
+			m.AssertExpectations(t)
+		})
+	}
+}
+
 func TestTerraformCLIApply(t *testing.T) {
 	t.Parallel()
 

--- a/client/terraform_cli_test.go
+++ b/client/terraform_cli_test.go
@@ -155,39 +155,6 @@ func TestTerraformCLIInit(t *testing.T) {
 			m.AssertExpectations(t)
 		})
 	}
-
-	t.Run("workspace artifact with empty state", func(t *testing.T) {
-		// Edge case to handle https://github.com/hashicorp/terraform/issues/21393
-		initErr := errors.New(`Initializing the backend...
-
-The currently selected workspace (test-workspace) does not exist.
-This is expected behavior when the selected workspace did not have an
-existing non-empty state. Please enter a number to select a workspace:
-
-1. default
-
-Enter a value:
-
-Error: Failed to select workspace: input not a valid number`)
-
-		m := new(mocks.TerraformExec)
-		var initCount int
-		m.On("Init", mock.Anything).Return(func(context.Context, ...tfexec.InitOption) error {
-			initCount++
-			if initCount == 1 {
-				return initErr
-			}
-			return nil
-		}).Twice()
-		m.On("WorkspaceNew", mock.Anything, mock.Anything).Return(nil)
-		m.On("WorkspaceSelect", mock.Anything, mock.Anything).Return(nil)
-
-		client := NewTestTerraformCLI(&TerraformCLIConfig{}, m)
-		ctx := context.Background()
-		err := client.Init(ctx)
-		assert.NoError(t, err)
-		m.AssertExpectations(t)
-	})
 }
 
 func TestTerraformCLIApply(t *testing.T) {


### PR DESCRIPTION
This PR acts to resolve #701 

CTS handles workspaces with non existing states by checking the [error type returned by Terraform CLI](https://github.com/hashicorp/consul-terraform-sync/blob/2efab4125b2fdcad618118c76c801126e2b4444b/client/terraform_cli.go#L115) . It uses a [regex string](https://github.com/hashicorp/consul-terraform-sync/blob/2efab4125b2fdcad618118c76c801126e2b4444b/client/terraform_cli.go#L20) to match on the error, and if it matches, it then recreates the workspace.

With newer versions of Terraform, the error returned has changed so the error string was no longer matching. Adding the new error string, alongside the old one as to not break compatibility, fixes the issue.

In the future, it would be better if instead the terraform error used the tfexec.ErrNoWorkspace error wrapping, this would make the check less reliant on a string match should the error string change in the future.