### PR TITLE
Update fallback Terraform version to 1.1.8

### DIFF
--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -22,7 +22,7 @@ const (
 	terraformSubsystemName = "terraform"
 )
 
-const fallbackTFVersion = "0.13.7"
+const fallbackTFVersion = "1.1.8"
 
 // TerraformVersion is the version of Terraform CLI for the Terraform driver.
 var TerraformVersion *goVersion.Version


### PR DESCRIPTION
CTS has the following strategy when determining what version of Terraform to download and use:

1. Use the version specified in the Terraform driver block (`driver.version`)
2. Use the latest version of Terraform
3. If determining the latest version of Terraform fails or if the latest version is not compatible with CTS, then use the hardcoded fallback version.

This PR updates the fallback version to a more recent version of Terraform. The plan is to periodically keep this version more up to date.