### PR TITLE
Stop scheduled task as soon as task is deleted

### DIFF
--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -51,6 +51,8 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 		baseController:  baseCtrl,
 		store:           event.NewStore(),
 		retry:           retry.NewRetry(defaultRetry, time.Now().UnixNano()),
+		scheduleStartCh: make(chan driver.Driver, 10), // arbitrarily chosen size
+		deleteCh:        make(chan string, 10),        // arbitrarily chosen size
 		scheduleStopChs: make(map[string](chan struct{})),
 	}, nil
 }

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -750,6 +750,7 @@ func TestReadWrite_Run_ScheduledTasks(t *testing.T) {
 			},
 			watcherCh:       make(chan string, 5),
 			store:           event.NewStore(),
+			scheduleStartCh: make(chan driver.Driver, 1),
 			scheduleStopChs: make(map[string](chan struct{})),
 		}
 		ctrl.EnableTestMode()

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -501,6 +501,7 @@ func TestReadWrite_runScheduledTask(t *testing.T) {
 		ctx := context.Background()
 		errCh := make(chan error)
 		stopCh := make(chan struct{}, 1)
+		ctrl.scheduleStopChs[taskName] = stopCh
 		done := make(chan bool)
 		go func() {
 			err := ctrl.runScheduledTask(ctx, d, stopCh)
@@ -516,6 +517,8 @@ func TestReadWrite_runScheduledTask(t *testing.T) {
 		case <-done:
 			// runScheduledTask exited as expected
 			d.AssertExpectations(t)
+			_, ok := ctrl.scheduleStopChs[taskName]
+			assert.False(t, ok, "expected scheduled task stop channel to be removed")
 		case <-time.After(time.Second * 5):
 			t.Fatal("runScheduledTask did not exit as expected")
 		}
@@ -707,6 +710,7 @@ func TestReadWrite_deleteTask(t *testing.T) {
 			func(d *driver.Drivers) {
 				mockD.On("TemplateIDs").Return(nil)
 				d.Add("success", mockD)
+				mockD.On("Task").Return(enabledTestTask(t, "success"))
 				mockD.On("DestroyTask", ctx).Return()
 			},
 		},
@@ -739,12 +743,44 @@ func TestReadWrite_deleteTask(t *testing.T) {
 		})
 	}
 
+	t.Run("scheduled_task", func(t *testing.T) {
+		// Tests that deleting a scheduled task sends a stop notification
+
+		// Setup controller and drivers
+		taskName := "scheduled_task"
+		scheduledDriver := new(mocksD.Driver)
+		scheduledDriver.On("Task").Return(scheduledTestTask(t, taskName))
+		scheduledDriver.On("DestroyTask", ctx).Return()
+		scheduledDriver.On("TemplateIDs").Return(nil)
+		ctrl := newTestController()
+		ctrl.drivers.Add(taskName, scheduledDriver)
+		stopCh := make(chan struct{}, 1)
+		ctrl.scheduleStopChs[taskName] = stopCh
+
+		// Delete task
+		err := ctrl.deleteTask(ctx, taskName)
+		assert.NoError(t, err)
+
+		// Verify the stop channel received message
+		select {
+		case <-time.After(1 * time.Second):
+			t.Fatal("scheduled task was not notified to stop")
+		case <-stopCh:
+			break // expected case
+		}
+		_, ok := ctrl.scheduleStopChs[taskName]
+		assert.False(t, ok, "scheduled task stop channel still in map")
+	})
+
 	t.Run("active_task", func(t *testing.T) {
 		// Set up drivers with active task
 		drivers := driver.NewDrivers()
 		taskName := "active_task"
-		mockD.On("TemplateIDs").Return(nil)
-		drivers.Add(taskName, mockD)
+		activeDriver := new(mocksD.Driver)
+		activeDriver.On("Task").Return(enabledTestTask(t, taskName))
+		activeDriver.On("DestroyTask", ctx).Return()
+		activeDriver.On("TemplateIDs").Return(nil)
+		drivers.Add(taskName, activeDriver)
 		drivers.SetActive(taskName)
 
 		// Set up controller with drivers and store
@@ -928,6 +964,7 @@ func newTestController() ReadWrite {
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
 		},
-		store: event.NewStore(),
+		store:           event.NewStore(),
+		scheduleStopChs: make(map[string](chan struct{})),
 	}
 }

--- a/controller/server.go
+++ b/controller/server.go
@@ -58,7 +58,7 @@ func (rw *ReadWrite) TaskCreate(ctx context.Context, taskConfig config.TaskConfi
 	}
 
 	if d.Task().IsScheduled() {
-		rw.scheduleCh <- d
+		rw.scheduleStartCh <- d
 	}
 
 	return conf, nil
@@ -90,7 +90,7 @@ func (rw *ReadWrite) TaskCreateAndRun(ctx context.Context, taskConfig config.Tas
 	}
 
 	if d.Task().IsScheduled() {
-		rw.scheduleCh <- d
+		rw.scheduleStartCh <- d
 	}
 
 	return conf, nil


### PR DESCRIPTION
Changed scheduled task deletion flow to stop the scheduled task immediately. This was accomplished by adding a stop channel for each scheduled task.

Previously, we stopped the scheduled task at the next scheduled run of the task. However, if a task with the same name was created between the deletion and the next scheduled run, the scheduled task would continue running. This was because the method checked if the tasks exists by name and continued running because a task with the same name did exist, even though it was not the original task.

Logs with new workflow:
```
2022-03-03T16:50:11.845-0600 [INFO]  ctrl: scheduled task next run time: task_name=scheduled-task wait_time=1m48.154932s next_runtime="2022-03-03 16:52:00 -0600 CST"
2022-03-03T16:50:11.863-0600 [INFO]  api: starting server: port=8558
2022-03-03T16:50:14.408-0600 [DEBUG] api: received request: request_id=942fc99b-228a-bc83-6719-c7911fd6ed6c time=2022-03-03T16:50:14.408-0600 remote_ip=[::1]:63392 uri=/v1/tasks/scheduled-task method=DELETE host=localhost:8558
2022-03-03T16:50:14.408-0600 [TRACE] api.deletetask: delete task request: request_id=942fc99b-228a-bc83-6719-c7911fd6ed6c task_name=scheduled-task
2022-03-03T16:50:14.408-0600 [DEBUG] ctrl: task marked for deletion: task_name=scheduled-task
2022-03-03T16:50:14.408-0600 [DEBUG] ctrl: task deleted: task_name=scheduled-task
2022-03-03T16:50:14.408-0600 [INFO]  ctrl: stopping deleted scheduled task: task_name=scheduled-task
```
Task with same name was created after deletion, no task ran at `"2022-03-03 16:52:00 -0600 CST"`
```
2022-03-03T16:51:30.003-0600 [INFO]  ctrl: scheduled task next run time: task_name=scheduled-task wait_time=59.996161s next_runtime="2022-03-03 16:52:30 -0600 CST"
2022-03-03T16:52:29.951-0600 [INFO]  ctrl: time for scheduled task: task_name=scheduled-task
```

Purposefully did not add an e2e test for this case and tested manually e2e instead. This was mostly because there's a bit of overhead for an e2e scheduled task test, and I was able to add a lot of unit/integration tests for this flow. Namely:

1. The Run method creates a stop channel for each scheduled task and maps it to the task name
2. Sending a signal to the stop channel stops the method
3. Deleting a task sends a signal to the proper stop channel

Fixes https://github.com/hashicorp/consul-terraform-sync/issues/715