### PR TITLE
Improve error message if license configs set

### DIFF
--- a/config/decode.go
+++ b/config/decode.go
@@ -29,11 +29,23 @@ try 'terraform_provider'. The terraform_provider configuration blocks are
 similar to provider blocks in Terraform but have additional features
 supported only by CTS.`, err)
 
+			// Enterprise-specific configurations, will only error in OSS
 		case "driver.terraform-cloud":
 			return fmt.Errorf(`%s
 
 Terraform Cloud is a Consul-Terraform-Sync (CTS) Enterprise feature.
 Upgrade to Consul Enterprise to enable CTS Enterprise features.`, err)
+
+		case "license_path":
+			return fmt.Errorf(`%s
+
+'license_path' is a Consul-Terraform-Sync (CTS) Enterprise configuration.`, err)
+
+		case "license":
+			return fmt.Errorf(`%s
+
+'license' is a Consul-Terraform-Sync (CTS) Enterprise configuration.`, err)
+
 		}
 	}
 	return err


### PR DESCRIPTION
Log a more helpful message if the enterprise-only `licence` or `license_path` is
configured. This also makes the UX more consistent with our other enterprise-only
configurations.

Previous error:
```
2022-04-14T17:29:10.464-0500 [ERROR] config: failed decoding content from file: file_path=config.hcl
2022-04-14T17:29:10.464-0500 [ERROR] cli: error building configuration: error="'config.hcl' has invalid keys: license"
```

New errors:
```
2022-04-14T17:21:50.422-0500 [ERROR] config: failed decoding content from file: file_path=config.hcl
2022-04-14T17:21:50.422-0500 [ERROR] cli: error building configuration:
  error=
  | 'config.hcl' has invalid keys: license_path
  | 
  | 'license_path' is a Consul-Terraform-Sync (CTS) Enterprise configuration.
```

```
2022-04-14T17:23:37.824-0500 [ERROR] config: failed decoding content from file: file_path=config.hcl
2022-04-14T17:23:37.824-0500 [ERROR] cli: error building configuration:
  error=
  | 'config.hcl' has invalid keys: license
  | 
  | 'license' is a Consul-Terraform-Sync (CTS) Enterprise configuration.
```