### PR TITLE
Fix syslog enabled value

### DIFF
--- a/config/syslog.go
+++ b/config/syslog.go
@@ -26,7 +26,8 @@ type SyslogConfig struct {
 // DefaultSyslogConfig returns the default configuration struct.
 func DefaultSyslogConfig() *SyslogConfig {
 	return &SyslogConfig{
-		Enabled: Bool(false),
+		// No default values. `Enabled` value depends on other fields as
+		// handled in Finalize()
 	}
 }
 


### PR DESCRIPTION
Context: syslog should be automatically enabled if other fields (e.g. facility
or name) values are provided. This is documented in CTS

Issue: syslog enabled field has to be specifically set to true. Otherwise it is
false even though other config fields are provided.

This was caused by the default was set to enabled=false. When CTS builds the
config, the user-provided config is merged with the default config. If the user
left enabled unconfigured, it would merge with the default enabled=false. This
results in enabled being set to false in a way that looks as though the user set
enabled to false.

Related: https://github.com/hashicorp/consul-terraform-sync/issues/812