### PR TITLE
Add config key to the promote-staging event

### DIFF
--- a/.release/ci.hcl
+++ b/.release/ci.hcl
@@ -164,6 +164,7 @@ event "promote-staging" {
     organization = "hashicorp"
     repository = "crt-workflows-common"
     workflow = "promote-staging"
+    config = "release-metadata.hcl"
   }
 
   notification {


### PR DESCRIPTION
We need to pass the `release-metadata.hcl` filename to the promote-staging workflow prior to the RelAPI launch on May 9th.

Note: it looks like my `.hcl` linter found a missing `}` at the end of the `promote-production-packaging` event -- LMK if it was intentional to leave that out. 