### PR TITLE
Refactor monitoring/triggering out of TasksManager (pt1)

### DIFF
--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -18,10 +18,6 @@ type ConditionMonitor struct {
 	// TODO: placeholder. Will convert TaskManager methods to ConditionMonitor
 }
 
-func (tm *TasksManager) Stop() {
-	tm.watcher.Stop()
-}
-
 // WatchDep is a helper method to start watching dependencies to allow templates
 // to render. It will run until the caller cancels the context.
 func (tm *TasksManager) WatchDep(ctx context.Context) error {

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -216,15 +216,6 @@ func (tm *TasksManager) runScheduledTask(ctx context.Context, d driver.Driver, s
 	}
 }
 
-// EnableTestMode is a helper for testing which tasks were triggered and
-// executed. Callers of this method must consume from TaskNotify channel to
-// prevent the buffered channel from filling and causing a dead lock.
-func (tm *TasksManager) EnableTestMode() <-chan string {
-	tasks := tm.state.GetAllTasks()
-	tm.taskNotify = make(chan string, tasks.Len())
-	return tm.taskNotify
-}
-
 // logDepSize logs the watcher dependency size every nth iteration. Set the
 // iterator to a negative value to log each iteration.
 func (tm *TasksManager) logDepSize(n uint, i int64) {

--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -34,7 +34,7 @@ func Test_Daemon_Run_long(t *testing.T) {
 	tm.state = state.NewInMemoryStore(&config.Config{
 		Port: config.Int(port),
 	})
-	ctl.tasksManager = &tm
+	ctl.tasksManager = tm
 
 	t.Run("cancel exits successfully", func(t *testing.T) {
 		errCh := make(chan error)
@@ -115,7 +115,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	tm := newTestTasksManager()
 	tm.watcherCh = make(chan string, 5)
 	tm.state = st
-	rw.tasksManager = &tm
+	rw.tasksManager = tm
 
 	// Mock driver
 	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {

--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -115,6 +115,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	tm := newTestTasksManager()
 	tm.watcherCh = make(chan string, 5)
 	tm.state = st
+	completedTasksCh := tm.EnableTestMode()
 	rw.tasksManager = tm
 
 	// Mock driver
@@ -134,7 +135,6 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	errCh := make(chan error)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	completedTasksCh := tm.EnableTestMode()
 
 	// Mock watcher
 	w := new(mocksTmpl.Watcher)

--- a/controller/inspect_test.go
+++ b/controller/inspect_test.go
@@ -91,7 +91,7 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = &tm
+	ro.tasksManager = tm
 
 	// Mock watcher
 	waitErrCh := make(chan error)
@@ -161,7 +161,7 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = &tm
+	ro.tasksManager = tm
 
 	// Mock watcher
 	expectedErr := errors.New("error!")
@@ -221,7 +221,7 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = &tm
+	ro.tasksManager = tm
 
 	// Mock watcher
 	errCh := make(chan error)

--- a/controller/once_test.go
+++ b/controller/once_test.go
@@ -115,7 +115,7 @@ func Test_Once_onceConsecutive_context_canceled(t *testing.T) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ctrl.tasksManager = &tm
+	ctrl.tasksManager = tm
 
 	// Set up driver factory
 	tm.factory.initConf = conf
@@ -175,7 +175,7 @@ func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig,
 	tm := newTestTasksManager()
 	tm.state = ss
 	tm.deleteCh = make(chan string, 1)
-	ctrl.tasksManager = &tm
+	ctrl.tasksManager = tm
 
 	// Mock watcher
 	errCh := make(chan error)
@@ -222,7 +222,7 @@ func testOnceWatchDepErrors(t *testing.T, driverConf *config.DriverConfig) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ctrl.tasksManager = &tm
+	ctrl.tasksManager = tm
 
 	// Mock watcher
 	expectedErr := errors.New("error!")

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/logging"
@@ -47,15 +46,8 @@ type TasksManager struct {
 }
 
 // NewTasksManager configures a new tasks manager
-func NewTasksManager(conf *config.Config, state state.Store) (*TasksManager, error) {
-
+func NewTasksManager(conf *config.Config, state state.Store, watcher templates.Watcher) (*TasksManager, error) {
 	logger := logging.Global().Named(tasksManagerSystemName)
-
-	logger.Info("initializing Consul client and testing connection")
-	watcher, err := newWatcher(conf, client.ConsulDefaultMaxRetry)
-	if err != nil {
-		return nil, err
-	}
 
 	factory, err := NewDriverFactory(conf, watcher)
 	if err != nil {

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -404,6 +404,15 @@ func (tm *TasksManager) checkApply(ctx context.Context, d driver.Driver, retry, 
 	return rendered, nil
 }
 
+// EnableTestMode is a helper for testing which tasks were triggered and
+// executed. Callers of this method must consume from TaskNotify channel to
+// prevent the buffered channel from filling and causing a dead lock.
+func (tm *TasksManager) EnableTestMode() <-chan string {
+	tasks := tm.state.GetAllTasks()
+	tm.taskNotify = make(chan string, tasks.Len())
+	return tm.taskNotify
+}
+
 // createTask creates and initializes a singular task from configuration
 func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskConfig) (driver.Driver, error) {
 	conf := tm.state.GetConfig()

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -940,8 +940,8 @@ func mockDriver(ctx context.Context, d *mocksD.Driver, task *driver.Task) {
 		On("ApplyTask", ctx).Return(nil)
 }
 
-func newTestTasksManager() TasksManager {
-	return TasksManager{
+func newTestTasksManager() *TasksManager {
+	return &TasksManager{
 		logger: logging.NewNullLogger(),
 		factory: &driverFactory{
 			logger: logging.NewNullLogger(),

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -753,6 +753,27 @@ func Test_TasksManager_CheckApply_Store(t *testing.T) {
 	})
 }
 
+func Test_ConditionMonitor_EnableTestMode(t *testing.T) {
+	t.Parallel()
+
+	// Mock state store
+	taskConfs := config.TaskConfigs{
+		{Name: config.String("task_a")},
+		{Name: config.String("task_b")},
+	}
+	s := new(mocksS.Store)
+	s.On("GetAllTasks", mock.Anything, mock.Anything).Return(taskConfs)
+
+	// Set up tasks manager
+	tm := newTestTasksManager()
+	tm.state = s
+
+	// Test EnableTestMode
+	channel := tm.EnableTestMode()
+	assert.Equal(t, 2, cap(channel))
+	s.AssertExpectations(t)
+}
+
 func Test_TasksManager_deleteTask(t *testing.T) {
 	ctx := context.Background()
 	mockD := new(mocksD.Driver)

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -21,14 +21,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var validTaskConf = config.TaskConfig{
-	Enabled: config.Bool(true),
-	Name:    config.String("task"),
-	Module:  config.String("module"),
-	Condition: &config.CatalogServicesConditionConfig{
-		CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{Regexp: config.String("regex")},
-	},
-}
+var (
+	validTaskName = "task"
+	validTaskConf = config.TaskConfig{
+		Enabled: config.Bool(true),
+		Name:    config.String(validTaskName),
+		Module:  config.String("module"),
+		Condition: &config.CatalogServicesConditionConfig{
+			CatalogServicesMonitorConfig: config.CatalogServicesMonitorConfig{Regexp: config.String("regex")},
+		},
+	}
+)
 
 func Test_TasksManager_Task(t *testing.T) {
 	ctx := context.Background()
@@ -142,11 +145,11 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 		assert.Equal(t, conf, actual)
 
 		// Basic check that task was added
-		_, ok := tm.drivers.Get("task")
+		_, ok := tm.drivers.Get(validTaskName)
 		assert.True(t, ok, "task should have a driver")
 
 		// Basic check that task was not run
-		events := tm.state.GetTaskEvents("task")
+		events := tm.state.GetTaskEvents(validTaskName)
 		assert.Len(t, events, 0, "no events stored on creation")
 	})
 
@@ -170,10 +173,10 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 		_, err := tm.TaskCreate(ctx, validTaskConf)
 		assert.Error(t, err)
 
-		_, ok := tm.drivers.Get("task")
+		_, ok := tm.drivers.Get(validTaskName)
 		assert.False(t, ok, "errored task should not have a driver added")
 
-		events := tm.state.GetTaskEvents("task")
+		events := tm.state.GetTaskEvents(validTaskName)
 		assert.Len(t, events, 0, "no events stored on creation")
 	})
 }
@@ -198,7 +201,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		mockD.On("OverrideNotifier").Return()
 		task, err := driver.NewTask(driver.TaskConfig{
 			Enabled: true,
-			Name:    "task",
+			Name:    validTaskName,
 		})
 		require.NoError(t, err)
 		mockDriver(ctx, mockD, task)
@@ -212,14 +215,14 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Basic check that task was added
-		_, ok := tm.drivers.Get("task")
+		_, ok := tm.drivers.Get(validTaskName)
 		assert.True(t, ok)
 
 		// Basic check that task was ran
-		events := tm.state.GetTaskEvents("task")
+		events := tm.state.GetTaskEvents(validTaskName)
 		assert.Len(t, events, 1)
-		require.Len(t, events["task"], 1)
-		assert.Nil(t, events["task"][0].EventError, "unexpected error event")
+		require.Len(t, events[validTaskName], 1)
+		assert.Nil(t, events[validTaskName][0].EventError, "unexpected error event")
 	})
 
 	t.Run("disabled task", func(t *testing.T) {
@@ -228,7 +231,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		mockD.On("OverrideNotifier").Return()
 		task, err := driver.NewTask(driver.TaskConfig{
 			Enabled: false,
-			Name:    "task",
+			Name:    validTaskName,
 		})
 		require.NoError(t, err)
 		mockDriver(ctx, mockD, task)
@@ -244,10 +247,10 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		_, err = tm.TaskCreateAndRun(ctx, *taskConf)
 		assert.NoError(t, err)
 
-		_, ok := tm.drivers.Get("task")
+		_, ok := tm.drivers.Get(validTaskName)
 		assert.True(t, ok, "driver is created for task even if it's disabled")
 
-		events := tm.state.GetTaskEvents("task")
+		events := tm.state.GetTaskEvents(validTaskName)
 		assert.Len(t, events, 0, "task is disabled, no run should occur")
 	})
 
@@ -255,7 +258,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		mockD := new(mocksD.Driver)
 		task, err := driver.NewTask(driver.TaskConfig{
 			Enabled: true,
-			Name:    "task",
+			Name:    validTaskName,
 		})
 		require.NoError(t, err)
 		mockD.On("Task").Return(task).
@@ -272,10 +275,10 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		_, err = tm.TaskCreateAndRun(ctx, validTaskConf)
 		assert.Error(t, err)
 
-		_, ok := tm.drivers.Get("task")
+		_, ok := tm.drivers.Get(validTaskName)
 		assert.False(t, ok, "driver is only added if the run is successful")
 
-		events := tm.state.GetTaskEvents("task")
+		events := tm.state.GetTaskEvents(validTaskName)
 		assert.Len(t, events, 0, "event is only stored on successful creation and run")
 	})
 }
@@ -698,25 +701,24 @@ func Test_TasksManager_CheckApply(t *testing.T) {
 		tm := newTestTasksManager()
 
 		d := new(mocksD.Driver)
-		taskName := "scheduled_task"
-		d.On("Task").Return(scheduledTestTask(t, taskName))
+		d.On("Task").Return(scheduledTestTask(t, schedTaskName))
 		d.On("TemplateIDs").Return(nil)
 		d.On("RenderTemplate", mock.Anything).Return(false, nil)
-		tm.drivers.Add(taskName, d)
+		tm.drivers.Add(schedTaskName, d)
 
 		// Once-mode - confirm no events are stored
 		ctx := context.Background()
 		_, err := tm.checkApply(ctx, d, false, true)
 		assert.NoError(t, err)
-		data := tm.state.GetTaskEvents(taskName)
-		events := data[taskName]
+		data := tm.state.GetTaskEvents(schedTaskName)
+		events := data[schedTaskName]
 		assert.Equal(t, 0, len(events))
 
 		// Daemon-mode - confirm an event is stored
 		_, err = tm.checkApply(ctx, d, false, false)
 		assert.NoError(t, err)
-		data = tm.state.GetTaskEvents(taskName)
-		events = data[taskName]
+		data = tm.state.GetTaskEvents(schedTaskName)
+		events = data[schedTaskName]
 		assert.Equal(t, 1, len(events))
 	})
 }
@@ -825,18 +827,17 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 		// Tests that deleting a scheduled task sends a stop notification
 
 		// Setup tm and drivers
-		taskName := "scheduled_task"
 		scheduledDriver := new(mocksD.Driver)
-		scheduledDriver.On("Task").Return(scheduledTestTask(t, taskName))
+		scheduledDriver.On("Task").Return(scheduledTestTask(t, schedTaskName))
 		scheduledDriver.On("DestroyTask", ctx).Return()
 		scheduledDriver.On("TemplateIDs").Return(nil)
 		tm := newTestTasksManager()
-		tm.drivers.Add(taskName, scheduledDriver)
+		tm.drivers.Add(schedTaskName, scheduledDriver)
 		stopCh := make(chan struct{}, 1)
-		tm.scheduleStopChs[taskName] = stopCh
+		tm.scheduleStopChs[schedTaskName] = stopCh
 
 		// Delete task
-		err := tm.deleteTask(ctx, taskName)
+		err := tm.deleteTask(ctx, schedTaskName)
 		assert.NoError(t, err)
 
 		// Verify the stop channel received message
@@ -846,7 +847,7 @@ func Test_TasksManager_deleteTask(t *testing.T) {
 		case <-stopCh:
 			break // expected case
 		}
-		_, ok := tm.scheduleStopChs[taskName]
+		_, ok := tm.scheduleStopChs[schedTaskName]
 		assert.False(t, ok, "scheduled task stop channel still in map")
 	})
 


### PR DESCRIPTION
First PR of two to refactor monitoring/triggering out of TasksManager. The intent is to keep TasksManager scoped to managing tasks (crud + run). A separate struct (currently named planning to be named ConditionMonitor) will be used to monitor changes and trigger task runs using the TasksManager.

The changes to disentangle monitoring/triggering code out of TasksManager is pretty large. This first PR contains miscellaneous commits that could be separated out without breaking tests and compilation. The bulk of the refactor will be in the next PR.