### PR TITLE
Fix deprecated services warning

### DIFF
--- a/config/task.go
+++ b/config/task.go
@@ -261,7 +261,7 @@ func (c *TaskConfig) Finalize(globalBp *BufferPeriodConfig, wd string) {
 
 	if c.DeprecatedServices == nil {
 		c.DeprecatedServices = []string{}
-	} else {
+	} else if len(c.DeprecatedServices) > 0 {
 		logger.Warn(servicesFieldLogMsg)
 	}
 


### PR DESCRIPTION
Warning should only be logged if there are a non-zero number of services in the
deprecated field.

Noticed that this recently started logging even though I don't have the deprecated field set.

Checked with older versions, and previously when Finalize was called, DeprecatedServices was nil when no `services` configuration was set. At some point, it changed to being an empty but initialized list of strings. This new `else if` is the more appropriate behavior either way, so didn't really look into what made this change.