### PR TITLE
Log when dynamic task apply errors

### DIFF
--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -134,6 +134,7 @@ func (tm *TasksManager) runDynamicTask(ctx context.Context, d driver.Driver) err
 	}
 	complete, err := tm.checkApply(ctx, d, true, false)
 	if err != nil {
+		tm.logger.Error("error applying task", taskNameLogKey, taskName, "error", err)
 		return err
 	}
 
@@ -198,8 +199,7 @@ func (tm *TasksManager) runScheduledTask(ctx context.Context, d driver.Driver, s
 			complete, err := tm.checkApply(ctx, d, true, false)
 			if err != nil {
 				// print error but continue
-				tm.logger.Error("error applying task %q: %s",
-					taskNameLogKey, taskName, "error", err)
+				tm.logger.Error("error applying task", taskNameLogKey, taskName, "error", err)
 			}
 
 			if tm.taskNotify != nil && complete {


### PR DESCRIPTION
We weren't logging previously, so there was no indicator that a task
has failed and was no longer executing.

New logs for a dynamic task:
```
2022-05-03T11:14:18.296-0500 [INFO]  tasksmanager: executing task: task_name=failing
2022-05-03T11:14:23.269-0500 [WARN]  task: retrying: attempt_number=2 description="ApplyTask failing"
2022-05-03T11:14:23.640-0500 [ERROR] tasksmanager: error applying task: task_name=failing
  error=
  | could not apply changes for task failing: retry attempt #2 failed 'error tf-apply for 'failing': exit status 1
  | 
  | Error: open .terraform/modules/failing/foo.txt: no such file or directory
  | 
  |   with module.failing.data.local_file.foo,
  |   on .terraform/modules/failing/main.tf line 6, in data "local_file" "foo":
  |    6: data "local_file" "foo" {
  | 
  | ': retry attempt #1 failed 'error tf-apply for 'failing': exit status 1
  | 
  | Error: open .terraform/modules/failing/foo.txt: no such file or directory
  | 
  |   with module.failing.data.local_file.foo,
  |   on .terraform/modules/failing/main.tf line 6, in data "local_file" "foo":
  |    6: data "local_file" "foo" {
  | 
  | '
```

One thing to note is that failure on initialization will log this error twice, once in the task manager and once in the cli when the error is returned to the cli from the controller. I didn't want to potentially miss logging any other controller errors, though, so didn't address this duplication in this PR. 
```
2022-05-03T11:19:06.612-0500 [INFO]  templates.tftmpl: overwriting file in root module for task: file_name=providers.auto.tfvars task_name=failing_scheduled
2022-05-03T11:19:08.247-0500 [ERROR] tasksmanager: error applying task: task_name=failing_scheduled
  error=
  | error tf-apply for 'failing_scheduled': exit status 1
  | 
  | Error: open .terraform/modules/failing_scheduled/foo.txt: no such file or directory
  | 
  |   with module.failing_scheduled.data.local_file.foo,
  |   on .terraform/modules/failing_scheduled/main.tf line 6, in data "local_file" "foo":
  |    6: data "local_file" "foo" {
  | 
  
2022-05-03T11:19:08.247-0500 [ERROR] cli: error running controller:
  error=
  | error tf-apply for 'failing_scheduled': exit status 1
  | 
  | Error: open .terraform/modules/failing_scheduled/foo.txt: no such file or directory
  | 
  |   with module.failing_scheduled.data.local_file.foo,
  |   on .terraform/modules/failing_scheduled/main.tf line 6, in data "local_file" "foo":
  |    6: data "local_file" "foo" {
  | 
 
```

This is happening in 0.5.X as well. I can open a separate PR to fix this if we want it backported since the backport-assistant won't be able to cleanly cherry-pick this.
