### PR TITLE
Rename driver task TF version to deprecated

### DIFF
--- a/controller/base.go
+++ b/controller/base.go
@@ -254,8 +254,8 @@ func newDriverTask(conf *config.Config, taskConfig *config.TaskConfig,
 		WorkingDir:   *taskConfig.WorkingDir,
 
 		// Enterprise
-		TFVersion:    *taskConfig.DeprecatedTFVersion,
-		TFCWorkspace: *taskConfig.TFCWorkspace,
+		DeprecatedTFVersion: *taskConfig.DeprecatedTFVersion,
+		TFCWorkspace:        *taskConfig.TFCWorkspace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error initializing task %s: %s", *taskConfig.Name, err)

--- a/controller/base_test.go
+++ b/controller/base_test.go
@@ -123,8 +123,8 @@ func TestNewDriverTask(t *testing.T) {
 				WorkingDir:   "working-dir/name",
 
 				// Enterprise
-				TFVersion:    "1.0.0",
-				TFCWorkspace: *config.DefaultTerraformCloudWorkspaceConfig(),
+				DeprecatedTFVersion: "1.0.0",
+				TFCWorkspace:        *config.DefaultTerraformCloudWorkspaceConfig(),
 
 				Env: map[string]string{
 					"CONSUL_HTTP_ADDR": "localhost:8500",

--- a/controller/server.go
+++ b/controller/server.go
@@ -242,7 +242,7 @@ func configFromDriverTask(t *driver.Task) (config.TaskConfig, error) {
 		WorkingDir:         config.String(t.WorkingDir()),
 
 		// Enterprise
-		DeprecatedTFVersion: config.String(t.TFVersion()),
+		DeprecatedTFVersion: config.String(t.DeprecatedTFVersion()),
 		TFCWorkspace:        &tfcWs,
 	}, nil
 }

--- a/driver/task.go
+++ b/driver/task.go
@@ -70,8 +70,8 @@ type Task struct {
 	logger       logging.Logger
 
 	// Enterprise
-	tfVersion    string
-	tfcWorkspace config.TerraformCloudWorkspaceConfig
+	deprecatedTFVersion string
+	tfcWorkspace        config.TerraformCloudWorkspaceConfig
 }
 
 type TaskConfig struct {
@@ -92,8 +92,8 @@ type TaskConfig struct {
 	WorkingDir   string
 
 	// Enterprise
-	TFVersion    string
-	TFCWorkspace config.TerraformCloudWorkspaceConfig
+	DeprecatedTFVersion string
+	TFCWorkspace        config.TerraformCloudWorkspaceConfig
 }
 
 func NewTask(conf TaskConfig) (*Task, error) {
@@ -141,8 +141,8 @@ func NewTask(conf TaskConfig) (*Task, error) {
 		logger:       logging.Global().Named(logSystemName),
 
 		// Enterprise
-		tfVersion:    conf.TFVersion,
-		tfcWorkspace: conf.TFCWorkspace,
+		deprecatedTFVersion: conf.DeprecatedTFVersion,
+		tfcWorkspace:        conf.TFCWorkspace,
 	}, nil
 }
 
@@ -303,14 +303,17 @@ func (t *Task) WorkingDir() string {
 	return t.workingDir
 }
 
-// TFVersion returns the Terraform version to use when using the Terraform Cloud
+// DeprecatedTFVersion returns the Terraform version to use when using the Terraform Cloud
 // driver. Enterprise.
-func (t *Task) TFVersion() string {
+// Deprecated, use the Terraform Version from TFCWorkspace() instead.
+func (t *Task) DeprecatedTFVersion() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return t.tfVersion
+	return t.deprecatedTFVersion
 }
 
+// TFCWorkspace returns the Terraform Cloud Workspace configuration to use for the task
+// when using the Terraform Cloud driver. Enterprise only.
 func (t *Task) TFCWorkspace() config.TerraformCloudWorkspaceConfig {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/driver/task_test.go
+++ b/driver/task_test.go
@@ -341,11 +341,11 @@ func TestTask_WorkingDir(t *testing.T) {
 	assert.Equal(t, task.workingDir, workingDir)
 }
 
-func TestTask_TFVersion(t *testing.T) {
+func TestTask_DeprecatedTFVersion(t *testing.T) {
 	var task Task
-	task.tfVersion = "1.0.0"
-	tfVersion := task.TFVersion()
-	assert.Equal(t, task.tfVersion, tfVersion)
+	task.deprecatedTFVersion = "1.0.0"
+	tfVersion := task.DeprecatedTFVersion()
+	assert.Equal(t, task.deprecatedTFVersion, tfVersion)
 }
 
 func TestTask_TFCWorkspace(t *testing.T) {


### PR DESCRIPTION
Rename the TF version of a driver task to reflect that it has
been deprecated in favor of the TF version on the TFC workspace
configuration.

Missed this field when I previously was deprecating the task Terraform version.

Part of https://github.com/hashicorp/consul-terraform-sync/issues/790