### PR TITLE
Self-Registration with Consul: Configurations, Consul client changes, manager

### DIFF
--- a/command/start.go
+++ b/command/start.go
@@ -195,7 +195,12 @@ func (c *startCommand) Run(args []string) int {
 		logger.Error("error building configuration", "error", err)
 		os.Exit(ExitCodeConfigError)
 	}
-	conf.Finalize()
+
+	err = conf.Finalize()
+	if err != nil {
+		logger.Error("error finalzing configuration", "error", err)
+		os.Exit(ExitCodeConfigError)
+	}
 
 	if err := conf.Validate(); err != nil {
 		logger.Error("error validating configuration", "error", err)

--- a/command/start.go
+++ b/command/start.go
@@ -198,7 +198,7 @@ func (c *startCommand) Run(args []string) int {
 
 	err = conf.Finalize()
 	if err != nil {
-		logger.Error("error finalzing configuration", "error", err)
+		logger.Error("error finalizing configuration", "error", err)
 		os.Exit(ExitCodeConfigError)
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,7 @@ var (
 		LogLevel:   String("ERR"),
 		Port:       Int(8502),
 		WorkingDir: String("working"),
+		ID:         String("cts-123"),
 		Syslog: &SyslogConfig{
 			Enabled: Bool(true),
 			Name:    String("syslog"),
@@ -385,6 +386,15 @@ func TestConfig_Finalize(t *testing.T) {
 
 	c := longConfig.Copy()
 	c.Finalize()
+
+	// Verify that ID is not nil, then hardcode since we don't know what
+	// the exact genenerated value would be. Allows us to still use
+	// assert.Equal to check all other values.
+	assert.NotNil(t, c.ID)
+	id := "cts-123"
+	c.ID = &id
+	expected.ID = &id
+
 	assert.Equal(t, expected, c)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,10 @@ var (
 				MaxIdleConnsPerHost: Int(100),
 				TLSHandshakeTimeout: TimeDuration(10 * time.Second),
 			},
+			SelfRegistration: &SelfRegistrationConfig{
+				Enabled:   Bool(true),
+				Namespace: String("test-ns"),
+			},
 		},
 		TLS: &CTSTLSConfig{
 			Enabled:        Bool(true),

--- a/config/consul.go
+++ b/config/consul.go
@@ -36,15 +36,19 @@ type ConsulConfig struct {
 
 	// Transport configures the low-level network connection details.
 	Transport *TransportConfig `mapstructure:"transport"`
+
+	// SelfRegistration configures the self-registration as a service with Consul
+	SelfRegistration *SelfRegistrationConfig `mapstructure:"self_registration"`
 }
 
 // DefaultConsulConfig returns the default configuration struct
 func DefaultConsulConfig() *ConsulConfig {
 	return &ConsulConfig{
-		Auth:      DefaultAuthConfig(),
-		KVPath:    String(DefaultConsulKVPath),
-		TLS:       DefaultTLSConfig(),
-		Transport: DefaultTransportConfig(),
+		Auth:             DefaultAuthConfig(),
+		KVPath:           String(DefaultConsulKVPath),
+		TLS:              DefaultTLSConfig(),
+		Transport:        DefaultTransportConfig(),
+		SelfRegistration: DefaultSelfRegistrationConfig(),
 	}
 }
 
@@ -74,6 +78,10 @@ func (c *ConsulConfig) Copy() *ConsulConfig {
 
 	if c.Transport != nil {
 		o.Transport = c.Transport.Copy()
+	}
+
+	if c.SelfRegistration != nil {
+		o.SelfRegistration = c.SelfRegistration.Copy()
 	}
 
 	return &o
@@ -125,6 +133,10 @@ func (c *ConsulConfig) Merge(o *ConsulConfig) *ConsulConfig {
 		r.Transport = r.Transport.Merge(o.Transport)
 	}
 
+	if o.SelfRegistration != nil {
+		r.SelfRegistration = r.SelfRegistration.Merge(o.SelfRegistration)
+	}
+
 	return r
 }
 
@@ -169,6 +181,12 @@ func (c *ConsulConfig) Finalize() {
 		c.Transport = DefaultTransportConfig()
 	}
 	c.Transport.Finalize()
+
+	if c.SelfRegistration == nil {
+		c.SelfRegistration = DefaultSelfRegistrationConfig()
+	}
+	c.SelfRegistration.Finalize()
+
 }
 
 // GoString defines the printable version of this struct.
@@ -185,7 +203,8 @@ func (c *ConsulConfig) GoString() string {
 		"KVPath:%s, "+
 		"TLS:%s, "+
 		"Token:%s, "+
-		"Transport:%s"+
+		"Transport:%s, "+
+		"SelfRegistration:%s"+
 		"}",
 		StringVal(c.Address),
 		c.Auth.GoString(),
@@ -194,6 +213,7 @@ func (c *ConsulConfig) GoString() string {
 		c.TLS.GoString(),
 		sensitiveGoString(c.Token),
 		c.Transport.GoString(),
+		c.SelfRegistration.GoString(),
 	)
 }
 

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -39,6 +39,10 @@ func TestConsulConfig_Copy(t *testing.T) {
 				KVNamespace: String("org"),
 				TLS:         &TLSConfig{Enabled: Bool(true)},
 				Token:       String("abcd1234"),
+				SelfRegistration: &SelfRegistrationConfig{
+					Enabled:   Bool(false),
+					Namespace: String("test-ns"),
+				},
 			},
 		},
 	}
@@ -204,6 +208,30 @@ func TestConsulConfig_Merge(t *testing.T) {
 			&ConsulConfig{Transport: &TransportConfig{DialKeepAlive: TimeDuration(10 * time.Second)}},
 			&ConsulConfig{Transport: &TransportConfig{DialKeepAlive: TimeDuration(10 * time.Second)}},
 		},
+		{
+			"self_registration_overrides",
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(false)}},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(false)}},
+		},
+		{
+			"self_registration_empty_one",
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+			&ConsulConfig{},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+		},
+		{
+			"self_registration_empty_two",
+			&ConsulConfig{},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+		},
+		{
+			"self_registration_same",
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+			&ConsulConfig{SelfRegistration: &SelfRegistrationConfig{Enabled: Bool(true)}},
+		},
 	}
 
 	for i, tc := range cases {
@@ -252,6 +280,10 @@ func TestConsulConfig_Finalize(t *testing.T) {
 					MaxIdleConns:        Int(DefaultMaxIdleConns),
 					MaxIdleConnsPerHost: Int(DefaultMaxIdleConnsPerHost),
 					TLSHandshakeTimeout: TimeDuration(DefaultTLSHandshakeTimeout),
+				},
+				SelfRegistration: &SelfRegistrationConfig{
+					Enabled:   Bool(true),
+					Namespace: String(""),
 				},
 			},
 		},

