### PR TITLE
Add Terraform Cloud workspace configuration to tasks

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -328,6 +328,7 @@ func TestConfig_Finalize(t *testing.T) {
 	backend["key_file"] = "key"
 	(*expected.Tasks)[0].Enabled = Bool(true)
 	(*expected.Tasks)[0].TFVersion = String("")
+	(*expected.Tasks)[0].TFCWorkspace = DefaultTerraformCloudWorkspaceConfig()
 	(*expected.Tasks)[0].VarFiles = []string{}
 	(*expected.Tasks)[0].Version = String("")
 	(*expected.Tasks)[0].BufferPeriod = &BufferPeriodConfig{}

--- a/config/terraform_cloud_workspace.go
+++ b/config/terraform_cloud_workspace.go
@@ -26,7 +26,11 @@ func DefaultTerraformCloudWorkspaceConfig() *TerraformCloudWorkspaceConfig {
 
 func (c *TerraformCloudWorkspaceConfig) isEmpty() bool {
 	return (*c == TerraformCloudWorkspaceConfig{}) ||
-		(reflect.DeepEqual(*c, *DefaultTerraformCloudWorkspaceConfig()))
+		(reflect.DeepEqual(c, &TerraformCloudWorkspaceConfig{
+			ExecutionMode: String(""),
+			AgentPoolID:   String(""),
+			AgentPoolName: String(""),
+		}))
 }
 
 // Copy returns a deep copy of this configuration.

--- a/config/terraform_cloud_workspace.go
+++ b/config/terraform_cloud_workspace.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/consul-terraform-sync/logging"
+)
+
+// TerraformCloudWorkspaceConfig is an enterprise-only configuration that controls
+// workspace attributes that are specific to a task.
+type TerraformCloudWorkspaceConfig struct {
+	ExecutionMode *string `mapstructure:"execution_mode"`
+	AgentPoolID   *string `mapstructure:"agent_pool_id"`
+	AgentPoolName *string `mapstructure:"agent_pool_name"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *TerraformCloudWorkspaceConfig) Copy() *TerraformCloudWorkspaceConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o TerraformCloudWorkspaceConfig
+	o.ExecutionMode = c.ExecutionMode
+	o.AgentPoolID = c.AgentPoolID
+	o.AgentPoolName = c.AgentPoolName
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+func (c *TerraformCloudWorkspaceConfig) Merge(o *TerraformCloudWorkspaceConfig) *TerraformCloudWorkspaceConfig {
+	if c == nil {
+		if o == nil {
+			return o
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.ExecutionMode != nil {
+		r.ExecutionMode = StringCopy(o.ExecutionMode)
+	}
+
+	if o.AgentPoolID != nil {
+		r.AgentPoolID = StringCopy(o.AgentPoolID)
+	}
+
+	if o.AgentPoolName != nil {
+		r.AgentPoolName = StringCopy(o.AgentPoolName)
+	}
+
+	return r
+}
+
+// Finalize ensures that the receiver contains no nil pointers.
+func (c *TerraformCloudWorkspaceConfig) Finalize() {
+	if c == nil { // config is not required, return early
+		return
+	}
+
+	if c.ExecutionMode == nil {
+		c.ExecutionMode = String("remote")
+	}
+
+	if c.AgentPoolID == nil {
+		c.AgentPoolID = String("")
+	}
+
+	if c.AgentPoolName == nil {
+		c.AgentPoolName = String("")
+	}
+}
+
+// Validate validates the values of the configuration struct
+func (c *TerraformCloudWorkspaceConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if StringVal(c.ExecutionMode) == "" {
+		return errors.New("execution mode is required for Terraform Cloud workspace")
+	}
+
+	if StringVal(c.ExecutionMode) != "remote" && StringVal(c.ExecutionMode) != "agent" {
+		return fmt.Errorf("execution mode '%s' not supported for CTS, use 'remote' or 'agent' instead", *c.ExecutionMode)
+	}
+
+	if StringVal(c.ExecutionMode) == "agent" &&
+		StringVal(c.AgentPoolID) == "" && StringVal(c.AgentPoolName) == "" {
+		return errors.New("agent_pool_id or agent_pool_name is required if execution mode is 'agent'")
+	}
+
+	if StringVal(c.ExecutionMode) != "agent" &&
+		(StringVal(c.AgentPoolID) != "" || StringVal(c.AgentPoolName) != "") {
+		return errors.New("agent pool configured when execution mode is not 'agent'")
+	}
+
+	if StringVal(c.AgentPoolID) != "" && StringVal(c.AgentPoolName) != "" {
+		logger := logging.Global().Named(logSystemName)
+		logger.Warn("agent_pool_id and agent_pool_name are both configured, agent_pool_id will be used")
+	}
+
+	return nil
+}
+
+// GoString defines the printable version of this struct.
+func (c *TerraformCloudWorkspaceConfig) GoString() string {
+	if c == nil {
+		return "(*TerraformCloudWorkspaceConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&TerraformCloudWorkspaceConfig{"+
+		"AgentPoolID:%s, "+
+		"AgentPoolName:%s,"+
+		"ExecutionMode:%s"+
+		"}",
+		StringVal(c.AgentPoolID),
+		StringVal(c.AgentPoolName),
+		StringVal(c.ExecutionMode),
+	)
+}

--- a/config/terraform_cloud_workspace_test.go
+++ b/config/terraform_cloud_workspace_test.go
@@ -39,6 +39,7 @@ func TestTerraformCloudWorkspaceConfig_Copy(t *testing.T) {
 		})
 	}
 }
+
 func TestTerraformCloudWorkspaceConfig_Merge(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
@@ -159,11 +160,11 @@ func TestTerraformCloudWorkspaceConfig_Finalize(t *testing.T) {
 		{
 			"fully_configured",
 			&TerraformCloudWorkspaceConfig{
-				ExecutionMode: String("remote"),
+				ExecutionMode: String("test_mode"),
 				AgentPoolID:   String("apool-1"),
 				AgentPoolName: String("test")},
 			&TerraformCloudWorkspaceConfig{
-				ExecutionMode: String("remote"),
+				ExecutionMode: String("test_mode"),
 				AgentPoolID:   String("apool-1"),
 				AgentPoolName: String("test"),
 			},

--- a/config/terraform_cloud_workspace_test.go
+++ b/config/terraform_cloud_workspace_test.go
@@ -1,0 +1,316 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraformCloudWorkspaceConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		c    *TerraformCloudWorkspaceConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"fully_configured",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolID:   String("apool-123"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c.Copy()
+			assert.Equal(t, tc.c, c)
+		})
+	}
+}
+func TestTerraformCloudWorkspaceConfig_Merge(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    *TerraformCloudWorkspaceConfig
+		b    *TerraformCloudWorkspaceConfig
+		r    *TerraformCloudWorkspaceConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"nil_b",
+			&TerraformCloudWorkspaceConfig{},
+			nil,
+			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"execution_mode_overrides",
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("remote")},
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+		},
+		{
+			"execution_mode_empty_a",
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+		},
+		{
+			"execution_mode_empty_b",
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{ExecutionMode: String("agent")},
+		},
+		{
+			"agent_pool_id_overrides",
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-1")},
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-2")},
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-2")},
+		},
+		{
+			"agent_pool_id_empty_a",
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-2")},
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-2")},
+		},
+		{
+			"agent_pool_id_empty_b",
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-1")},
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{AgentPoolID: String("apool-1")},
+		},
+		{
+			"agent_pool_name_overrides",
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_a")},
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_b")},
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_b")},
+		},
+		{
+			"agent_pool_name_empty_a",
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_b")},
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_b")},
+		},
+		{
+			"agent_pool_name_empty_b",
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_a")},
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{AgentPoolName: String("agent_pool_a")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestTerraformCloudWorkspaceConfig_Finalize(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		c    *TerraformCloudWorkspaceConfig
+		r    *TerraformCloudWorkspaceConfig
+	}{
+		{
+			"nil",
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&TerraformCloudWorkspaceConfig{},
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+				AgentPoolID:   String(""),
+				AgentPoolName: String(""),
+			},
+		},
+		{
+			"fully_configured",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+				AgentPoolID:   String("apool-1"),
+				AgentPoolName: String("test")},
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+				AgentPoolID:   String("apool-1"),
+				AgentPoolName: String("test"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.c.Finalize()
+			assert.Equal(t, tc.r, tc.c)
+		})
+	}
+}
+
+func TestTerraformCloudWorkspaceConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		expectErr bool
+		c         *TerraformCloudWorkspaceConfig
+	}{
+		{
+			"nil",
+			false,
+			nil,
+		},
+		{
+			"valid_remote",
+			false,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+			},
+		},
+		{
+			"valid_agent_pool_id",
+			false,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolID:   String("apool-1"),
+			},
+		},
+		{
+			"valid_agent_pool_name",
+			false,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+		},
+		{
+			"valid_both_agent_pool_id_and_name",
+			false, // warns but does not error
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolID:   String("apool-1"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+		},
+		{
+			"no_execution_mode",
+			true,
+			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"invalid_execution_mode",
+			true,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("local"),
+			},
+		},
+		{
+			"agent_with_no_agent_pool",
+			true,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+			},
+		},
+		{
+			"remote_with_agent_pool_id",
+			true,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+				AgentPoolID:   String("apool-1"),
+			},
+		},
+		{
+			"remote_with_agent_pool_name",
+			true,
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTerraformCloudWorkspaceConfig_GoString(t *testing.T) {
+	cases := []struct {
+		name     string
+		c        *TerraformCloudWorkspaceConfig
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*TerraformCloudWorkspaceConfig)(nil)",
+		},
+		{
+			"remote",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("remote"),
+			},
+			"&TerraformCloudWorkspaceConfig{" +
+				"AgentPoolID:, " +
+				"AgentPoolName:," +
+				"ExecutionMode:remote" +
+				"}",
+		},
+		{
+			"fully_configured",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolID:   String("apool-1"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+			"&TerraformCloudWorkspaceConfig{" +
+				"AgentPoolID:apool-1, " +
+				"AgentPoolName:test_agent_pool," +
+				"ExecutionMode:agent" +
+				"}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.c.GoString()
+			assert.Equal(t, tc.expected, r)
+		})
+	}
+}

--- a/config/terraform_cloud_workspace_test.go
+++ b/config/terraform_cloud_workspace_test.go
@@ -151,7 +151,7 @@ func TestTerraformCloudWorkspaceConfig_Finalize(t *testing.T) {
 			"empty",
 			&TerraformCloudWorkspaceConfig{},
 			&TerraformCloudWorkspaceConfig{
-				ExecutionMode: String("remote"),
+				ExecutionMode: String(""),
 				AgentPoolID:   String(""),
 				AgentPoolName: String(""),
 			},
@@ -224,8 +224,8 @@ func TestTerraformCloudWorkspaceConfig_Validate(t *testing.T) {
 			},
 		},
 		{
-			"no_execution_mode",
-			true,
+			"empty",
+			false, // shouldn't error because optional
 			&TerraformCloudWorkspaceConfig{},
 		},
 		{
@@ -310,6 +310,55 @@ func TestTerraformCloudWorkspaceConfig_GoString(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := tc.c.GoString()
+			assert.Equal(t, tc.expected, r)
+		})
+	}
+}
+
+func TestTerraformCloudWorkspaceConfig_DefaultTerraformCloudWorkspaceConfig(t *testing.T) {
+	r := DefaultTerraformCloudWorkspaceConfig()
+	expected := &TerraformCloudWorkspaceConfig{
+		ExecutionMode: String(""),
+		AgentPoolID:   String(""),
+		AgentPoolName: String(""),
+	}
+	assert.Equal(t, expected, r)
+}
+
+func TestTerraformCloudWorkspaceConfig_isEmpty(t *testing.T) {
+	cases := []struct {
+		name     string
+		c        *TerraformCloudWorkspaceConfig
+		expected bool
+	}{
+		{
+			"configured",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String("agent"),
+				AgentPoolID:   String("apool-1"),
+				AgentPoolName: String("test_agent_pool"),
+			},
+			false,
+		},
+		{
+			"empty_nil_values",
+			&TerraformCloudWorkspaceConfig{},
+			true,
+		},
+		{
+			"empty_default_values",
+			&TerraformCloudWorkspaceConfig{
+				ExecutionMode: String(""),
+				AgentPoolID:   String(""),
+				AgentPoolName: String(""),
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.c.isEmpty()
 			assert.Equal(t, tc.expected, r)
 		})
 	}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -279,7 +279,8 @@ func newDriverTask(conf *config.Config, taskConfig *config.TaskConfig,
 		WorkingDir:   *taskConfig.WorkingDir,
 
 		// Enterprise
-		TFVersion: *taskConfig.TFVersion,
+		TFVersion:    *taskConfig.TFVersion,
+		TFCWorkspace: *taskConfig.TFCWorkspace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing task %s: %s", *taskConfig.Name, err)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -174,7 +174,8 @@ func TestNewDriverTask(t *testing.T) {
 					WorkingDir:   config.String("working-dir/name"),
 
 					// Enterprise
-					TFVersion: config.String("1.0.0"),
+					TFVersion:    config.String("1.0.0"),
+					TFCWorkspace: config.DefaultTerraformCloudWorkspaceConfig(),
 				},
 			}},
 			[]*driver.Task{newTestTask(t, driver.TaskConfig{
@@ -192,7 +193,8 @@ func TestNewDriverTask(t *testing.T) {
 				WorkingDir:   "working-dir/name",
 
 				// Enterprise
-				TFVersion: "1.0.0",
+				TFVersion:    "1.0.0",
+				TFCWorkspace: *config.DefaultTerraformCloudWorkspaceConfig(),
 
 				Env: map[string]string{
 					"CONSUL_HTTP_ADDR": "localhost:8500",
@@ -255,6 +257,9 @@ func TestNewDriverTask(t *testing.T) {
 					Max: 20 * time.Second,
 				},
 				WorkingDir: "sync-tasks/name",
+
+				// Enterprise
+				TFCWorkspace: *config.DefaultTerraformCloudWorkspaceConfig(),
 			})},
 		}, {
 			// Fetches correct provider and required_providers blocks from config
@@ -322,6 +327,9 @@ func TestNewDriverTask(t *testing.T) {
 					Max: 20 * time.Second,
 				},
 				WorkingDir: "sync-tasks/name",
+
+				// Enterprise
+				TFCWorkspace: *config.DefaultTerraformCloudWorkspaceConfig(),
 			})},
 		}, {
 			// Task env is fetched from providers and Consul config when using
@@ -374,6 +382,8 @@ func TestNewDriverTask(t *testing.T) {
 					Max: 20 * time.Second,
 				},
 				WorkingDir: "sync-tasks/name",
+				// Enterprise
+				TFCWorkspace: *config.DefaultTerraformCloudWorkspaceConfig(),
 			})},
 		},
 	}

--- a/controller/server.go
+++ b/controller/server.go
@@ -225,6 +225,7 @@ func configFromDriverTask(t *driver.Task) (config.TaskConfig, error) {
 	}
 
 	inputs := t.ModuleInputs()
+	tfcWs := t.TFCWorkspace()
 
 	return config.TaskConfig{
 		Description:        config.String(t.Description()),
@@ -241,7 +242,8 @@ func configFromDriverTask(t *driver.Task) (config.TaskConfig, error) {
 		WorkingDir:         config.String(t.WorkingDir()),
 
 		// Enterprise
-		TFVersion: config.String(t.TFVersion()),
+		TFVersion:    config.String(t.TFVersion()),
+		TFCWorkspace: &tfcWs,
 	}, nil
 }
 

--- a/controller/server_test.go
+++ b/controller/server_test.go
@@ -48,7 +48,8 @@ func TestServer_Task(t *testing.T) {
 				Min: *taskConf.BufferPeriod.Min,
 				Max: *taskConf.BufferPeriod.Max,
 			},
-			WorkingDir: *taskConf.WorkingDir,
+			WorkingDir:   *taskConf.WorkingDir,
+			TFCWorkspace: *taskConf.TFCWorkspace,
 		})
 		require.NoError(t, err)
 

--- a/driver/task.go
+++ b/driver/task.go
@@ -70,7 +70,8 @@ type Task struct {
 	logger       logging.Logger
 
 	// Enterprise
-	tfVersion string
+	tfVersion    string
+	tfcWorkspace config.TerraformCloudWorkspaceConfig
 }
 
 type TaskConfig struct {
@@ -91,7 +92,8 @@ type TaskConfig struct {
 	WorkingDir   string
 
 	// Enterprise
-	TFVersion string
+	TFVersion    string
+	TFCWorkspace config.TerraformCloudWorkspaceConfig
 }
 
 func NewTask(conf TaskConfig) (*Task, error) {
@@ -139,7 +141,8 @@ func NewTask(conf TaskConfig) (*Task, error) {
 		logger:       logging.Global().Named(logSystemName),
 
 		// Enterprise
-		tfVersion: conf.TFVersion,
+		tfVersion:    conf.TFVersion,
+		tfcWorkspace: conf.TFCWorkspace,
 	}, nil
 }
 
@@ -306,6 +309,12 @@ func (t *Task) TFVersion() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return t.tfVersion
+}
+
+func (t *Task) TFCWorkspace() config.TerraformCloudWorkspaceConfig {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.tfcWorkspace
 }
 
 func (s Service) copy() Service {

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -348,6 +348,17 @@ func TestTask_TFVersion(t *testing.T) {
 	assert.Equal(t, task.tfVersion, tfVersion)
 }
 
+func TestTask_TFCWorkspace(t *testing.T) {
+	var task Task
+	task.tfcWorkspace = config.TerraformCloudWorkspaceConfig{
+		ExecutionMode: config.String("agent"),
+		AgentPoolID:   config.String("apool-1"),
+		AgentPoolName: config.String("test-agent-pool"),
+	}
+	tfcWorkspace := task.TFCWorkspace()
+	assert.Equal(t, task.tfcWorkspace, tfcWorkspace)
+}
+
 func TestTask_configureRootModuleInput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add an enterprise-only configuration `task.terraform_cloud_workspace` that handles TFC workspace configurations that are specific to the task (rather than to all tasks, which is handled by the [`driver.workspaces` configuration](https://www.consul.io/docs/nia/configuration#workspaces)). The new configuration is needed to support configuring Terraform Cloud agents with the Terraform Cloud driver. The requirements for the configuration are as followed:

1. Only support "remote" and "agent".
2. Allow agent pool to be identified by either the ID or the name. If both are provided, ID takes precedence.
3. At least one agent pool config is required to be configured if the execution mode is "agent".
4. Agent pool configs should not be set if the execution mode is not "agent".

Example:
```
task {
  name = "mkam_agent_test"
  module = "mkam/hello/cts"
  condition "services" {
    names = ["web", "api"]
  }
  terraform_cloud_workspace {
    execution_mode = "agent"
    agent_pool_name = "test_agent_pool"
  }
}
```

The existing enterprise-only config `task.terraform_version`, which controls the Terraform version for the workspace, will be added to `task.terraform_cloud_workspace` in a follow up PR and deprecated. 

Part of https://github.com/hashicorp/consul-terraform-sync/issues/772