### PR TITLE
Tune WaitForTestReadiness sleep to 100ms

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -200,8 +200,10 @@ func (c *Client) WaitForTestReadiness(timeout time.Duration) error {
 				taskStatuses, err := statusAPI.Task("", nil)
 				if err != nil {
 					if timeout.Seconds() > 1 {
-						// Add a sleep for longer tests
-						time.Sleep(500 * time.Millisecond)
+						// Add a small sleep for longer tests. Reduces resource
+						// usage but doesn't wait too long to cause flakiness
+						// with schedule task runs
+						time.Sleep(100 * time.Millisecond)
 					}
 					continue
 				}
@@ -216,8 +218,10 @@ func (c *Client) WaitForTestReadiness(timeout time.Duration) error {
 				}
 				if !once {
 					if timeout.Seconds() > 1 {
-						// Add a sleep for longer tests
-						time.Sleep(500 * time.Millisecond)
+						// Add a small sleep for longer tests. Reduces resource
+						// usage but doesn't wait too long to cause flakiness
+						// with schedule task runs
+						time.Sleep(100 * time.Millisecond)
 					}
 					continue
 				}


### PR DESCRIPTION
The sleep was added to reduce WaitForTestReadiness impact on resources which
was causing frequent timeouts in Consul start up in e2e tests.

This sleep has since caused flakiness in e2e tests with scheduled tasks where
event runs are counted.

Example:
 - 0ms: scheduled task starts running once
 - 100ms: WaitForTestReadiness polls - not ready for tests
 - 200ms: scheduled task run once complete. 1 event added. Ready for tests
 - 300ms: scheduled task runs again on schedule (here's the problem!)
 - 400ms: scheduled task run completes. 2nd event added.
 - 500ms: WaitForTestReadiness polls - ready for tests
 - 501ms: test checks that scheduled task should have run one i.e. 1 event. Test fails

The extra run during the Wait sleep is unlikely but 500ms has a couple instances
of flakiness so far. Reducing to 100ms, which has been tested and does not lead
to Consul start up timouts