### PR TITLE
[RelAPI Onboarding] Add release API metadata file

### DIFF
--- a/.release/release-metadata.hcl
+++ b/.release/release-metadata.hcl
@@ -1,0 +1,5 @@
+url_docker_registry_dockerhub = "https://hub.docker.com/r/hashicorp/consul-terraform-sync"
+url_license = "https://github.com/hashicorp/consul-terraform-sync/blob/main/LICENSE"
+url_project_website = "https://www.consul.io/docs/nia"
+url_release_notes = "https://www.consul.io/docs/nia/release-notes"
+url_source_repository = "https://github.com/hashicorp/consul-terraform-sync"


### PR DESCRIPTION
👋  This PR adds a `.release/release-metadata.hcl` file to the repo. This contains static metadata that will be processed and sent as part of the payload in RelAPI POST requests, which will be sent when staging and production releases are triggered.  

This can be merged the week of March 28th, but will not have any effect until after the RelAPI launch. We'll also want to add any backport labels to add this change to active release branches. Similar additions are being added across all projects that publish to releases.hashicorp.com.

Also note that the release notes link (https://www.consul.io/docs/nia/release-notes) is throwing a 404 right now because there's no index page. I'm opening a PR in the consul website repo to update this. 