### PR TITLE
Wait longer for API to start

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -266,7 +266,7 @@ func TestServeWithTLS(t *testing.T) {
 			})
 			require.NoError(t, err)
 			go api.Serve(ctx)
-			time.Sleep(time.Microsecond)
+			time.Sleep(500 * time.Millisecond)
 
 			// Set up a client with the CA for the test case
 			tlsConf := &tls.Config{}
@@ -363,7 +363,7 @@ func TestServeWithMutualTLS(t *testing.T) {
 	})
 	require.NoError(t, err)
 	go api.Serve(ctx)
-	time.Sleep(time.Microsecond)
+	time.Sleep(500 * time.Millisecond)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -493,7 +493,7 @@ func TestServeWithMutualTLS_MultipleCA(t *testing.T) {
 	})
 	require.NoError(t, err)
 	go api.Serve(ctx)
-	time.Sleep(time.Microsecond)
+	time.Sleep(500 * time.Millisecond)
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The TLS tests are occasionally failing because the API has not fully
started. Adjusting the wait time to match what we use for TestServe.

A better fix would be to implement polling that ignores non-connection issues, but I wanted a quicker fix for these tests that have been flaking. Ran 3 times in CircleCI without a failure, though these tests didn't fail super often in the first place. Just enough where I noted the pattern.