### PR TITLE
Fixed bug in event storage - using wrong type of lock for delete method

### DIFF
--- a/state/event/event.go
+++ b/state/event/event.go
@@ -52,13 +52,13 @@ func NewEvent(taskName string, config *Config) (*Event, error) {
 	if taskName == "" {
 		return nil, errors.New("error creating new event: taskname cannot be empty")
 	}
-	uuid, err := uuid.GenerateUUID()
+	id, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, err
 	}
 
 	return &Event{
-		ID:       uuid,
+		ID:       id,
 		TaskName: taskName,
 		Config:   config,
 	}, nil
@@ -82,7 +82,6 @@ func (e *Event) End(err error) {
 	}
 
 	e.EndTime = time.Now()
-
 	if err == nil {
 		e.Success = true
 		return

--- a/state/event/event_test.go
+++ b/state/event/event_test.go
@@ -233,10 +233,12 @@ func assertEqualConfig(t *testing.T, exp, act *Config) {
 		assert.Nil(t, act)
 		return
 	}
+
 	if act == nil {
 		assert.Nil(t, exp)
 		return
 	}
+
 	assert.Equal(t, exp.Providers, act.Providers)
 	assert.Equal(t, exp.Services, act.Services)
 	assert.Equal(t, exp.Source, act.Source)

--- a/state/event/event_test.go
+++ b/state/event/event_test.go
@@ -29,7 +29,7 @@ func ExampleEvent() {
 	for _, ex := range examples {
 		fmt.Println("\nExample:", ex.name)
 
-		func() (string, error) {
+		_, _ = func() (string, error) {
 			// setup capturing event
 			event, err := NewEvent(ex.taskName, nil)
 			if err != nil {
@@ -65,6 +65,13 @@ func ExampleEvent() {
 	// Task Name: task_success
 	// Success: true
 	// Error: <nil>
+}
+
+func businessLogic(expectError bool) (string, error) {
+	if expectError {
+		return "", errors.New("error")
+	}
+	return "mock", nil
 }
 
 func TestNewEvent(t *testing.T) {
@@ -178,13 +185,6 @@ func TestEvent_End(t *testing.T) {
 			assert.Equal(t, firstEndTime, event.EndTime)
 		})
 	}
-}
-
-func businessLogic(expectError bool) (string, error) {
-	if expectError {
-		return "", errors.New("error")
-	}
-	return "mock", nil
 }
 
 func TestEvent_GoString(t *testing.T) {

--- a/state/event_storage.go
+++ b/state/event_storage.go
@@ -63,8 +63,8 @@ func (s *eventStorage) Read(taskName string) map[string][]event.Event {
 	ret := make(map[string][]event.Event)
 	for k, v := range data {
 		events := make([]event.Event, len(v))
-		for ix, event := range v {
-			events[ix] = *event
+		for ix, e := range v {
+			events[ix] = *e
 		}
 		ret[k] = events
 	}
@@ -73,8 +73,8 @@ func (s *eventStorage) Read(taskName string) map[string][]event.Event {
 
 // Delete removes all events for a task name.
 func (s *eventStorage) Delete(taskName string) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if taskName != "" {
 		delete(s.events, taskName)

--- a/state/event_storage_test.go
+++ b/state/event_storage_test.go
@@ -25,18 +25,20 @@ func Test_eventStorage_Add(t *testing.T) {
 			true,
 		},
 	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			storage := newEventStorage()
 			err := storage.Add(tc.event)
+
 			if tc.expectErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 				events := storage.events[tc.event.TaskName]
-				assert.Equal(t, 1, len(events))
-				event := events[0]
-				assert.Equal(t, tc.event, *event)
+				assert.Len(t, events, 1)
+				e := events[0]
+				assert.Equal(t, tc.event, *e)
 			}
 		})
 	}
@@ -48,16 +50,16 @@ func Test_eventStorage_Add(t *testing.T) {
 		// fill storage
 		err := storage.Add(event.Event{ID: "1", TaskName: "task"})
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(storage.events["task"]))
+		assert.Len(t, storage.events["task"], 1)
 
 		err = storage.Add(event.Event{ID: "2", TaskName: "task"})
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(storage.events["task"]))
+		assert.Len(t, storage.events["task"], 2)
 
 		// check storage did not grow beyond limit
 		err = storage.Add(event.Event{ID: "3", TaskName: "task"})
 		require.NoError(t, err)
-		assert.Equal(t, 2, len(storage.events["task"]))
+		assert.Len(t, storage.events["task"], 2)
 
 		// confirm events in storage
 		event3 := storage.events["task"][0]
@@ -124,8 +126,8 @@ func Test_eventStorage_Read(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			storage := newEventStorage()
-			for _, event := range tc.values {
-				err := storage.Add(event)
+			for _, e := range tc.values {
+				err := storage.Add(e)
 				require.NoError(t, err)
 			}
 
@@ -165,12 +167,12 @@ func Test_eventStorage_Delete(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			storage := newEventStorage()
-			for _, event := range tc.values {
-				err := storage.Add(event)
+			for _, e := range tc.values {
+				err := storage.Add(e)
 				require.NoError(t, err)
 			}
-			storage.Delete(tc.input)
 
+			storage.Delete(tc.input)
 			after := storage.Read("")
 			assert.Equal(t, tc.expected, after)
 		})

--- a/state/in_memory_store_test.go
+++ b/state/in_memory_store_test.go
@@ -66,7 +66,8 @@ func Test_InMemoryStore_GetTaskEvents(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			events := newEventStorage()
-			events.Add(event.Event{TaskName: "existing_task"})
+			err := events.Add(event.Event{TaskName: "existing_task"})
+			assert.NoError(t, err)
 
 			store := InMemoryStore{
 				events: events,
@@ -93,7 +94,8 @@ func Test_InMemoryStore_DeleteTaskEvents(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			events := newEventStorage()
-			events.Add(event.Event{TaskName: "existing_task"})
+			err := events.Add(event.Event{TaskName: "existing_task"})
+			assert.NoError(t, err)
 
 			store := InMemoryStore{
 				events: events,
@@ -123,13 +125,16 @@ func Test_InMemoryStore_AddTaskEvent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			events := newEventStorage()
-			events.Add(event.Event{TaskName: "existing_task"})
+			err := events.Add(event.Event{TaskName: "existing_task"})
+			assert.NoError(t, err)
 
 			store := InMemoryStore{
 				events: events,
 			}
 
-			store.AddTaskEvent(tc.event)
+			err = store.AddTaskEvent(tc.event)
+			assert.NoError(t, err)
+
 			// confirm event is added
 			taskName := tc.event.TaskName
 			actual := events.Read(taskName)
@@ -140,6 +145,7 @@ func Test_InMemoryStore_AddTaskEvent(t *testing.T) {
 					exists = true
 				}
 			}
+
 			assert.True(t, exists)
 		})
 	}


### PR DESCRIPTION
Fixed bug in event storage - using wrong type of lock for delete method
Addressed warnings (unhandled errors, conflicting variable and package names, etc.)
Made small improvements to tests