### PR TITLE
Updates to benchmark tests

### DIFF
--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -40,16 +40,16 @@ func BenchmarkTaskTrigger(b *testing.B) {
 		numServices: 25,
 	})
 
-	rwCtrl, err := controller.NewDaemon(conf)
+	ctrl, err := controller.NewDaemon(conf)
 	require.NoError(b, err)
-	err = rwCtrl.Init(ctx)
+	err = ctrl.Init(ctx)
 	require.NoError(b, err)
-	err = rwCtrl.Once(ctx)
+	err = ctrl.Once(ctx)
 	require.NoError(b, err)
 
 	ctrlStopped := make(chan error)
 	go func() {
-		err := rwCtrl.Run(ctx)
+		err := ctrl.Run(ctx)
 		ctrlStopped <- err
 	}()
 

--- a/e2e/benchmarks/task_trigger_test.go
+++ b/e2e/benchmarks/task_trigger_test.go
@@ -44,6 +44,8 @@ func BenchmarkTaskTrigger(b *testing.B) {
 	require.NoError(b, err)
 	err = ctrl.Init(ctx)
 	require.NoError(b, err)
+	defer ctrl.Stop()
+
 	err = ctrl.Once(ctx)
 	require.NoError(b, err)
 

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -79,6 +79,7 @@ func benchmarkTasksConcurrent(b *testing.B, bConf benchmarkConfig) {
 
 	err = ctrl.Init(context.Background())
 	require.NoError(b, err)
+	defer ctrl.Stop()
 
 	err = ctrl.Once(context.Background())
 	require.NoError(b, err)

--- a/e2e/benchmarks/tasks_concurrent_test.go
+++ b/e2e/benchmarks/tasks_concurrent_test.go
@@ -74,13 +74,13 @@ func benchmarkTasksConcurrent(b *testing.B, bConf benchmarkConfig) {
 
 	conf := generateConf(b, bConf)
 
-	rwCtrl, err := controller.NewDaemon(conf)
+	ctrl, err := controller.NewDaemon(conf)
 	require.NoError(b, err)
 
-	err = rwCtrl.Init(context.Background())
+	err = ctrl.Init(context.Background())
 	require.NoError(b, err)
 
-	err = rwCtrl.Once(context.Background())
+	err = ctrl.Once(context.Background())
 	require.NoError(b, err)
 
 	// This is the crux of the benchmark which evaluates the performance of
@@ -88,10 +88,10 @@ func benchmarkTasksConcurrent(b *testing.B, bConf benchmarkConfig) {
 	ctx, ctxCancel := context.WithCancel(context.Background())
 	defer ctxCancel()
 	ctrlStopped := make(chan error)
-	completedTasksCh := rwCtrl.EnableTestMode()
+	completedTasksCh := ctrl.EnableTestMode()
 
 	go func() {
-		ctrlStopped <- rwCtrl.Run(ctx)
+		ctrlStopped <- ctrl.Run(ctx)
 	}()
 
 	// Benchmark setup is done, reset the timer

--- a/e2e/benchmarks/tasks_test.go
+++ b/e2e/benchmarks/tasks_test.go
@@ -80,6 +80,7 @@ func benchmarkTasks(b *testing.B, numTasks int, numServices int) {
 
 	err = ctrl.Init(ctx)
 	require.NoError(b, err)
+	defer ctrl.Stop()
 
 	// Make an initial dependency change as setup, reset timer
 	random := rand.New(rand.NewSource(time.Now().UnixNano()))


### PR DESCRIPTION
 - Cleans up some controller variable names that were missed during controller renaming
 - Stops controllers to reduce benchmark log clutter