### PR TITLE
Add sleep for long running WaitForTestReadiness

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -199,6 +199,10 @@ func (c *Client) WaitForTestReadiness(timeout time.Duration) error {
 			default:
 				taskStatuses, err := statusAPI.Task("", nil)
 				if err != nil {
+					if timeout.Seconds() > 1 {
+						// Add a sleep for longer tests
+						time.Sleep(500 * time.Millisecond)
+					}
 					continue
 				}
 
@@ -211,6 +215,10 @@ func (c *Client) WaitForTestReadiness(timeout time.Duration) error {
 					}
 				}
 				if !once {
+					if timeout.Seconds() > 1 {
+						// Add a sleep for longer tests
+						time.Sleep(500 * time.Millisecond)
+					}
 					continue
 				}
 


### PR DESCRIPTION
When WaitForTestReadiness is used by e2e tests, the wait can be long. There was
a change to serve the API before once-mode. This caused WaitForTestReadiness
to use more resources, which in turn caused Consul start up to frequently
timeout in e2e tests.

Add a 500ms sleep when the timeout is expected to be 1s or more.