### PR TITLE
Split out baseController from TasksManager pt1

### DIFF
--- a/controller/base.go
+++ b/controller/base.go
@@ -47,10 +47,6 @@ func newBaseController(conf *config.Config, watcher templates.Watcher) (*baseCon
 	}, nil
 }
 
-func (ctrl *baseController) Stop() {
-	ctrl.watcher.Stop()
-}
-
 func (ctrl *baseController) init(ctx context.Context) error {
 	ctrl.logger.Info("initializing driver")
 

--- a/controller/base.go
+++ b/controller/base.go
@@ -76,7 +76,7 @@ func (ctrl *baseController) init(ctx context.Context) error {
 
 		var err error
 		taskName := *t.Name
-		d, err := ctrl.createNewTaskDriver(*t)
+		d, err := ctrl.createNewTaskDriver(ctrl.initConf, *t)
 		if err != nil {
 			ctrl.logger.Error("error creating new task driver", taskNameLogKey, taskName)
 			return err
@@ -101,15 +101,15 @@ func (ctrl *baseController) init(ctx context.Context) error {
 	return nil
 }
 
-func (ctrl *baseController) createNewTaskDriver(taskConfig config.TaskConfig) (driver.Driver, error) {
+func (ctrl *baseController) createNewTaskDriver(conf *config.Config, taskConfig config.TaskConfig) (driver.Driver, error) {
 	logger := ctrl.logger.With("task_name", *taskConfig.Name)
 	logger.Trace("creating new task driver")
-	task, err := newDriverTask(ctrl.initConf, &taskConfig, ctrl.providers)
+	task, err := newDriverTask(conf, &taskConfig, ctrl.providers)
 	if err != nil {
 		return nil, err
 	}
 
-	d, err := ctrl.newDriver(ctrl.initConf, task, ctrl.watcher)
+	d, err := ctrl.newDriver(conf, task, ctrl.watcher)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/base.go
+++ b/controller/base.go
@@ -11,14 +11,12 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/logging"
-	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
 	"github.com/hashicorp/hcat"
 )
 
 type baseController struct {
-	state     state.Store
 	newDriver func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error)
 	drivers   *driver.Drivers
 	watcher   templates.Watcher
@@ -40,7 +38,6 @@ func newBaseController(conf *config.Config, watcher templates.Watcher) (*baseCon
 	logger := logging.Global().Named(ctrlSystemName)
 
 	return &baseController{
-		state:     state.NewInMemoryStore(conf),
 		newDriver: nd,
 		drivers:   driver.NewDrivers(),
 		watcher:   watcher,

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -18,6 +18,10 @@ type ConditionMonitor struct {
 	// TODO: placeholder. Will convert ReadWrite methods to ConditionMonitor
 }
 
+func (tm *TasksManager) Stop() {
+	tm.watcher.Stop()
+}
+
 // Run runs the controller in read-write mode by continuously monitoring Consul
 // catalog and using the driver to apply network infrastructure changes for
 // any work that have been updated.

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/cronexpr"
 )
 
@@ -330,4 +331,17 @@ func (tm *TasksManager) checkInspect(ctx context.Context, d driver.Driver) (bool
 	}
 
 	return rendered, nil
+}
+
+// logDepSize logs the watcher dependency size every nth iteration. Set the
+// iterator to a negative value to log each iteration.
+func (tm *TasksManager) logDepSize(n uint, i int64) {
+	depSize := tm.watcher.Size()
+	if i%int64(n) == 0 || i < 0 {
+		tm.logger.Debug("watching dependencies", "dependency_size", depSize)
+		if depSize > templates.DepSizeWarning {
+			tm.logger.Warn(fmt.Sprintf(" watching more than %d dependencies could "+
+				"DDoS your Consul cluster: %d", templates.DepSizeWarning, depSize))
+		}
+	}
 }

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -689,12 +689,14 @@ func singleTaskConfig() *config.Config {
 				Version:            config.String("v1"),
 			},
 		},
-		TerraformProviders: &config.TerraformProviderConfigs{{
-			"X": map[string]interface{}{},
-			handler.TerraformProviderFake: map[string]interface{}{
-				"name": "fake-provider",
+		TerraformProviders: &config.TerraformProviderConfigs{
+			{"X": map[string]interface{}{}},
+			{
+				handler.TerraformProviderFake: map[string]interface{}{
+					"name": "fake-provider",
+				},
 			},
-		}},
+		},
 	}
 
 	c.Finalize()

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -29,7 +29,7 @@ func Test_TasksManager_once_error(t *testing.T) {
 	w.On("WaitCh", mock.Anything).Return(nil)
 	w.On("Size").Return(numTasks)
 
-	rw := newTestTasksManager()
+	tm := newTestTasksManager()
 
 	testCases := []struct {
 		name    string
@@ -37,7 +37,7 @@ func Test_TasksManager_once_error(t *testing.T) {
 	}{
 		{
 			"onceConsecutive",
-			rw.onceConsecutive,
+			tm.onceConsecutive,
 		},
 	}
 
@@ -47,10 +47,10 @@ func Test_TasksManager_once_error(t *testing.T) {
 
 			// Set up read-write tm with mocks
 			conf := multipleTaskConfig(numTasks)
-			rw.state = state.NewInMemoryStore(conf)
-			rw.initConf = conf
-			rw.baseController.watcher = w
-			rw.baseController.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+			tm.state = state.NewInMemoryStore(conf)
+			tm.initConf = conf
+			tm.baseController.watcher = w
+			tm.baseController.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 				taskName := task.Name()
 				d := new(mocksD.Driver)
 				d.On("Task").Return(enabledTestTask(t, taskName))
@@ -67,7 +67,7 @@ func Test_TasksManager_once_error(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := rw.Init(ctx)
+			err := tm.Init(ctx)
 			require.NoError(t, err)
 
 			// testing really starts here...
@@ -302,13 +302,13 @@ func Test_TasksManager_Run_context_cancel(t *testing.T) {
 		On("Size").Return(5).
 		On("Stop").Return()
 
-	ctl := newTestTasksManager()
-	ctl.watcher = w
+	tm := newTestTasksManager()
+	tm.watcher = w
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)
 	go func() {
-		err := ctl.Run(ctx)
+		err := tm.Run(ctx)
 		if err != nil {
 			errCh <- err
 		}

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -307,9 +307,9 @@ func Test_TasksManager_Run_context_cancel(t *testing.T) {
 		On("Stop").Return()
 
 	ctl := TasksManager{
+		watcher: w,
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
-			watcher: w,
 			logger:  logging.NewNullLogger(),
 			state:   state.NewInMemoryStore(nil),
 		},
@@ -637,11 +637,13 @@ func Test_TasksManager_RunInspect(t *testing.T) {
 			w := new(mocks.Watcher)
 			w.On("Size").Return(5)
 
-			tm := TasksManager{baseController: &baseController{
+			tm := TasksManager{
 				watcher: w,
-				drivers: driver.NewDrivers(),
-				logger:  logging.NewNullLogger(),
-			}}
+				baseController: &baseController{
+					drivers: driver.NewDrivers(),
+					logger:  logging.NewNullLogger(),
+				},
+			}
 
 			d := new(mocksD.Driver)
 			d.On("Task").Return(enabledTestTask(t, "task"))
@@ -683,12 +685,14 @@ func Test_TasksManager_RunInspect_context_cancel(t *testing.T) {
 	err := drivers.Add("task", d)
 	require.NoError(t, err)
 
-	tm := TasksManager{baseController: &baseController{
-		watcher:  w,
-		resolver: r,
-		drivers:  drivers,
-		logger:   logging.NewNullLogger(),
-	}}
+	tm := TasksManager{
+		watcher: w,
+		baseController: &baseController{
+			resolver: r,
+			drivers:  drivers,
+			logger:   logging.NewNullLogger(),
+		},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -47,8 +47,8 @@ func Test_TasksManager_once_error(t *testing.T) {
 
 			// Set up read-write tm with mocks
 			conf := multipleTaskConfig(numTasks)
+			rw.state = state.NewInMemoryStore(conf)
 			rw.baseController = &baseController{
-				state:   state.NewInMemoryStore(conf),
 				watcher: w,
 				drivers: driver.NewDrivers(),
 				newDriver: func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
@@ -307,11 +307,11 @@ func Test_TasksManager_Run_context_cancel(t *testing.T) {
 		On("Stop").Return()
 
 	ctl := TasksManager{
+		state:   state.NewInMemoryStore(nil),
 		watcher: w,
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
-			state:   state.NewInMemoryStore(nil),
 		},
 	}
 
@@ -349,8 +349,8 @@ func Test_TasksManager_once_then_Run(t *testing.T) {
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
-			state:   state.NewInMemoryStore(nil),
 		},
+		state:     state.NewInMemoryStore(nil),
 		watcherCh: make(chan string, 5),
 	}
 	tm.drivers.Add("task_a", d)
@@ -411,8 +411,8 @@ func Test_TasksManager_Run_ActiveTask(t *testing.T) {
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
-			state:   state.NewInMemoryStore(nil),
 		},
+		state:     state.NewInMemoryStore(nil),
 		watcherCh: make(chan string, 5),
 	}
 	for _, n := range []string{"task_a", "task_b"} {
@@ -492,8 +492,8 @@ func Test_TasksManager_Run_ScheduledTasks(t *testing.T) {
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
 				logger:  logging.NewNullLogger(),
-				state:   state.NewInMemoryStore(nil),
 			},
+			state:           state.NewInMemoryStore(nil),
 			watcherCh:       make(chan string, 5),
 			scheduleStopChs: make(map[string](chan struct{})),
 		}
@@ -536,8 +536,8 @@ func Test_TasksManager_Run_ScheduledTasks(t *testing.T) {
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
 				logger:  logging.NewNullLogger(),
-				state:   state.NewInMemoryStore(nil),
 			},
+			state:           state.NewInMemoryStore(nil),
 			watcherCh:       make(chan string, 5),
 			scheduleStartCh: make(chan driver.Driver, 1),
 			scheduleStopChs: make(map[string](chan struct{})),
@@ -588,9 +588,7 @@ func Test_TasksManager_EnableTestMode(t *testing.T) {
 
 	// Set up tm
 	tm := TasksManager{
-		baseController: &baseController{
-			state: s,
-		},
+		state: s,
 	}
 
 	// Test EnableTestMode
@@ -802,8 +800,8 @@ func newTestTasksManager() TasksManager {
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
-			state:   state.NewInMemoryStore(nil),
 		},
+		state:           state.NewInMemoryStore(nil),
 		scheduleStopChs: make(map[string](chan struct{})),
 	}
 }

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -797,6 +797,7 @@ func scheduledTestTask(tb testing.TB, name string) *driver.Task {
 
 func newTestTasksManager() TasksManager {
 	return TasksManager{
+		logger: logging.NewNullLogger(),
 		baseController: &baseController{
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 )
 
@@ -21,6 +22,7 @@ var (
 type ReadOnly struct {
 	logger logging.Logger
 
+	state        state.Store
 	tasksManager *TasksManager
 	watcher      templates.Watcher
 }
@@ -40,13 +42,16 @@ func NewReadOnly(conf *config.Config) (*ReadOnly, error) {
 		return nil, err
 	}
 
-	tm, err := NewTasksManager(conf, watcher)
+	state := state.NewInMemoryStore(conf)
+
+	tm, err := NewTasksManager(conf, watcher, state)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ReadOnly{
 		logger:       logger,
+		state:        state,
 		tasksManager: tm,
 		watcher:      watcher,
 	}, nil

--- a/controller/readonly.go
+++ b/controller/readonly.go
@@ -3,7 +3,10 @@ package controller
 import (
 	"context"
 
+	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/templates"
 )
 
 var (
@@ -16,7 +19,10 @@ var (
 
 // ReadOnly is the controller to run in read-only mode
 type ReadOnly struct {
+	logger logging.Logger
+
 	tasksManager *TasksManager
+	watcher      templates.Watcher
 }
 
 // NewReadOnly configures and initializes a new ReadOnly controller
@@ -26,13 +32,23 @@ func NewReadOnly(conf *config.Config) (*ReadOnly, error) {
 		tfConfig.Log = config.Bool(true)
 	}
 
-	tm, err := NewTasksManager(conf)
+	logger := logging.Global().Named(ctrlSystemName)
+
+	logger.Info("initializing Consul client and testing connection")
+	watcher, err := newWatcher(conf, client.ConsulDefaultMaxRetry)
+	if err != nil {
+		return nil, err
+	}
+
+	tm, err := NewTasksManager(conf, watcher)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ReadOnly{
+		logger:       logger,
 		tasksManager: tm,
+		watcher:      watcher,
 	}, nil
 }
 

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -4,7 +4,10 @@ import (
 	"context"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/templates"
 )
 
 var (
@@ -16,18 +19,31 @@ var (
 
 // ReadWrite is the controller to run in read-write mode
 type ReadWrite struct {
+	logger logging.Logger
+
 	tasksManager *TasksManager
+	watcher      templates.Watcher
 }
 
 // NewReadWrite configures and initializes a new ReadWrite controller
 func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
-	tm, err := NewTasksManager(conf)
+	logger := logging.Global().Named(ctrlSystemName)
+
+	logger.Info("initializing Consul client and testing connection")
+	watcher, err := newWatcher(conf, client.ConsulDefaultMaxRetry)
+	if err != nil {
+		return nil, err
+	}
+
+	tm, err := NewTasksManager(conf, watcher)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ReadWrite{
+		logger:       logger,
 		tasksManager: tm,
+		watcher:      watcher,
 	}, nil
 }
 

--- a/controller/readwrite.go
+++ b/controller/readwrite.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 )
 
@@ -21,6 +22,7 @@ var (
 type ReadWrite struct {
 	logger logging.Logger
 
+	state        state.Store
 	tasksManager *TasksManager
 	watcher      templates.Watcher
 }
@@ -35,13 +37,16 @@ func NewReadWrite(conf *config.Config) (*ReadWrite, error) {
 		return nil, err
 	}
 
-	tm, err := NewTasksManager(conf, watcher)
+	state := state.NewInMemoryStore(conf)
+
+	tm, err := NewTasksManager(conf, watcher, state)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ReadWrite{
 		logger:       logger,
+		state:        state,
 		tasksManager: tm,
 		watcher:      watcher,
 	}, nil

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/consul-terraform-sync/config"
-	"github.com/hashicorp/consul-terraform-sync/driver"
-	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocks "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/testutils"
@@ -23,18 +21,14 @@ func Test_ReadWrite_Run(t *testing.T) {
 
 	port := testutils.FreePort(t)
 
-	ctl := ReadWrite{
-		tasksManager: &TasksManager{
-			watcher: w,
-			baseController: &baseController{
-				drivers: driver.NewDrivers(),
-				logger:  logging.NewNullLogger(),
-			},
-			state: state.NewInMemoryStore(&config.Config{
-				Port: config.Int(port),
-			}),
-		},
-	}
+	ctl := ReadWrite{}
+
+	tm := newTestTasksManager()
+	tm.watcher = w
+	tm.state = state.NewInMemoryStore(&config.Config{
+		Port: config.Int(port),
+	})
+	ctl.tasksManager = &tm
 
 	t.Run("cancel exits successfully", func(t *testing.T) {
 		errCh := make(chan error)

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -25,9 +25,9 @@ func Test_ReadWrite_Run(t *testing.T) {
 
 	ctl := ReadWrite{
 		tasksManager: &TasksManager{
+			watcher: w,
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
-				watcher: w,
 				logger:  logging.NewNullLogger(),
 				state: state.NewInMemoryStore(&config.Config{
 					Port: config.Int(port),

--- a/controller/readwrite_test.go
+++ b/controller/readwrite_test.go
@@ -29,10 +29,10 @@ func Test_ReadWrite_Run(t *testing.T) {
 			baseController: &baseController{
 				drivers: driver.NewDrivers(),
 				logger:  logging.NewNullLogger(),
-				state: state.NewInMemoryStore(&config.Config{
-					Port: config.Int(port),
-				}),
 			},
+			state: state.NewInMemoryStore(&config.Config{
+				Port: config.Int(port),
+			}),
 		},
 	}
 

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -412,7 +412,7 @@ func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskCo
 		return nil, fmt.Errorf("task with name %s already exists", taskName)
 	}
 
-	d, err := tm.createNewTaskDriver(taskConfig)
+	d, err := tm.createNewTaskDriver(&conf, taskConfig)
 	if err != nil {
 		logger.Error("error creating new task driver", "error", err)
 		return nil, err

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/state/event"
@@ -18,6 +19,7 @@ import (
 // TasksManager manages the CRUD operations and execution of tasks
 type TasksManager struct {
 	*baseController
+	logger logging.Logger
 
 	watcher templates.Watcher
 	state   state.Store
@@ -43,12 +45,15 @@ type TasksManager struct {
 func NewTasksManager(conf *config.Config, watcher templates.Watcher,
 	state state.Store) (*TasksManager, error) {
 
+	logger := logging.Global().Named("tasks_manager")
+
 	baseCtrl, err := newBaseController(conf, watcher)
 	if err != nil {
 		return nil, err
 	}
 
 	return &TasksManager{
+		logger:          logger,
 		baseController:  baseCtrl,
 		watcher:         watcher,
 		state:           state,

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/retry"
+	"github.com/hashicorp/consul-terraform-sync/state"
 	"github.com/hashicorp/consul-terraform-sync/state/event"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/pkg/errors"
@@ -19,6 +20,7 @@ type TasksManager struct {
 	*baseController
 
 	watcher templates.Watcher
+	state   state.Store
 
 	retry retry.Retry
 
@@ -38,7 +40,9 @@ type TasksManager struct {
 }
 
 // NewTasksManager configures a new tasks manager
-func NewTasksManager(conf *config.Config, watcher templates.Watcher) (*TasksManager, error) {
+func NewTasksManager(conf *config.Config, watcher templates.Watcher,
+	state state.Store) (*TasksManager, error) {
+
 	baseCtrl, err := newBaseController(conf, watcher)
 	if err != nil {
 		return nil, err
@@ -47,6 +51,7 @@ func NewTasksManager(conf *config.Config, watcher templates.Watcher) (*TasksMana
 	return &TasksManager{
 		baseController:  baseCtrl,
 		watcher:         watcher,
+		state:           state,
 		retry:           retry.NewRetry(defaultRetry, time.Now().UnixNano()),
 		scheduleStartCh: make(chan driver.Driver, 10), // arbitrarily chosen size
 		deleteCh:        make(chan string, 10),        // arbitrarily chosen size

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/retry"
 	"github.com/hashicorp/consul-terraform-sync/state/event"
+	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/pkg/errors"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
@@ -16,6 +17,8 @@ import (
 // TasksManager manages the CRUD operations and execution of tasks
 type TasksManager struct {
 	*baseController
+
+	watcher templates.Watcher
 
 	retry retry.Retry
 
@@ -35,14 +38,15 @@ type TasksManager struct {
 }
 
 // NewTasksManager configures a new tasks manager
-func NewTasksManager(conf *config.Config) (*TasksManager, error) {
-	baseCtrl, err := newBaseController(conf)
+func NewTasksManager(conf *config.Config, watcher templates.Watcher) (*TasksManager, error) {
+	baseCtrl, err := newBaseController(conf, watcher)
 	if err != nil {
 		return nil, err
 	}
 
 	return &TasksManager{
 		baseController:  baseCtrl,
+		watcher:         watcher,
 		retry:           retry.NewRetry(defaultRetry, time.Now().UnixNano()),
 		scheduleStartCh: make(chan driver.Driver, 10), // arbitrarily chosen size
 		deleteCh:        make(chan string, 10),        // arbitrarily chosen size

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -412,19 +412,8 @@ func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskCo
 		return nil, fmt.Errorf("task with name %s already exists", taskName)
 	}
 
-	d, err := tm.createNewTaskDriver(&conf, taskConfig)
+	d, err := tm.makeDriver(ctx, &conf, taskConfig)
 	if err != nil {
-		logger.Error("error creating new task driver", "error", err)
-		return nil, err
-	}
-
-	// Initialize the new task
-	err = d.InitTask(ctx)
-	if err != nil {
-		logger.Error("error initializing new task", "error", err)
-		// Cleanup the task
-		d.DestroyTask(ctx)
-		logger.Debug("task destroyed", "task_name", *taskConfig.Name)
 		return nil, err
 	}
 

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -16,6 +16,8 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
 
+var tasksManagerSystemName = "tasksmanager"
+
 // TasksManager manages the CRUD operations and execution of tasks
 type TasksManager struct {
 	*baseController
@@ -45,7 +47,7 @@ type TasksManager struct {
 func NewTasksManager(conf *config.Config, watcher templates.Watcher,
 	state state.Store) (*TasksManager, error) {
 
-	logger := logging.Global().Named("tasks_manager")
+	logger := logging.Global().Named(tasksManagerSystemName)
 
 	baseCtrl, err := newBaseController(conf, watcher)
 	if err != nil {

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -117,8 +117,8 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
 			watcher: new(mocksTmpl.Watcher),
-			state:   state.NewInMemoryStore(conf),
 		},
+		state: state.NewInMemoryStore(conf),
 	}
 
 	t.Run("success", func(t *testing.T) {
@@ -298,8 +298,8 @@ func Test_TasksManager_TaskDelete(t *testing.T) {
 	tm := TasksManager{
 		baseController: &baseController{
 			logger: logging.NewNullLogger(),
-			state:  state.NewInMemoryStore(nil),
 		},
+		state:    state.NewInMemoryStore(nil),
 		deleteCh: make(chan string),
 	}
 
@@ -338,10 +338,10 @@ func Test_TasksManager_TaskUpdate(t *testing.T) {
 	ctx := context.Background()
 	tm := TasksManager{
 		baseController: &baseController{
-			state:   state.NewInMemoryStore(conf),
 			drivers: driver.NewDrivers(),
 			logger:  logging.NewNullLogger(),
 		},
+		state: state.NewInMemoryStore(conf),
 	}
 
 	t.Run("disable-then-enable", func(t *testing.T) {
@@ -811,8 +811,8 @@ func Test_once(t *testing.T) {
 			// Set up read-write tm with mocks
 			conf := multipleTaskConfig(tc.numTasks)
 			rw.watcher = w
+			rw.state = state.NewInMemoryStore(conf)
 			rw.baseController = &baseController{
-				state:   state.NewInMemoryStore(conf),
 				drivers: driver.NewDrivers(),
 				newDriver: func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 					taskName := task.Name()
@@ -883,8 +883,8 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 			tm := TasksManager{
 				baseController: &baseController{
 					logger: logging.NewNullLogger(),
-					state:  state.NewInMemoryStore(nil),
 				},
+				state: state.NewInMemoryStore(nil),
 			}
 			tm.baseController.drivers = drivers
 			tm.state.AddTaskEvent(event.Event{TaskName: "success"})
@@ -947,8 +947,8 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 		tm := TasksManager{
 			baseController: &baseController{
 				logger: logging.NewNullLogger(),
-				state:  state.NewInMemoryStore(nil),
 			},
+			state: state.NewInMemoryStore(nil),
 		}
 		tm.baseController.drivers = drivers
 		tm.state.AddTaskEvent(event.Event{TaskName: taskName})

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -810,9 +810,9 @@ func Test_once(t *testing.T) {
 
 			// Set up read-write tm with mocks
 			conf := multipleTaskConfig(tc.numTasks)
+			rw.watcher = w
 			rw.baseController = &baseController{
 				state:   state.NewInMemoryStore(conf),
-				watcher: w,
 				drivers: driver.NewDrivers(),
 				newDriver: func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 					taskName := task.Name()

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
-	"github.com/hashicorp/consul-terraform-sync/logging"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocksS "github.com/hashicorp/consul-terraform-sync/mocks/store"
 	mocksTmpl "github.com/hashicorp/consul-terraform-sync/mocks/templates"
@@ -32,9 +31,7 @@ var validTaskConf = config.TaskConfig{
 
 func Test_TasksManager_Task(t *testing.T) {
 	ctx := context.Background()
-	tm := TasksManager{
-		baseController: &baseController{},
-	}
+	tm := newTestTasksManager()
 
 	t.Run("success", func(t *testing.T) {
 		taskConf := validTaskConf
@@ -66,9 +63,7 @@ func Test_TasksManager_Task(t *testing.T) {
 
 func Test_TasksManager_Tasks(t *testing.T) {
 	ctx := context.Background()
-	tm := TasksManager{
-		baseController: &baseController{},
-	}
+	tm := newTestTasksManager()
 
 	t.Run("success", func(t *testing.T) {
 		taskConfs := config.TaskConfigs{
@@ -112,14 +107,9 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 		WorkingDir:   config.String(config.DefaultWorkingDir),
 	}
 	conf.Finalize()
-	tm := TasksManager{
-		baseController: &baseController{
-			drivers: driver.NewDrivers(),
-			logger:  logging.NewNullLogger(),
-			watcher: new(mocksTmpl.Watcher),
-		},
-		state: state.NewInMemoryStore(conf),
-	}
+	tm := newTestTasksManager()
+	tm.baseController.watcher = new(mocksTmpl.Watcher)
+	tm.state = state.NewInMemoryStore(conf)
 
 	t.Run("success", func(t *testing.T) {
 		taskConf := validTaskConf
@@ -192,12 +182,8 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 	// This tests what hasn't been testeed in Test_TasksManager_TaskCreate
 	ctx := context.Background()
 
-	tm := TasksManager{
-		baseController: &baseController{
-			logger:  logging.NewNullLogger(),
-			watcher: new(mocksTmpl.Watcher),
-		},
-	}
+	tm := newTestTasksManager()
+	tm.baseController.watcher = new(mocksTmpl.Watcher)
 
 	conf := &config.Config{
 		BufferPeriod: config.DefaultBufferPeriodConfig(),
@@ -295,13 +281,8 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 
 func Test_TasksManager_TaskDelete(t *testing.T) {
 	ctx := context.Background()
-	tm := TasksManager{
-		baseController: &baseController{
-			logger: logging.NewNullLogger(),
-		},
-		state:    state.NewInMemoryStore(nil),
-		deleteCh: make(chan string),
-	}
+	tm := newTestTasksManager()
+	tm.deleteCh = make(chan string)
 
 	t.Run("happy path", func(t *testing.T) {
 		drivers := driver.NewDrivers()
@@ -336,13 +317,8 @@ func Test_TasksManager_TaskUpdate(t *testing.T) {
 	conf := &config.Config{}
 	conf.Finalize()
 	ctx := context.Background()
-	tm := TasksManager{
-		baseController: &baseController{
-			drivers: driver.NewDrivers(),
-			logger:  logging.NewNullLogger(),
-		},
-		state: state.NewInMemoryStore(conf),
-	}
+	tm := newTestTasksManager()
+	tm.state = state.NewInMemoryStore(conf)
 
 	t.Run("disable-then-enable", func(t *testing.T) {
 		taskName := "task_a"
@@ -517,13 +493,9 @@ func Test_TasksManager_TaskUpdate(t *testing.T) {
 func Test_TasksManager_addTask(t *testing.T) {
 	t.Parallel()
 
-	tm := TasksManager{
-		deleteCh:        make(chan string, 1),
-		scheduleStartCh: make(chan driver.Driver, 1),
-		baseController: &baseController{
-			logger: logging.NewNullLogger(),
-		},
-	}
+	tm := newTestTasksManager()
+	tm.deleteCh = make(chan string, 1)
+	tm.scheduleStartCh = make(chan driver.Driver, 1)
 
 	t.Run("success", func(t *testing.T) {
 		// Set up driver's task object
@@ -781,7 +753,7 @@ func Test_TasksManager_CheckApply_Store(t *testing.T) {
 }
 
 func Test_once(t *testing.T) {
-	rw := &TasksManager{}
+	rw := newTestTasksManager()
 
 	testCases := []struct {
 		name     string
@@ -812,21 +784,17 @@ func Test_once(t *testing.T) {
 			conf := multipleTaskConfig(tc.numTasks)
 			rw.watcher = w
 			rw.state = state.NewInMemoryStore(conf)
-			rw.baseController = &baseController{
-				drivers: driver.NewDrivers(),
-				newDriver: func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
-					taskName := task.Name()
-					d := new(mocksD.Driver)
-					d.On("Task").Return(enabledTestTask(t, taskName)).Twice()
-					d.On("TemplateIDs").Return(nil)
-					d.On("RenderTemplate", mock.Anything).Return(false, nil).Once()
-					d.On("RenderTemplate", mock.Anything).Return(true, nil).Once()
-					d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
-					d.On("ApplyTask", mock.Anything).Return(nil).Once()
-					return d, nil
-				},
-				initConf: conf,
-				logger:   logging.NewNullLogger(),
+			rw.baseController.initConf = conf
+			rw.baseController.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+				taskName := task.Name()
+				d := new(mocksD.Driver)
+				d.On("Task").Return(enabledTestTask(t, taskName)).Twice()
+				d.On("TemplateIDs").Return(nil)
+				d.On("RenderTemplate", mock.Anything).Return(false, nil).Once()
+				d.On("RenderTemplate", mock.Anything).Return(true, nil).Once()
+				d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
+				d.On("ApplyTask", mock.Anything).Return(nil).Once()
+				return d, nil
 			}
 
 			ctx := context.Background()
@@ -858,41 +826,38 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 	mockD := new(mocksD.Driver)
 
 	testCases := []struct {
-		name  string
-		setup func(*driver.Drivers)
+		name         string
+		setupDrivers func() *driver.Drivers
 	}{
 		{
 			"success",
-			func(d *driver.Drivers) {
+			func() *driver.Drivers {
 				mockD.On("TemplateIDs").Return(nil)
-				d.Add("success", mockD)
 				mockD.On("Task").Return(enabledTestTask(t, "success"))
 				mockD.On("DestroyTask", ctx).Return()
+				d := driver.NewDrivers()
+				d.Add("success", mockD)
+				return d
 			},
 		},
 		{
 			"does_not_exist",
-			func(*driver.Drivers) {},
+			func() *driver.Drivers {
+				return driver.NewDrivers()
+			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			drivers := driver.NewDrivers()
+			tm := newTestTasksManager()
+			tm.drivers = tc.setupDrivers()
 
-			tc.setup(drivers)
-			tm := TasksManager{
-				baseController: &baseController{
-					logger: logging.NewNullLogger(),
-				},
-				state: state.NewInMemoryStore(nil),
-			}
-			tm.baseController.drivers = drivers
 			tm.state.AddTaskEvent(event.Event{TaskName: "success"})
 
 			err := tm.deleteTask(ctx, tc.name)
 
 			assert.NoError(t, err)
-			_, exists := drivers.Get(tc.name)
+			_, exists := tm.drivers.Get(tc.name)
 			assert.False(t, exists, "driver should no longer exist")
 
 			events := tm.state.GetTaskEvents(tc.name)
@@ -944,12 +909,7 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 		drivers.SetActive(taskName)
 
 		// Set up tm with drivers and store
-		tm := TasksManager{
-			baseController: &baseController{
-				logger: logging.NewNullLogger(),
-			},
-			state: state.NewInMemoryStore(nil),
-		}
+		tm := newTestTasksManager()
 		tm.baseController.drivers = drivers
 		tm.state.AddTaskEvent(event.Event{TaskName: taskName})
 

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -753,7 +753,7 @@ func Test_TasksManager_CheckApply_Store(t *testing.T) {
 }
 
 func Test_once(t *testing.T) {
-	rw := newTestTasksManager()
+	tm := newTestTasksManager()
 
 	testCases := []struct {
 		name     string
@@ -762,12 +762,12 @@ func Test_once(t *testing.T) {
 	}{
 		{
 			"consecutive one task",
-			rw.onceConsecutive,
+			tm.onceConsecutive,
 			1,
 		},
 		{
 			"consecutive multiple tasks",
-			rw.onceConsecutive,
+			tm.onceConsecutive,
 			10,
 		},
 	}
@@ -782,10 +782,10 @@ func Test_once(t *testing.T) {
 
 			// Set up read-write tm with mocks
 			conf := multipleTaskConfig(tc.numTasks)
-			rw.watcher = w
-			rw.state = state.NewInMemoryStore(conf)
-			rw.baseController.initConf = conf
-			rw.baseController.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+			tm.watcher = w
+			tm.state = state.NewInMemoryStore(conf)
+			tm.baseController.initConf = conf
+			tm.baseController.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 				taskName := task.Name()
 				d := new(mocksD.Driver)
 				d.On("Task").Return(enabledTestTask(t, taskName)).Twice()
@@ -798,7 +798,7 @@ func Test_once(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			err := rw.Init(ctx)
+			err := tm.Init(ctx)
 			require.NoError(t, err)
 
 			// testing really starts here...
@@ -814,7 +814,7 @@ func Test_once(t *testing.T) {
 				t.Fatal("Once didn't return in expected time")
 			}
 
-			for _, d := range rw.drivers.Map() {
+			for _, d := range tm.drivers.Map() {
 				d.(*mocksD.Driver).AssertExpectations(t)
 			}
 		})


### PR DESCRIPTION
Currently, baseController is embedded in TasksManager

This is the first PR in a series of changes to split out baseController from TasksManager. baseController logic is mostly around creating and initializing drivers for tasks. Currently the goal is:
 - Convert `controller.baseController` to something like `driver.Factory`
 - TasksManager will have a `driverFactory` field and call `driverFactory.Make()` for new tasks (naming input welcome)

This PR starts detangling some of the baseController fields:
 - Commit 1: pass in watcher to baseController instead of creating it
 - Commit 2: pass in state store to baseController instead of creating it
 - Commit 3-4: refactor out a baseController.makeDriver (this is the start of the driverFactory.Make)
 - Commit 5-6: create a logger for TasksManager instead of sharing with baseController
 - Commit 7: fix typos
 - Commit 8: remove watcher.Stop from baseController
 - Commit 9: test config fix

Future work: mover drivers field from baseController to TasksManager, move/rename baseController struct and methods

Note: this PR got a little bit large. The individual commits are intended to make reviewing a little easier. Please let me know if it would be helpful to go over anything in person