--- a/config/self_registration.go
+++ b/config/self_registration.go
@@ -2,11 +2,15 @@ package config
 
 import "fmt"
 
+// SelfRegistrationConfig is a configuration that controls how CTS will
+// self-register itself as a service with Consul.
 type SelfRegistrationConfig struct {
 	Enabled   *bool   `mapstructure:"enabled"`
 	Namespace *string `mapstructure:"namespace"`
 }
 
+// DefaultSelfRegistrationConfig returns a SelfRegistrationConfig with
+// default values.
 func DefaultSelfRegistrationConfig() *SelfRegistrationConfig {
 	return &SelfRegistrationConfig{
 		Enabled:   Bool(true),
@@ -14,6 +18,7 @@ func DefaultSelfRegistrationConfig() *SelfRegistrationConfig {
 	}
 }
 
+// Copy returns a deep copy of this configuration.
 func (c *SelfRegistrationConfig) Copy() *SelfRegistrationConfig {
 	if c == nil {
 		return nil
@@ -26,6 +31,8 @@ func (c *SelfRegistrationConfig) Copy() *SelfRegistrationConfig {
 	return &o
 }
 
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
 func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrationConfig {
 	if c == nil {
 		if o == nil {
@@ -51,6 +58,7 @@ func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrat
 	return r
 }
 
+// Finalize ensures that the receiver contains no nil pointers.
 func (c *SelfRegistrationConfig) Finalize() {
 	if c.Enabled == nil {
 		c.Enabled = Bool(true)
@@ -61,6 +69,7 @@ func (c *SelfRegistrationConfig) Finalize() {
 	}
 }
 
+// GoString defines the printable version of this struct.
 func (c *SelfRegistrationConfig) GoString() string {
 	if c == nil {
 		return "(*SelfRegistrationConfig)(nil)"

--- a/config/self_registration.go
+++ b/config/self_registration.go
@@ -1,0 +1,76 @@
+package config
+
+import "fmt"
+
+type SelfRegistrationConfig struct {
+	Enabled   *bool   `mapstructure:"enabled"`
+	Namespace *string `mapstructure:"namespace"`
+}
+
+func DefaultSelfRegistrationConfig() *SelfRegistrationConfig {
+	return &SelfRegistrationConfig{
+		Enabled:   Bool(true),
+		Namespace: String(""),
+	}
+}
+
+func (c *SelfRegistrationConfig) Copy() *SelfRegistrationConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o SelfRegistrationConfig
+	o.Enabled = BoolCopy(c.Enabled)
+	o.Namespace = StringCopy(c.Namespace)
+
+	return &o
+}
+
+func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrationConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.Enabled != nil {
+		r.Enabled = BoolCopy(o.Enabled)
+	}
+
+	if o.Namespace != nil {
+		r.Namespace = StringCopy(o.Namespace)
+	}
+
+	return r
+}
+
+func (c *SelfRegistrationConfig) Finalize() {
+	if c.Enabled == nil {
+		c.Enabled = Bool(true)
+	}
+
+	if c.Namespace == nil {
+		c.Namespace = String("")
+	}
+}
+
+func (c *SelfRegistrationConfig) GoString() string {
+	if c == nil {
+		return "(*SelfRegistrationConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&SelfRegistrationConfig{"+
+		"Enabled:%v, "+
+		"Namespace:%s"+
+		"}",
+		BoolVal(c.Enabled),
+		StringVal(c.Namespace),
+	)
+}

--- a/config/self_registration_test.go
+++ b/config/self_registration_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelfRegistrationConfig_DefaultSelfRegistrationConfig(t *testing.T) {
+	t.Parallel()
+	r := DefaultSelfRegistrationConfig()
+	expected := &SelfRegistrationConfig{
+		Enabled:   Bool(true),
+		Namespace: String(""),
+	}
+	assert.Equal(t, expected, r)
+}
+
+func TestSelfRegistrationConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	finalizedConf := &SelfRegistrationConfig{}
+	finalizedConf.Finalize()
+
+	cases := []struct {
+		name string
+		a    *SelfRegistrationConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&SelfRegistrationConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
+		},
+		{
+			"fully_configured",
+			&SelfRegistrationConfig{
+				Enabled:   Bool(false),
+				Namespace: String("test"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
+func TestSelfRegistrationConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *SelfRegistrationConfig
+		b    *SelfRegistrationConfig
+		r    *SelfRegistrationConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{},
+		},
+		{
+			"nil_b",
+			&SelfRegistrationConfig{},
+			nil,
+			&SelfRegistrationConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{},
+		},
+		{
+			"enabled_overrides",
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+			&SelfRegistrationConfig{Enabled: Bool(true)},
+			&SelfRegistrationConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_empty_one",
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_empty_two",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_same",
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+			&SelfRegistrationConfig{Enabled: Bool(false)},
+		},
+		{
+			"namespace_overrides",
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+			&SelfRegistrationConfig{Namespace: String("ns_b")},
+			&SelfRegistrationConfig{Namespace: String("ns_b")},
+		},
+		{
+			"namespace_empty_one",
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+		},
+		{
+			"namespace_empty_two",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+		},
+		{
+			"namespace_same",
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+			&SelfRegistrationConfig{Namespace: String("ns_a")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestSelfRegistrationConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    *SelfRegistrationConfig
+		r    *SelfRegistrationConfig
+	}{
+		{
+			"empty",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{
+				Enabled:   Bool(true),
+				Namespace: String(""),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestSelfRegistrationConfig_GoString(t *testing.T) {
+	cases := []struct {
+		name     string
+		c        *SelfRegistrationConfig
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*SelfRegistrationConfig)(nil)",
+		},
+		{
+			"fully_configured",
+			&SelfRegistrationConfig{
+				Enabled:   Bool(true),
+				Namespace: String("test"),
+			},
+			"&SelfRegistrationConfig{" +
+				"Enabled:true, " +
+				"Namespace:test" +
+				"}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.c.GoString()
+			assert.Equal(t, tc.expected, r)
+		})
+	}
+}

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -46,6 +46,10 @@ consul {
     max_idle_conns_per_host = 100
     tls_handshake_timeout = "10s"
   }
+  self_registration {
+    enabled = true
+    namespace = "test-ns"
+  }
 }
 
 driver "terraform" {

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -1,6 +1,7 @@
 log_level = "ERR"
 port = 8502
 working_dir = "working"
+id = "cts-123"
 
 syslog {
   enabled = true

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -2,6 +2,7 @@
   "log_level": "ERR",
   "port": "8502",
   "working_dir": "working",
+  "id": "cts-123",
   "syslog": {
     "enabled": true,
     "name": "syslog"
@@ -110,7 +111,7 @@
             "path": "key-path",
             "recurse": true,
             "datacenter": "dc2",
-            "namespace": "ns2"  
+            "namespace": "ns2"
           }
         }
       ]

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -42,6 +42,10 @@
       "idle_conn_timeout": "1m",
       "max_idle_conns_per_host": 100,
       "tls_handshake_timeout": "10s"
+    },
+    "self_registration": {
+      "enabled": true,
+      "namespace": "test-ns"
     }
   },
   "driver": {

--- a/mocks/client/consul_client.go
+++ b/mocks/client/consul_client.go
@@ -15,6 +15,20 @@ type ConsulClientInterface struct {
 	mock.Mock
 }
 
+// DeregisterService provides a mock function with given fields: ctx, serviceID
+func (_m *ConsulClientInterface) DeregisterService(ctx context.Context, serviceID string) error {
+	ret := _m.Called(ctx, serviceID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, serviceID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetLicense provides a mock function with given fields: ctx, q
 func (_m *ConsulClientInterface) GetLicense(ctx context.Context, q *api.QueryOptions) (string, error) {
 	ret := _m.Called(ctx, q)
@@ -36,23 +50,16 @@ func (_m *ConsulClientInterface) GetLicense(ctx context.Context, q *api.QueryOpt
 	return r0, r1
 }
 
-// IsEnterprise provides a mock function with given fields: ctx
-func (_m *ConsulClientInterface) IsEnterprise(ctx context.Context) (bool, error) {
-	ret := _m.Called(ctx)
+// RegisterService provides a mock function with given fields: ctx, s
+func (_m *ConsulClientInterface) RegisterService(ctx context.Context, s *api.AgentServiceRegistration) error {
+	ret := _m.Called(ctx, s)
 
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
-		r0 = rf(ctx)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.AgentServiceRegistration) error); ok {
+		r0 = rf(ctx, s)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -1,0 +1,129 @@
+package registration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/consul-terraform-sync/client"
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	consulapi "github.com/hashicorp/consul/api"
+)
+
+const (
+	// Service defaults
+	defaultServiceName = "Consul-Terraform-Sync"
+	defaultNamespace   = ""
+
+	// Check defaults
+	defaultCheckName                      = "CTS Health Status"
+	defaultCheckNotes                     = "Check created by Consul-Terraform-Sync"
+	defaultDeregisterCriticalServiceAfter = "30m"
+	defaultCheckStatus                    = consulapi.HealthCritical
+
+	// HTTP-specific check defaults
+	defaultEndpoint      = "/v1/status" // TODO: temporary until /v1/health is implemented
+	defaultMethod        = "GET"
+	defaultInterval      = "10s"
+	defaultTimeout       = "2s"
+	defaultTLSSkipVerify = true
+
+	logSystemName = "registration"
+)
+
+var defaultServiceTags = []string{"cts"}
+
+// RegistrationManager handles the registration of a service and the health checks for that service
+// to Consul.
+type RegistrationManager struct {
+	client  client.ConsulClientInterface
+	service *service
+
+	logger logging.Logger
+}
+
+type RegistrationManagerConfig struct {
+	ID               string
+	Port             int
+	TLSEnabled       bool
+	SelfRegistration *config.SelfRegistrationConfig
+}
+
+type service struct {
+	name      string
+	id        string
+	tags      []string
+	port      int
+	namespace string
+
+	checks []*consulapi.AgentServiceCheck
+}
+
+func NewRegistrationManager(conf *RegistrationManagerConfig, client client.ConsulClientInterface) *RegistrationManager {
+	logger := logging.Global().Named(logSystemName)
+
+	name := defaultServiceName
+
+	ns := defaultNamespace
+	if conf.SelfRegistration.Namespace != nil {
+		ns = *conf.SelfRegistration.Namespace
+	}
+
+	var checks []*consulapi.AgentServiceCheck
+	checks = append(checks, defaultHTTPCheck(conf))
+
+	return &RegistrationManager{
+		client: client,
+		logger: logger,
+		service: &service{
+			name:      name,
+			id:        conf.ID,
+			tags:      defaultServiceTags,
+			port:      conf.Port,
+			namespace: ns,
+			checks:    checks,
+		},
+	}
+}
+
+func (m *RegistrationManager) RegisterService(ctx context.Context) error {
+	s := m.service
+	r := &consulapi.AgentServiceRegistration{
+		ID:        s.id,
+		Name:      s.name,
+		Tags:      s.tags,
+		Port:      s.port,
+		Checks:    s.checks,
+		Namespace: s.namespace,
+	}
+
+	m.logger.Debug("registering service with Consul", "name", s.name, "id", s.id)
+	err := m.client.RegisterService(ctx, r)
+	if err != nil {
+		m.logger.Error("error registering service with Consul", "name", s.name, "id", s.id)
+		return err
+	}
+	return nil
+}
+
+func defaultHTTPCheck(conf *RegistrationManagerConfig) *consulapi.AgentServiceCheck {
+	var protocol string
+	if conf.TLSEnabled {
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+	address := fmt.Sprintf("%s://localhost:%d%s", protocol, conf.Port, defaultEndpoint)
+	return &consulapi.AgentServiceCheck{
+		Name:                           defaultCheckName,
+		CheckID:                        fmt.Sprintf("%s-health", conf.ID),
+		Notes:                          defaultCheckNotes,
+		DeregisterCriticalServiceAfter: defaultDeregisterCriticalServiceAfter,
+		Status:                         defaultCheckStatus,
+		HTTP:                           address,
+		Method:                         defaultMethod,
+		Interval:                       defaultInterval,
+		Timeout:                        defaultTimeout,
+		TLSSkipVerify:                  defaultTLSSkipVerify,
+	}
+}

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRegistrationManager(t *testing.T) {
+func TestNewSelfRegistrationManager(t *testing.T) {
 	testcases := []struct {
 		name            string
-		conf            *RegistrationManagerConfig
+		conf            *SelfRegistrationManagerConfig
 		expectedService *service
 	}{
 		{
 			"defaults",
-			&RegistrationManagerConfig{
+			&SelfRegistrationManagerConfig{
 				ID:               "cts-123",
 				Port:             123,
 				TLSEnabled:       false,
@@ -40,7 +40,7 @@ func TestNewRegistrationManager(t *testing.T) {
 		},
 		{
 			"namespace",
-			&RegistrationManagerConfig{
+			&SelfRegistrationManagerConfig{
 				ID:         "cts-123",
 				Port:       123,
 				TLSEnabled: false,
@@ -60,7 +60,7 @@ func TestNewRegistrationManager(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			client := new(mocks.ConsulClientInterface)
-			m := NewRegistrationManager(tc.conf, client)
+			m := NewSelfRegistrationManager(tc.conf, client)
 
 			// Verify general attributes
 			assert.NotNil(t, m)
@@ -85,7 +85,7 @@ func TestNewRegistrationManager(t *testing.T) {
 	}
 }
 
-func TestRegistrationManager_defaultHTTPCheck(t *testing.T) {
+func TestSelfRegistrationManager_defaultHTTPCheck(t *testing.T) {
 	id := "cts-123"
 	port := 8558
 	// TODO: update these addresses when /v1/health implemented
@@ -95,12 +95,12 @@ func TestRegistrationManager_defaultHTTPCheck(t *testing.T) {
 
 	testcases := []struct {
 		name     string
-		conf     *RegistrationManagerConfig
+		conf     *SelfRegistrationManagerConfig
 		expected *consulapi.AgentServiceCheck
 	}{
 		{
 			"tls_disabled",
-			&RegistrationManagerConfig{
+			&SelfRegistrationManagerConfig{
 				ID:               id,
 				Port:             port,
 				TLSEnabled:       false,
@@ -121,7 +121,7 @@ func TestRegistrationManager_defaultHTTPCheck(t *testing.T) {
 		},
 		{
 			"tls_enabled",
-			&RegistrationManagerConfig{
+			&SelfRegistrationManagerConfig{
 				ID:               id,
 				Port:             port,
 				TLSEnabled:       true,
@@ -149,11 +149,11 @@ func TestRegistrationManager_defaultHTTPCheck(t *testing.T) {
 	}
 }
 
-func TestRegistrationManager_RegisterService(t *testing.T) {
+func TestSelfRegistrationManager_SelfRegisterService(t *testing.T) {
 	id := "cts-123"
 	port := 8558
 	ns := "ns-1"
-	check := defaultHTTPCheck(&RegistrationManagerConfig{
+	check := defaultHTTPCheck(&SelfRegistrationManagerConfig{
 		ID:   id,
 		Port: port,
 		SelfRegistration: &config.SelfRegistrationConfig{
@@ -202,13 +202,13 @@ func TestRegistrationManager_RegisterService(t *testing.T) {
 			mockClient := new(mocks.ConsulClientInterface)
 			tc.setup(mockClient)
 
-			m := &RegistrationManager{
+			m := &SelfRegistrationManager{
 				client:  mockClient,
 				service: service,
 				logger:  logging.NewNullLogger(),
 			}
 
-			err := m.RegisterService(context.Background())
+			err := m.SelfRegisterService(context.Background())
 
 			if !tc.expectErr {
 				require.NoError(t, err)

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -1,0 +1,221 @@
+package registration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
+	consulapi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegistrationManager(t *testing.T) {
+	testcases := []struct {
+		name            string
+		conf            *RegistrationManagerConfig
+		expectedService *service
+	}{
+		{
+			"defaults",
+			&RegistrationManagerConfig{
+				ID:               "cts-123",
+				Port:             123,
+				TLSEnabled:       false,
+				SelfRegistration: config.DefaultSelfRegistrationConfig(),
+			},
+			&service{
+				name:      defaultServiceName,
+				tags:      defaultServiceTags,
+				id:        "cts-123",
+				port:      123,
+				namespace: "",
+			},
+		},
+		{
+			"namespace",
+			&RegistrationManagerConfig{
+				ID:         "cts-123",
+				Port:       123,
+				TLSEnabled: false,
+				SelfRegistration: &config.SelfRegistrationConfig{
+					Namespace: config.String("ns-1"),
+				},
+			},
+			&service{
+				name:      defaultServiceName,
+				tags:      defaultServiceTags,
+				id:        "cts-123",
+				port:      123,
+				namespace: "ns-1",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := new(mocks.ConsulClientInterface)
+			m := NewRegistrationManager(tc.conf, client)
+
+			// Verify general attributes
+			assert.NotNil(t, m)
+			assert.Equal(t, m.client, client)
+			assert.NotNil(t, m.logger)
+
+			// Verify service attributes
+			assert.NotNil(t, m.service)
+			assert.Equal(t, tc.expectedService.name, m.service.name)
+			assert.Equal(t, tc.expectedService.id, m.service.id)
+			assert.Equal(t, tc.expectedService.tags, m.service.tags)
+			assert.Equal(t, tc.expectedService.port, m.service.port)
+			assert.Equal(t, tc.expectedService.namespace, m.service.namespace)
+
+			// Verify service has default health check
+			assert.NotNil(t, m.service.checks)
+			assert.Equal(t, 1, len(m.service.checks))
+			check := m.service.checks[0]
+			defaultCheck := defaultHTTPCheck(tc.conf)
+			assert.Equal(t, defaultCheck, check)
+		})
+	}
+}
+
+func TestRegistrationManager_defaultHTTPCheck(t *testing.T) {
+	id := "cts-123"
+	port := 8558
+	// TODO: update these addresses when /v1/health implemented
+	httpAddress := fmt.Sprintf("http://localhost:%d/v1/status", port)
+	httpsAddress := fmt.Sprintf("https://localhost:%d/v1/status", port)
+	checkID := fmt.Sprintf("%s-health", id)
+
+	testcases := []struct {
+		name     string
+		conf     *RegistrationManagerConfig
+		expected *consulapi.AgentServiceCheck
+	}{
+		{
+			"tls_disabled",
+			&RegistrationManagerConfig{
+				ID:               id,
+				Port:             port,
+				TLSEnabled:       false,
+				SelfRegistration: config.DefaultSelfRegistrationConfig(),
+			},
+			&consulapi.AgentServiceCheck{
+				HTTP:                           httpAddress,
+				Name:                           defaultCheckName,
+				CheckID:                        checkID,
+				Notes:                          defaultCheckNotes,
+				DeregisterCriticalServiceAfter: defaultDeregisterCriticalServiceAfter,
+				Status:                         defaultCheckStatus,
+				Method:                         defaultMethod,
+				Interval:                       defaultInterval,
+				Timeout:                        defaultTimeout,
+				TLSSkipVerify:                  defaultTLSSkipVerify,
+			},
+		},
+		{
+			"tls_enabled",
+			&RegistrationManagerConfig{
+				ID:               id,
+				Port:             port,
+				TLSEnabled:       true,
+				SelfRegistration: config.DefaultSelfRegistrationConfig(),
+			},
+			&consulapi.AgentServiceCheck{
+				HTTP:                           httpsAddress,
+				Name:                           defaultCheckName,
+				CheckID:                        checkID,
+				Notes:                          defaultCheckNotes,
+				DeregisterCriticalServiceAfter: defaultDeregisterCriticalServiceAfter,
+				Status:                         defaultCheckStatus,
+				Method:                         defaultMethod,
+				Interval:                       defaultInterval,
+				Timeout:                        defaultTimeout,
+				TLSSkipVerify:                  defaultTLSSkipVerify,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := defaultHTTPCheck(tc.conf)
+			assert.Equal(t, tc.expected, c)
+		})
+	}
+}
+
+func TestRegistrationManager_RegisterService(t *testing.T) {
+	id := "cts-123"
+	port := 8558
+	ns := "ns-1"
+	check := defaultHTTPCheck(&RegistrationManagerConfig{
+		ID:   id,
+		Port: port,
+		SelfRegistration: &config.SelfRegistrationConfig{
+			Namespace: &ns,
+		},
+	})
+	service := &service{
+		name:      defaultServiceName,
+		tags:      defaultServiceTags,
+		port:      port,
+		id:        id,
+		namespace: ns,
+		checks:    []*consulapi.AgentServiceCheck{check},
+	}
+	testcases := []struct {
+		name      string
+		setup     func(*mocks.ConsulClientInterface)
+		expectErr bool
+	}{
+		{
+			"success",
+			func(cMock *mocks.ConsulClientInterface) {
+				cMock.On("RegisterService", mock.Anything,
+					mock.MatchedBy(func(r *consulapi.AgentServiceRegistration) bool {
+						// expect these values as for the service registration request
+						return r.ID == id &&
+							r.Name == defaultServiceName &&
+							r.Port == port &&
+							r.Namespace == ns &&
+							reflect.DeepEqual(r.Tags, defaultServiceTags) &&
+							reflect.DeepEqual(r.Checks, consulapi.AgentServiceChecks{check})
+					})).Return(nil)
+			},
+			false,
+		},
+		{
+			"registration_errors",
+			func(cMock *mocks.ConsulClientInterface) {
+				cMock.On("RegisterService", mock.Anything, mock.Anything).Return(errors.New("mock error"))
+			},
+			true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := new(mocks.ConsulClientInterface)
+			tc.setup(mockClient)
+
+			m := &RegistrationManager{
+				client:  mockClient,
+				service: service,
+				logger:  logging.NewNullLogger(),
+			}
+
+			err := m.RegisterService(context.Background())
+
+			if !tc.expectErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			mockClient.AssertExpectations(t)
+		})
+	}
+}

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -67,20 +67,12 @@ func TestNewSelfRegistrationManager(t *testing.T) {
 			assert.Equal(t, m.client, client)
 			assert.NotNil(t, m.logger)
 
-			// Verify service attributes
+			// Verify service attributes and health check attributes
 			assert.NotNil(t, m.service)
-			assert.Equal(t, tc.expectedService.name, m.service.name)
-			assert.Equal(t, tc.expectedService.id, m.service.id)
-			assert.Equal(t, tc.expectedService.tags, m.service.tags)
-			assert.Equal(t, tc.expectedService.port, m.service.port)
-			assert.Equal(t, tc.expectedService.namespace, m.service.namespace)
-
-			// Verify service has default health check
-			assert.NotNil(t, m.service.checks)
-			assert.Equal(t, 1, len(m.service.checks))
-			check := m.service.checks[0]
-			defaultCheck := defaultHTTPCheck(tc.conf)
-			assert.Equal(t, defaultCheck, check)
+			if tc.expectedService.checks == nil {
+				tc.expectedService.checks = []*consulapi.AgentServiceCheck{defaultHTTPCheck(tc.conf)}
+			}
+			assert.Equal(t, tc.expectedService, m.service)
 		})
 	}
 }


### PR DESCRIPTION
First part of implementing self-registration, mostly setting the groundwork and not actually doing any registration yet. 

**Overview of changes**
- Adds configuration for self-registration, which includes a top-level `id` config and a `self_registration` config under the existing `consul` config.
  - If `id` is not provided, it is automatically generated in the format of `cts-<uuid>`.
  -  A `name` configuration was still under discussion when I started this implementation and will be added in a follow up PR.
- Adds service registration and deregistration methods to the Consul client
  - These methods are not currently taking advantage of the improved retry logic added in https://github.com/hashicorp/consul-terraform-sync/pull/818
- Adds a service registration manager, which can register a service with a default HTTP health check
  - Not yet being used by CTS. Plan to add a `Start()` method that will be called in the daemon controller `Run()`
  - HTTP check is using `/v1/status` for now until `/v1/health` is implemented. Main advantage of `/v1/health` is that requests to it will not be logged, so health check polling will not clutter the logs. (see https://github.com/hashicorp/consul-terraform-sync/pull/823)
 