### PR TITLE
Fix in-memory state store config shared references

### DIFF
--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -10,6 +10,9 @@ import (
 func TestAuthConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &AuthConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *AuthConfig
@@ -21,6 +24,10 @@ func TestAuthConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&AuthConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"copy",

--- a/config/buffer_period_test.go
+++ b/config/buffer_period_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestBufferPeriodConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	finalizedConf := &BufferPeriodConfig{}
+	finalizedConf.Finalize(DefaultBufferPeriodConfig())
+
 	cases := []struct {
 		name string
 		a    *BufferPeriodConfig
@@ -20,6 +25,10 @@ func TestBufferPeriodConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&BufferPeriodConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/condition_catalog_services_test.go
+++ b/config/condition_catalog_services_test.go
@@ -9,6 +9,9 @@ import (
 func TestCatalogServicesConditionConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &CatalogServicesConditionConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *CatalogServicesConditionConfig
@@ -16,6 +19,14 @@ func TestCatalogServicesConditionConfig_Copy(t *testing.T) {
 		{
 			"nil",
 			nil,
+		},
+		{
+			"empty",
+			&CatalogServicesConditionConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"happy_path",

--- a/config/condition_consul_kv_test.go
+++ b/config/condition_consul_kv_test.go
@@ -9,6 +9,9 @@ import (
 func TestConsulKVConditionConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ConsulKVConditionConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ConsulKVConditionConfig
@@ -20,6 +23,10 @@ func TestConsulKVConditionConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ConsulKVConditionConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"fully_configured",

--- a/config/condition_schedule_test.go
+++ b/config/condition_schedule_test.go
@@ -9,6 +9,9 @@ import (
 func TestScheduleConditionConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ScheduleConditionConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ScheduleConditionConfig
@@ -20,6 +23,10 @@ func TestScheduleConditionConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ScheduleConditionConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"fully_configured",

--- a/config/condition_services_test.go
+++ b/config/condition_services_test.go
@@ -9,6 +9,9 @@ import (
 func TestServicesConditionConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ServicesConditionConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ServicesConditionConfig
@@ -20,6 +23,10 @@ func TestServicesConditionConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ServicesConditionConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"happy_path",

--- a/config/config.go
+++ b/config/config.go
@@ -110,6 +110,7 @@ func (c *Config) Copy() *Config {
 		TerraformProviders: c.TerraformProviders.Copy(),
 		BufferPeriod:       c.BufferPeriod.Copy(),
 		TLS:                c.TLS.Copy(),
+		ClientType:         StringCopy(c.ClientType),
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,6 +300,42 @@ func TestFromPath(t *testing.T) {
 	}
 }
 
+func TestConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	finalizedConf := &Config{}
+	finalizedConf.Finalize()
+
+	cases := []struct {
+		name string
+		a    *Config
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&Config{},
+		},
+		{
+			"finalized",
+			finalizedConf,
+		},
+		{
+			"long",
+			&longConfig,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
 func TestConfig_Finalize(t *testing.T) {
 	// Finalize tests top level config calls nested finalize
 	// Backfill expected values

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -11,6 +11,9 @@ import (
 func TestConsulConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ConsulConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ConsulConfig
@@ -22,6 +25,10 @@ func TestConsulConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ConsulConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/driver_test.go
+++ b/config/driver_test.go
@@ -12,6 +12,9 @@ import (
 func TestDriverConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &DriverConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *DriverConfig
@@ -22,6 +25,9 @@ func TestDriverConfig_Copy(t *testing.T) {
 		}, {
 			"empty",
 			&DriverConfig{},
+		}, {
+			"finalized",
+			finalizedConf,
 		}, {
 			"same_enabled",
 			&DriverConfig{

--- a/config/module_input_consul_kv_test.go
+++ b/config/module_input_consul_kv_test.go
@@ -11,6 +11,9 @@ import (
 func TestConsulKVModuleInputConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ConsulKVModuleInputConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ConsulKVModuleInputConfig
@@ -22,6 +25,10 @@ func TestConsulKVModuleInputConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ConsulKVModuleInputConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"fully_configured",

--- a/config/module_input_services_test.go
+++ b/config/module_input_services_test.go
@@ -10,6 +10,9 @@ import (
 func TestServicesModuleInputConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ServicesModuleInputConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ServicesModuleInputConfig
@@ -21,6 +24,10 @@ func TestServicesModuleInputConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ServicesModuleInputConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"happy_path",

--- a/config/monitor_catalog_services_test.go
+++ b/config/monitor_catalog_services_test.go
@@ -9,6 +9,9 @@ import (
 func TestCatalogServicesMonitorConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &CatalogServicesConditionConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *CatalogServicesConditionConfig
@@ -20,6 +23,10 @@ func TestCatalogServicesMonitorConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&CatalogServicesConditionConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"fully_configured",

--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -52,10 +52,18 @@ func (c *ServicesMonitorConfig) Copy() MonitorConfig {
 
 	var o ServicesMonitorConfig
 	o.Regexp = StringCopy(c.Regexp)
-	o.Names = append(o.Names, c.Names...)
+
+	if c.Names != nil {
+		o.Names = make([]string, 0)
+		o.Names = append(o.Names, c.Names...)
+	}
+
 	o.Datacenter = StringCopy(c.Datacenter)
+
 	o.Namespace = StringCopy(c.Namespace)
+
 	o.Filter = StringCopy(c.Filter)
+
 	if c.CTSUserDefinedMeta != nil {
 		o.CTSUserDefinedMeta = make(map[string]string)
 		for k, v := range c.CTSUserDefinedMeta {

--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -54,7 +54,7 @@ func (c *ServicesMonitorConfig) Copy() MonitorConfig {
 	o.Regexp = StringCopy(c.Regexp)
 
 	if c.Names != nil {
-		o.Names = make([]string, 0)
+		o.Names = make([]string, 0, len(c.Names))
 		o.Names = append(o.Names, c.Names...)
 	}
 

--- a/config/monitor_services_test.go
+++ b/config/monitor_services_test.go
@@ -10,6 +10,9 @@ import (
 func TestServicesMonitorConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ServicesMonitorConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ServicesMonitorConfig
@@ -21,6 +24,10 @@ func TestServicesMonitorConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ServicesMonitorConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"regexp_fully_configured",

--- a/config/provider_test.go
+++ b/config/provider_test.go
@@ -10,6 +10,9 @@ import (
 func TestProviderConfigs_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &TerraformProviderConfigs{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *TerraformProviderConfigs
@@ -21,6 +24,10 @@ func TestProviderConfigs_Copy(t *testing.T) {
 		{
 			"empty",
 			&TerraformProviderConfigs{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/service_test.go
+++ b/config/service_test.go
@@ -10,6 +10,9 @@ import (
 func TestServiceConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &ServiceConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *ServiceConfig
@@ -21,6 +24,10 @@ func TestServiceConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&ServiceConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/syslog_test.go
+++ b/config/syslog_test.go
@@ -10,6 +10,9 @@ import (
 func TestSyslogConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &SyslogConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *SyslogConfig
@@ -21,6 +24,10 @@ func TestSyslogConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&SyslogConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/task.go
+++ b/config/task.go
@@ -104,9 +104,15 @@ func (c *TaskConfig) Copy() *TaskConfig {
 	o.Description = StringCopy(c.Description)
 	o.Name = StringCopy(c.Name)
 
-	o.Providers = append(o.Providers, c.Providers...)
+	if c.Providers != nil {
+		o.Providers = make([]string, 0)
+		o.Providers = append(o.Providers, c.Providers...)
+	}
 
-	o.DeprecatedServices = append(o.DeprecatedServices, c.DeprecatedServices...)
+	if c.DeprecatedServices != nil {
+		o.DeprecatedServices = make([]string, 0)
+		o.DeprecatedServices = append(o.DeprecatedServices, c.DeprecatedServices...)
+	}
 
 	o.Module = StringCopy(c.Module)
 	o.DeprecatedSource = StringCopy(c.DeprecatedSource)
@@ -114,7 +120,10 @@ func (c *TaskConfig) Copy() *TaskConfig {
 	o.ModuleInputs = c.ModuleInputs.Copy()
 	o.DeprecatedSourceInputs = c.DeprecatedSourceInputs.Copy()
 
-	o.VarFiles = append(o.VarFiles, c.VarFiles...)
+	if c.VarFiles != nil {
+		o.VarFiles = make([]string, 0)
+		o.VarFiles = append(o.VarFiles, c.VarFiles...)
+	}
 
 	if c.Variables != nil {
 		o.Variables = make(map[string]string)

--- a/config/task.go
+++ b/config/task.go
@@ -105,12 +105,12 @@ func (c *TaskConfig) Copy() *TaskConfig {
 	o.Name = StringCopy(c.Name)
 
 	if c.Providers != nil {
-		o.Providers = make([]string, 0)
+		o.Providers = make([]string, 0, len(c.Providers))
 		o.Providers = append(o.Providers, c.Providers...)
 	}
 
 	if c.DeprecatedServices != nil {
-		o.DeprecatedServices = make([]string, 0)
+		o.DeprecatedServices = make([]string, 0, len(c.DeprecatedServices))
 		o.DeprecatedServices = append(o.DeprecatedServices, c.DeprecatedServices...)
 	}
 
@@ -121,7 +121,7 @@ func (c *TaskConfig) Copy() *TaskConfig {
 	o.DeprecatedSourceInputs = c.DeprecatedSourceInputs.Copy()
 
 	if c.VarFiles != nil {
-		o.VarFiles = make([]string, 0)
+		o.VarFiles = make([]string, 0, len(c.VarFiles))
 		o.VarFiles = append(o.VarFiles, c.VarFiles...)
 	}
 

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func TestTaskConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	finalizedConf := &TaskConfig{}
+	finalizedConf.Finalize(DefaultBufferPeriodConfig(), DefaultWorkingDir)
+
 	cases := []struct {
 		name string
 		a    *TaskConfig
@@ -20,6 +25,10 @@ func TestTaskConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&TaskConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/terraform_cloud_workspace_test.go
+++ b/config/terraform_cloud_workspace_test.go
@@ -10,6 +10,9 @@ import (
 func TestTerraformCloudWorkspaceConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &TerraformCloudWorkspaceConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		c    *TerraformCloudWorkspaceConfig
@@ -21,6 +24,10 @@ func TestTerraformCloudWorkspaceConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&TerraformCloudWorkspaceConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 	}
 	for _, tc := range cases {

--- a/config/terraform_test.go
+++ b/config/terraform_test.go
@@ -12,6 +12,11 @@ import (
 func TestTerraformConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	consulConf := DefaultConsulConfig()
+	consulConf.Finalize()
+	finalizedConf := &TerraformConfig{}
+	finalizedConf.Finalize(consulConf)
+
 	cases := []struct {
 		name string
 		a    *TerraformConfig
@@ -22,6 +27,9 @@ func TestTerraformConfig_Copy(t *testing.T) {
 		}, {
 			"empty",
 			&TerraformConfig{},
+		}, {
+			"finalized",
+			finalizedConf,
 		}, {
 			"same_enabled",
 			&TerraformConfig{

--- a/config/tls_cts_test.go
+++ b/config/tls_cts_test.go
@@ -10,6 +10,9 @@ import (
 func TestCTSTLSConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &CTSTLSConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *CTSTLSConfig
@@ -21,6 +24,10 @@ func TestCTSTLSConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&CTSTLSConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -10,6 +10,9 @@ import (
 func TestTLSConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &TLSConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *TLSConfig
@@ -21,6 +24,10 @@ func TestTLSConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&TLSConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/transport_test.go
+++ b/config/transport_test.go
@@ -11,6 +11,9 @@ import (
 func TestTransportConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &TransportConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *TransportConfig
@@ -22,6 +25,10 @@ func TestTransportConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&TransportConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/config/vault_test.go
+++ b/config/vault_test.go
@@ -12,6 +12,9 @@ import (
 func TestVaultConfig_Copy(t *testing.T) {
 	t.Parallel()
 
+	finalizedConf := &VaultConfig{}
+	finalizedConf.Finalize()
+
 	cases := []struct {
 		name string
 		a    *VaultConfig
@@ -23,6 +26,10 @@ func TestVaultConfig_Copy(t *testing.T) {
 		{
 			"empty",
 			&VaultConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
 		},
 		{
 			"same_enabled",

--- a/state/in_memory_store.go
+++ b/state/in_memory_store.go
@@ -36,6 +36,7 @@ func NewInMemoryStore(conf *config.Config) *InMemoryStore {
 	}
 }
 
+// GetConfig returns a copy of the CTS configuration
 func (s *InMemoryStore) GetConfig() config.Config {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
@@ -43,14 +44,19 @@ func (s *InMemoryStore) GetConfig() config.Config {
 	return *s.conf.Copy()
 }
 
+// GetTaskEvents returns all the events for a task. If no task name is
+// specified, then it returns events for all tasks
 func (s *InMemoryStore) GetTaskEvents(taskName string) map[string][]event.Event {
 	return s.events.Read(taskName)
 }
 
+// DeleteTaskEvents deletes all the events for a given task
 func (s *InMemoryStore) DeleteTaskEvents(taskName string) {
 	s.events.Delete(taskName)
 }
 
+// AddTaskEvent adds an event to the store for the task configured in the
+// event
 func (s *InMemoryStore) AddTaskEvent(event event.Event) error {
 	return s.events.Add(event)
 }

--- a/state/in_memory_store.go
+++ b/state/in_memory_store.go
@@ -19,8 +19,8 @@ type InMemoryStore struct {
 
 // configStorage is the storage for the configuration with its own mutex lock
 type configStorage struct {
-	mu   sync.RWMutex
-	conf config.Config
+	config.Config
+	mu sync.RWMutex
 }
 
 // NewInMemoryStore returns a new in-memory store for CTS state
@@ -31,7 +31,7 @@ func NewInMemoryStore(conf *config.Config) *InMemoryStore {
 	}
 
 	return &InMemoryStore{
-		conf:   &configStorage{conf: *conf.Copy()},
+		conf:   &configStorage{Config: *conf.Copy()},
 		events: newEventStorage(),
 	}
 }
@@ -40,7 +40,7 @@ func (s *InMemoryStore) GetConfig() config.Config {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 
-	return *s.conf.conf.Copy()
+	return *s.conf.Copy()
 }
 
 func (s *InMemoryStore) GetTaskEvents(taskName string) map[string][]event.Event {

--- a/state/in_memory_store.go
+++ b/state/in_memory_store.go
@@ -36,7 +36,6 @@ func NewInMemoryStore(conf *config.Config) *InMemoryStore {
 	}
 }
 
-// GetConfig returns the config
 func (s *InMemoryStore) GetConfig() config.Config {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
@@ -44,18 +43,14 @@ func (s *InMemoryStore) GetConfig() config.Config {
 	return *s.conf.conf.Copy()
 }
 
-// GetTaskEvents returns the events for a given task name. If no task name is
-// specified, then it returns events for all tasks
 func (s *InMemoryStore) GetTaskEvents(taskName string) map[string][]event.Event {
 	return s.events.Read(taskName)
 }
 
-// DeleteTaskEvents deletes all the events for a given task name
 func (s *InMemoryStore) DeleteTaskEvents(taskName string) {
 	s.events.Delete(taskName)
 }
 
-// AddTaskEvent adds an event to the store for the task configured in the event
 func (s *InMemoryStore) AddTaskEvent(event event.Event) error {
 	return s.events.Add(event)
 }

--- a/state/in_memory_store.go
+++ b/state/in_memory_store.go
@@ -20,7 +20,7 @@ type InMemoryStore struct {
 // configStorage is the storage for the configuration with its own mutex lock
 type configStorage struct {
 	mu   sync.RWMutex
-	conf config.Config
+	conf *config.Config
 }
 
 // NewInMemoryStore returns a new in-memory store for CTS state
@@ -31,7 +31,7 @@ func NewInMemoryStore(conf *config.Config) *InMemoryStore {
 	}
 
 	return &InMemoryStore{
-		conf:   &configStorage{conf: *conf},
+		conf:   &configStorage{conf: conf.Copy()},
 		events: newEventStorage(),
 	}
 }
@@ -41,7 +41,7 @@ func (s *InMemoryStore) GetConfig() config.Config {
 	s.conf.mu.RLock()
 	defer s.conf.mu.RUnlock()
 
-	return s.conf.conf
+	return *s.conf.conf.Copy()
 }
 
 // GetTaskEvents returns the events for a given task name. If no task name is

--- a/state/in_memory_store.go
+++ b/state/in_memory_store.go
@@ -20,7 +20,7 @@ type InMemoryStore struct {
 // configStorage is the storage for the configuration with its own mutex lock
 type configStorage struct {
 	mu   sync.RWMutex
-	conf *config.Config
+	conf config.Config
 }
 
 // NewInMemoryStore returns a new in-memory store for CTS state
@@ -31,7 +31,7 @@ func NewInMemoryStore(conf *config.Config) *InMemoryStore {
 	}
 
 	return &InMemoryStore{
-		conf:   &configStorage{conf: conf.Copy()},
+		conf:   &configStorage{conf: *conf.Copy()},
 		events: newEventStorage(),
 	}
 }

--- a/state/in_memory_store_test.go
+++ b/state/in_memory_store_test.go
@@ -21,7 +21,7 @@ func Test_NewInMemoryStore(t *testing.T) {
 			nil,
 			InMemoryStore{
 				conf: &configStorage{
-					conf: *config.DefaultConfig(),
+					Config: *config.DefaultConfig(),
 				},
 				events: newEventStorage(),
 			},
@@ -33,7 +33,7 @@ func Test_NewInMemoryStore(t *testing.T) {
 			},
 			InMemoryStore{
 				conf: &configStorage{
-					conf: config.Config{
+					Config: config.Config{
 						Port: config.Int(1234),
 					},
 				},
@@ -55,13 +55,13 @@ func Test_NewInMemoryStore(t *testing.T) {
 		actual := NewInMemoryStore(finalizedConf)
 
 		// Confirm that input and stored config have same values
-		assert.Equal(t, *finalizedConf, actual.conf.conf)
+		assert.Equal(t, *finalizedConf, actual.conf.Config)
 
 		// Confrm that input and stored config reference different objects
-		assert.NotSame(t, finalizedConf, actual.conf.conf)
+		assert.NotSame(t, finalizedConf, actual.conf.Config)
 
 		// Confrm that input and stored config fields reference different objects
-		assert.NotSame(t, finalizedConf.Tasks, actual.conf.conf.Tasks)
+		assert.NotSame(t, finalizedConf.Tasks, actual.conf.Tasks)
 	})
 }
 
@@ -95,7 +95,7 @@ func Test_InMemoryStore_GetConfig(t *testing.T) {
 		store := NewInMemoryStore(finalizedConf)
 
 		actual := store.GetConfig()
-		storedConf := store.conf.conf
+		storedConf := store.conf.Config
 
 		// Confirm returned config has same value as stored
 		assert.Equal(t, storedConf, actual)

--- a/state/in_memory_store_test.go
+++ b/state/in_memory_store_test.go
@@ -21,7 +21,7 @@ func Test_NewInMemoryStore(t *testing.T) {
 			nil,
 			InMemoryStore{
 				conf: &configStorage{
-					conf: config.DefaultConfig(),
+					conf: *config.DefaultConfig(),
 				},
 				events: newEventStorage(),
 			},
@@ -33,7 +33,7 @@ func Test_NewInMemoryStore(t *testing.T) {
 			},
 			InMemoryStore{
 				conf: &configStorage{
-					conf: &config.Config{
+					conf: config.Config{
 						Port: config.Int(1234),
 					},
 				},
@@ -55,7 +55,7 @@ func Test_NewInMemoryStore(t *testing.T) {
 		actual := NewInMemoryStore(finalizedConf)
 
 		// Confirm that input and stored config have same values
-		assert.Equal(t, *finalizedConf, *actual.conf.conf)
+		assert.Equal(t, *finalizedConf, actual.conf.conf)
 
 		// Confrm that input and stored config reference different objects
 		assert.NotSame(t, finalizedConf, actual.conf.conf)
@@ -98,7 +98,7 @@ func Test_InMemoryStore_GetConfig(t *testing.T) {
 		storedConf := store.conf.conf
 
 		// Confirm returned config has same value as stored
-		assert.Equal(t, *storedConf, actual)
+		assert.Equal(t, storedConf, actual)
 
 		// Confirm returned config references different object from stored
 		assert.NotSame(t, storedConf, actual)

--- a/state/store.go
+++ b/state/store.go
@@ -8,15 +8,17 @@ import (
 // Store stores the CTS state
 type Store interface {
 
-	// GetConfig returns the CTS configuration
+	// GetConfig returns a copy of the CTS configuration
 	GetConfig() config.Config
 
-	// GetTaskEvents retrieves all the events for a task
+	// GetTaskEvents returns all the events for a task. If no task name is
+	// specified, then it returns events for all tasks
 	GetTaskEvents(taskName string) map[string][]event.Event
 
-	// DeleteTaskEvents deletes all the events for a task
+	// DeleteTaskEvents deletes all the events for a given task
 	DeleteTaskEvents(taskName string)
 
-	// AddTaskEvent adds an event for a task
+	// AddTaskEvent adds an event to the store for the task configured in the
+	// event
 	AddTaskEvent(event event.Event) error
 }


### PR DESCRIPTION
Previously introduced storing the configuration in the in-memory state store: https://github.com/hashicorp/consul-terraform-sync/pull/785

Problem: the stored and returned config in NewInMemoryStore() and GetConfig() share references to the child fields
Fix: update these to store/return copies of the config

Changes:
 - Commits 1-4: fix some issues with configuration Copy() methods for finalized configs
 - Commit 5: fix shared references
 - Commit 6: cleanup redundant comments