### PR TITLE
fixed start logs

### DIFF
--- a/command/start.go
+++ b/command/start.go
@@ -214,6 +214,9 @@ func (c *startCommand) Run(args []string) int {
 		return ExitCodeConfigError
 	}
 
+	// Reset logger now that its been setup
+	logger = logging.Global().Named(logSystemName)
+
 	// Print information on startup for debugging
 	logger.Info(version.GetHumanVersion())
 	logger.Debug("configuration", "config", conf.GoString())


### PR DESCRIPTION
- logger was initialized before configuration and used throughout startCommand.Run()
- logger needs to be reset after configuration so that it honors the config

Resolves: #789 