### PR TITLE
Update e2e test WaitForAPI

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -176,10 +176,12 @@ func (c *Client) Scheme() string {
 	return c.url.Scheme
 }
 
-// WaitForOnce checks if all the current enabled tasks have been run once by
-// polling the /v1/status/tasks endpoint. Tasks that have not run will have an
-// unknown status. Should only use if no runtime changes are being actively made.
-func (c *Client) WaitForOnce(timeout time.Duration) error {
+// WaitForTestReadiness is used by tests that start CTS to determine how long
+// to wait until CTS is in a state to be tested. Currently this is determined by
+// when all enabled tasks have been run once by polling the /v1/status/tasks
+// endpoint. Tasks that have not run will have an unknown status. This should
+// only be use if no runtime changes are being actively made.
+func (c *Client) WaitForTestReadiness(timeout time.Duration) error {
 	polling := make(chan struct{})
 	stopPolling := make(chan struct{})
 	statusAPI := c.Status()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -352,7 +352,7 @@ func Test_StatusClient_Overall(t *testing.T) {
 	assert.Equal(t, expectedOverallStatus, o)
 }
 
-func Test_WaitForOnce_success(t *testing.T) {
+func Test_WaitForTestReadiness_success(t *testing.T) {
 	expected := map[string]TaskStatus{
 		"task_a": {Enabled: true, Status: StatusCritical},
 		"task_b": {Enabled: true, Status: StatusSuccessful},
@@ -375,11 +375,11 @@ func Test_WaitForOnce_success(t *testing.T) {
 	c, err := NewClient(clientConfig, nil)
 	assert.NoError(t, err)
 
-	err = c.WaitForOnce(100 * time.Millisecond)
+	err = c.WaitForTestReadiness(100 * time.Millisecond)
 	assert.NoError(t, err)
 }
 
-func Test_WaitForOnce_timeout(t *testing.T) {
+func Test_WaitForTestReadiness_timeout(t *testing.T) {
 	cases := []struct {
 		name        string
 		handlerFunc func(w http.ResponseWriter, r *http.Request)
@@ -413,7 +413,7 @@ func Test_WaitForOnce_timeout(t *testing.T) {
 			c, err := NewClient(clientConfig, nil)
 			require.NoError(t, err)
 
-			err = c.WaitForOnce(100 * time.Millisecond)
+			err = c.WaitForTestReadiness(100 * time.Millisecond)
 			assert.Error(t, err)
 		})
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -352,13 +352,14 @@ func Test_StatusClient_Overall(t *testing.T) {
 	assert.Equal(t, expectedOverallStatus, o)
 }
 
-func Test_WaitForOnce(t *testing.T) {
-	expectedOverallStatus := OverallStatus{TaskSummary: TaskSummary{
-		Status:  StatusSummary{Successful: 1},
-		Enabled: EnabledSummary{True: 2},
-	}}
+func Test_WaitForOnce_success(t *testing.T) {
+	expected := map[string]TaskStatus{
+		"task_a": {Enabled: true, Status: StatusCritical},
+		"task_b": {Enabled: true, Status: StatusSuccessful},
+		"task_c": {Enabled: false, Status: StatusUnknown},
+	}
 
-	bytes, err := json.Marshal(&expectedOverallStatus)
+	bytes, err := json.Marshal(&expected)
 	assert.NotEmpty(t, bytes)
 	assert.NoError(t, err)
 
@@ -378,18 +379,42 @@ func Test_WaitForOnce(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_WaitForOnce_Timeout(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// do nothing
-	}))
+func Test_WaitForOnce_timeout(t *testing.T) {
+	cases := []struct {
+		name        string
+		handlerFunc func(w http.ResponseWriter, r *http.Request)
+	}{
+		{
+			"api unavailable",
+			func(w http.ResponseWriter, r *http.Request) {
+				// do nothing
+			},
+		},
+		{
+			"enabled tasks with unknown status",
+			func(w http.ResponseWriter, r *http.Request) {
+				status := map[string]TaskStatus{
+					"task_a": {Enabled: true, Status: StatusUnknown},
+				}
 
-	defer server.Close()
+				bytes, _ := json.Marshal(&status)
+				_, _ = fmt.Fprint(w, string(bytes))
+			},
+		},
+	}
 
-	clientConfig := BaseClientConfig()
-	clientConfig.URL = server.URL
-	c, err := NewClient(clientConfig, nil)
-	assert.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(tc.handlerFunc))
+			defer server.Close()
 
-	err = c.WaitForOnce(100 * time.Millisecond)
-	assert.Error(t, err)
+			clientConfig := BaseClientConfig()
+			clientConfig.URL = server.URL
+			c, err := NewClient(clientConfig, nil)
+			require.NoError(t, err)
+
+			err = c.WaitForOnce(100 * time.Millisecond)
+			assert.Error(t, err)
+		})
+	}
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
@@ -351,7 +352,7 @@ func Test_StatusClient_Overall(t *testing.T) {
 	assert.Equal(t, expectedOverallStatus, o)
 }
 
-func Test_WaitForAPI(t *testing.T) {
+func Test_WaitForOnce(t *testing.T) {
 	expectedOverallStatus := OverallStatus{TaskSummary: TaskSummary{
 		Status:  StatusSummary{Successful: 1},
 		Enabled: EnabledSummary{True: 2},
@@ -373,11 +374,11 @@ func Test_WaitForAPI(t *testing.T) {
 	c, err := NewClient(clientConfig, nil)
 	assert.NoError(t, err)
 
-	err = c.WaitForAPI(100 * time.Millisecond)
+	err = c.WaitForOnce(100 * time.Millisecond)
 	assert.NoError(t, err)
 }
 
-func Test_WaitForAPI_Timeout(t *testing.T) {
+func Test_WaitForOnce_Timeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// do nothing
 	}))
@@ -389,6 +390,6 @@ func Test_WaitForAPI_Timeout(t *testing.T) {
 	c, err := NewClient(clientConfig, nil)
 	assert.NoError(t, err)
 
-	err = c.WaitForAPI(100 * time.Millisecond)
+	err = c.WaitForOnce(100 * time.Millisecond)
 	assert.Error(t, err)
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -135,7 +135,7 @@ func TestStatus(t *testing.T) {
 
 	c, err := NewClient(createTestClientConfig(port), nil)
 	require.NoError(t, err)
-	err = c.WaitForOnce(3 * time.Second) // in case tests run before server is ready
+	err = c.WaitForTestReadiness(3 * time.Second) // in case tests run before server is ready
 	require.NoError(t, err)
 
 	t.Run("overall-status", func(t *testing.T) {
@@ -277,13 +277,13 @@ func TestStatus(t *testing.T) {
 	})
 }
 
-func TestWaitForOnce(t *testing.T) {
+func TestWaitForTestReadiness(t *testing.T) {
 	t.Parallel()
 
 	t.Run("timeout", func(t *testing.T) {
 		cts, err := NewClient(createTestClientConfig(0), nil)
 		require.NoError(t, err)
-		err = cts.WaitForOnce(time.Second)
+		err = cts.WaitForTestReadiness(time.Second)
 		assert.Error(t, err, "No CTS API server running, test is expected to timeout")
 	})
 
@@ -305,7 +305,7 @@ func TestWaitForOnce(t *testing.T) {
 
 		cts, err := NewClient(createTestClientConfig(port), nil)
 		require.NoError(t, err)
-		err = cts.WaitForOnce(3 * time.Second)
+		err = cts.WaitForTestReadiness(3 * time.Second)
 		assert.NoError(t, err, "CTS API server should be available")
 	})
 }

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -135,7 +135,7 @@ func TestStatus(t *testing.T) {
 
 	c, err := NewClient(createTestClientConfig(port), nil)
 	require.NoError(t, err)
-	err = c.WaitForAPI(3 * time.Second) // in case tests run before server is ready
+	err = c.WaitForOnce(3 * time.Second) // in case tests run before server is ready
 	require.NoError(t, err)
 
 	t.Run("overall-status", func(t *testing.T) {
@@ -277,13 +277,13 @@ func TestStatus(t *testing.T) {
 	})
 }
 
-func TestWaitForAPI(t *testing.T) {
+func TestWaitForOnce(t *testing.T) {
 	t.Parallel()
 
 	t.Run("timeout", func(t *testing.T) {
 		cts, err := NewClient(createTestClientConfig(0), nil)
 		require.NoError(t, err)
-		err = cts.WaitForAPI(time.Second)
+		err = cts.WaitForOnce(time.Second)
 		assert.Error(t, err, "No CTS API server running, test is expected to timeout")
 	})
 
@@ -305,7 +305,7 @@ func TestWaitForAPI(t *testing.T) {
 
 		cts, err := NewClient(createTestClientConfig(port), nil)
 		require.NoError(t, err)
-		err = cts.WaitForAPI(3 * time.Second)
+		err = cts.WaitForOnce(3 * time.Second)
 		assert.NoError(t, err, "CTS API server should be available")
 	})
 }

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -65,7 +65,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	cts, stopCTS := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 
 	// wait to run once before registering another instance to collect another event
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 	service := testutil.TestService{
 		ID:      "api-2",

--- a/e2e/api_test.go
+++ b/e2e/api_test.go
@@ -65,7 +65,7 @@ func TestE2E_StatusEndpoints(t *testing.T) {
 	cts, stopCTS := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 
 	// wait to run once before registering another instance to collect another event
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 	service := testutil.TestService{
 		ID:      "api-2",

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -41,7 +41,7 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	address := cts.FullAddress()
@@ -249,7 +249,7 @@ func TestE2E_ReenableTaskTriggers(t *testing.T) {
 		stop(t)
 	})
 
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test that regex filter is filtering service registration information and

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -41,7 +41,7 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 
 	cts, stop := api.StartCTS(t, configPath, api.CTSDevModeFlag)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	address := cts.FullAddress()
@@ -249,7 +249,7 @@ func TestE2E_ReenableTaskTriggers(t *testing.T) {
 		stop(t)
 	})
 
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test that regex filter is filtering service registration information and

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -31,7 +31,7 @@ const (
 
 	nullTaskName = "null_task"
 
-	defaultWaitForAPI   = 30 * time.Second
+	defaultWaitForOnce  = 30 * time.Second
 	defaultWaitForEvent = 8 * time.Second
 )
 
@@ -140,7 +140,7 @@ func testConsulBackendCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test: ConsulKV backend
@@ -162,7 +162,7 @@ func testServiceInstanceCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test adding and removing service instances
@@ -227,7 +227,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test updating service-related values
@@ -320,7 +320,7 @@ func testTagQueryCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test that filtering by tags
@@ -358,7 +358,7 @@ func testNodeValuesCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// Test updating node-related values

--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -31,8 +31,8 @@ const (
 
 	nullTaskName = "null_task"
 
-	defaultWaitForOnce  = 30 * time.Second
-	defaultWaitForEvent = 8 * time.Second
+	defaultWaitForTestReadiness = 30 * time.Second
+	defaultWaitForEvent         = 8 * time.Second
 )
 
 // TestCompatibility_Compile confirms that the compatibility test(s) are
@@ -140,7 +140,7 @@ func testConsulBackendCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test: ConsulKV backend
@@ -162,7 +162,7 @@ func testServiceInstanceCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test adding and removing service instances
@@ -227,7 +227,7 @@ func testServiceValuesCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test updating service-related values
@@ -320,7 +320,7 @@ func testTagQueryCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test that filtering by tags
@@ -358,7 +358,7 @@ func testNodeValuesCompatibility(t *testing.T, tempDir string, port int) {
 
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// Test updating node-related values

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -51,7 +51,7 @@ func TestE2EBasic(t *testing.T) {
 	// Start CTS and wait for once mode to complete before verifying
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	dbResourcesPath := filepath.Join(tempDir, dbTaskName, resourcesDir)
@@ -83,14 +83,14 @@ func TestE2EBasic(t *testing.T) {
 	now := time.Now()
 	service := testutil.TestService{ID: "web-1", Name: "web", Address: "5.5.5.5"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForOnce)
+	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForTestReadiness)
 
 	contents = testutils.CheckFile(t, true, webResourcesPath, "web-1.txt")
 	assert.Equal(t, service.Address, contents, "web-1 should be created after registering")
 
 	now = time.Now()
 	testutils.DeregisterConsulService(t, srv, service.ID)
-	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForOnce)
+	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForTestReadiness)
 
 	// web-1 should be removed after deregistering
 	testutils.CheckFile(t, false, webResourcesPath, "web-1.txt")
@@ -115,10 +115,10 @@ func TestE2ERestart(t *testing.T) {
 	config := baseConfig(tempDir).appendConsulBlock(srv).appendTerraformBlock().appendDBTask()
 	config.write(t, configPath)
 
-	runSyncStop(t, configPath, defaultWaitForOnce)
+	runSyncStop(t, configPath, defaultWaitForTestReadiness)
 
 	// rerun sync. confirm no errors e.g. recreating workspaces
-	runSyncStop(t, configPath, defaultWaitForOnce)
+	runSyncStop(t, configPath, defaultWaitForTestReadiness)
 
 	_ = cleanup()
 }
@@ -145,7 +145,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 	// wait enough for cts to cycle through once-mode successfully
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	// stop Consul

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -51,7 +51,7 @@ func TestE2EBasic(t *testing.T) {
 	// Start CTS and wait for once mode to complete before verifying
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	dbResourcesPath := filepath.Join(tempDir, dbTaskName, resourcesDir)
@@ -83,14 +83,14 @@ func TestE2EBasic(t *testing.T) {
 	now := time.Now()
 	service := testutil.TestService{ID: "web-1", Name: "web", Address: "5.5.5.5"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForAPI)
+	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForOnce)
 
 	contents = testutils.CheckFile(t, true, webResourcesPath, "web-1.txt")
 	assert.Equal(t, service.Address, contents, "web-1 should be created after registering")
 
 	now = time.Now()
 	testutils.DeregisterConsulService(t, srv, service.ID)
-	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForAPI)
+	api.WaitForEvent(t, cts, webTaskName, now, defaultWaitForOnce)
 
 	// web-1 should be removed after deregistering
 	testutils.CheckFile(t, false, webResourcesPath, "web-1.txt")
@@ -115,10 +115,10 @@ func TestE2ERestart(t *testing.T) {
 	config := baseConfig(tempDir).appendConsulBlock(srv).appendTerraformBlock().appendDBTask()
 	config.write(t, configPath)
 
-	runSyncStop(t, configPath, defaultWaitForAPI)
+	runSyncStop(t, configPath, defaultWaitForOnce)
 
 	// rerun sync. confirm no errors e.g. recreating workspaces
-	runSyncStop(t, configPath, defaultWaitForAPI)
+	runSyncStop(t, configPath, defaultWaitForOnce)
 
 	_ = cleanup()
 }
@@ -145,7 +145,7 @@ func TestE2ERestartConsul(t *testing.T) {
 	cts, stop := api.StartCTS(t, configPath)
 	defer stop(t)
 	// wait enough for cts to cycle through once-mode successfully
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	// stop Consul

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -54,7 +54,7 @@ task {
 
 	t.Run("once mode", func(t *testing.T) {
 		// Wait for all three tasks to execute once
-		err := cts.WaitForAPI(defaultWaitForAPI * 3)
+		err := cts.WaitForOnce(defaultWaitForOnce * 3)
 		require.NoError(t, err)
 
 		// Verify Catalog information is reflected in terraform.tfvars

--- a/e2e/tasks_test.go
+++ b/e2e/tasks_test.go
@@ -54,7 +54,7 @@ task {
 
 	t.Run("once mode", func(t *testing.T) {
 		// Wait for all three tasks to execute once
-		err := cts.WaitForOnce(defaultWaitForOnce * 3)
+		err := cts.WaitForTestReadiness(defaultWaitForTestReadiness * 3)
 		require.NoError(t, err)
 
 		// Verify Catalog information is reflected in terraform.tfvars

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -40,7 +40,7 @@ const (
 	// liberal default times to wait
 	defaultWaitForRegistration = 8 * time.Second
 	defaultWaitForEvent        = 15 * time.Second
-	defaultWaitForAPI          = 30 * time.Second
+	defaultWaitForOnce         = 30 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
 	defaultWaitForNoEvent = 6 * time.Second
@@ -121,7 +121,7 @@ func newTestConsulServer(t *testing.T) *testutil.TestServer {
 
 func runSyncStop(t *testing.T, configPath string, dur time.Duration) {
 	cts, stop := api.StartCTS(t, configPath)
-	err := cts.WaitForAPI(dur)
+	err := cts.WaitForOnce(dur)
 	require.NoError(t, err)
 	stop(t)
 }
@@ -189,7 +189,7 @@ func ctsSetup(t *testing.T, srv *testutil.TestServer, tempDir string, taskConfig
 		stop(t)
 	})
 
-	err := cts.WaitForAPI(defaultWaitForAPI * time.Duration(len(taskConfig)))
+	err := cts.WaitForOnce(defaultWaitForOnce * time.Duration(len(taskConfig)))
 	require.NoError(t, err)
 
 	return cts
@@ -238,7 +238,7 @@ func ctsSetupTLS(t *testing.T, srv *testutil.TestServer, tempDir string, taskCon
 		stop(t)
 	})
 
-	err := cts.WaitForAPI(defaultWaitForAPI)
+	err := cts.WaitForOnce(defaultWaitForOnce)
 	require.NoError(t, err)
 
 	return cts

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -38,9 +38,9 @@ const (
 	configFile = "config.hcl"
 
 	// liberal default times to wait
-	defaultWaitForRegistration = 8 * time.Second
-	defaultWaitForEvent        = 15 * time.Second
-	defaultWaitForOnce         = 30 * time.Second
+	defaultWaitForRegistration  = 8 * time.Second
+	defaultWaitForEvent         = 15 * time.Second
+	defaultWaitForTestReadiness = 30 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
 	defaultWaitForNoEvent = 6 * time.Second
@@ -121,7 +121,7 @@ func newTestConsulServer(t *testing.T) *testutil.TestServer {
 
 func runSyncStop(t *testing.T, configPath string, dur time.Duration) {
 	cts, stop := api.StartCTS(t, configPath)
-	err := cts.WaitForOnce(dur)
+	err := cts.WaitForTestReadiness(dur)
 	require.NoError(t, err)
 	stop(t)
 }
@@ -189,7 +189,7 @@ func ctsSetup(t *testing.T, srv *testutil.TestServer, tempDir string, taskConfig
 		stop(t)
 	})
 
-	err := cts.WaitForOnce(defaultWaitForOnce * time.Duration(len(taskConfig)))
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness * time.Duration(len(taskConfig)))
 	require.NoError(t, err)
 
 	return cts
@@ -238,7 +238,7 @@ func ctsSetupTLS(t *testing.T, srv *testutil.TestServer, tempDir string, taskCon
 		stop(t)
 	})
 
-	err := cts.WaitForOnce(defaultWaitForOnce)
+	err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
 
 	return cts


### PR DESCRIPTION
Context:
 - Currently the API is served once daemon once-mode was complete
 - A lot of tests (e2e in particular) rely on API availability to determine daemon once-mode is complete

Goal: decouple serving the API from daemon once-mode. Serve the API before daemon once-mode

This PR removes test reliance on API availability to determine daemon once-mode is complete. Instead determine once-mode completion by examining the status response rather than API availability.

Future work: move when the API is served to be before daemon once-mode