### PR TITLE
Self-register CTS as a service with Consul in daemon mode

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -165,10 +165,15 @@ func (c *ConsulClient) GetLicense(ctx context.Context, q *consulapi.QueryOptions
 // RegisterService registers a service through the Consul agent.
 func (c *ConsulClient) RegisterService(ctx context.Context, r *consulapi.AgentServiceRegistration) error {
 	desc := "AgentServiceRegister"
+	logger := c.logger
+	if r != nil {
+		logger = logger.With("service_name", r.Name, "service_id", r.ID)
+	}
 
 	f := func(context.Context) error {
 		err := c.Agent().ServiceRegister(r)
 		if err != nil {
+			logger.Error("error registering service", "error", err)
 			return err
 		}
 		return nil
@@ -190,6 +195,7 @@ func (c *ConsulClient) DeregisterService(ctx context.Context, serviceID string) 
 	f := func(context.Context) error {
 		err := c.Agent().ServiceDeregister(serviceID)
 		if err != nil {
+			c.logger.Error("error deregistering service", "error", err, "service_id", serviceID)
 			// TODO: Do not retry depending on error, log message about service:write rule on 403
 			return err
 		}

--- a/controller/daemon.go
+++ b/controller/daemon.go
@@ -4,9 +4,11 @@ import (
 	"context"
 
 	"github.com/hashicorp/consul-terraform-sync/api"
+	"github.com/hashicorp/consul-terraform-sync/client"
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/health"
 	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/hashicorp/consul-terraform-sync/registration"
 	"github.com/hashicorp/consul-terraform-sync/state"
 )
 
@@ -25,6 +27,8 @@ type Daemon struct {
 
 	state        state.Store
 	tasksManager *TasksManager
+
+	consulClient client.ConsulClientInterface
 
 	// whether or not the tasks have gone through once-mode. intended to be used
 	// by benchmarks to run once-mode separately
@@ -57,7 +61,10 @@ func (ctrl *Daemon) Init(ctx context.Context) error {
 }
 
 func (ctrl *Daemon) Run(ctx context.Context) error {
-	// Serve API
+	exitBufLen := 2 // api & run tasks exit
+	exitCh := make(chan error, exitBufLen)
+
+	// Configure API
 	conf := ctrl.tasksManager.state.GetConfig()
 	s, err := api.NewAPI(api.Config{
 		Controller: ctrl.tasksManager,
@@ -69,8 +76,38 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 		return err
 	}
 
-	exitBufLen := 2 // api & run tasks exit
-	exitCh := make(chan error, exitBufLen)
+	var rm *registration.SelfRegistrationManager
+	if *conf.Consul.SelfRegistration.Enabled {
+		// Expect one more long-running goroutine
+		exitBufLen++
+		exitCh = make(chan error, exitBufLen)
+
+		// Configure Consul client if not already
+		if ctrl.consulClient == nil {
+			c, err := client.NewConsulClient(conf.Consul, client.ConsulDefaultMaxRetry)
+			if err != nil {
+				ctrl.logger.Error("error setting up Consul client", "error", err)
+				return err
+			}
+			ctrl.consulClient = c
+		}
+
+		// Configure and start self-registration manager
+		rm = registration.NewSelfRegistrationManager(
+			&registration.SelfRegistrationManagerConfig{
+				ID:               *conf.ID,
+				Port:             *conf.Port,
+				TLSEnabled:       (conf.TLS != nil && *conf.TLS.Enabled),
+				SelfRegistration: conf.Consul.SelfRegistration,
+			},
+			ctrl.consulClient)
+		go func() {
+			rm.Start(ctx)
+			exitCh <- nil // registration errors are logged only
+		}()
+	}
+
+	// Serve API
 	go func() {
 		err := s.Serve(ctx)
 		exitCh <- err
@@ -79,6 +116,10 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 	// Run tasks once through once-mode
 	if !ctrl.once {
 		if err := ctrl.Once(ctx); err != nil {
+			if rm != nil {
+				// Deregister CTS service from Consul
+				rm.Deregister(ctx)
+			}
 			return err
 		}
 	}
@@ -95,8 +136,6 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 		counter++
 		if err != nil && err != context.Canceled {
 			// Exit if an error is returned
-			// Not expecting any routines to send a nil error because they run
-			// until canceled. Nil check is just to be safe
 			return err
 		}
 		if counter >= exitBufLen {

--- a/controller/daemon.go
+++ b/controller/daemon.go
@@ -101,6 +101,7 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 				SelfRegistration: conf.Consul.SelfRegistration,
 			},
 			ctrl.consulClient)
+			
 		go func() {
 			rm.Start(ctx)
 			exitCh <- nil // registration errors are logged only

--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
 	"github.com/hashicorp/consul-terraform-sync/logging"
-	mocks "github.com/hashicorp/consul-terraform-sync/mocks/client"
+	mocksC "github.com/hashicorp/consul-terraform-sync/mocks/client"
 	mocksD "github.com/hashicorp/consul-terraform-sync/mocks/driver"
 	mocksTmpl "github.com/hashicorp/consul-terraform-sync/mocks/templates"
 	"github.com/hashicorp/consul-terraform-sync/state"
@@ -29,7 +29,7 @@ func Test_Daemon_Run_long(t *testing.T) {
 
 	port := testutils.FreePort(t)
 
-	mockConsul := new(mocks.ConsulClientInterface)
+	mockConsul := new(mocksC.ConsulClientInterface)
 	mockConsul.On("RegisterService", mock.Anything, mock.Anything).Return(nil)
 	mockConsul.On("DeregisterService", mock.Anything, mock.Anything).Return(nil)
 

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -92,22 +92,22 @@ func NewSelfRegistrationManager(conf *SelfRegistrationManagerConfig, client clie
 // with Consul and deregister it if CTS is stopped.
 func (m *SelfRegistrationManager) Start(ctx context.Context) error {
 	// Register CTS with Consul
-	err := m.SelfRegisterService(ctx)
+	err := m.register(ctx)
 	if err != nil {
 		return err
 	}
 
 	// Wait until the context is cancelled, initiate deregistration
 	<-ctx.Done()
-	err = m.Deregister(ctx)
+	err = m.deregister(ctx)
 	if err != nil {
 		return err
 	}
 	return ctx.Err()
 }
 
-// SelfRegisterService registers Consul-Terraform-Sync with Consul
-func (m *SelfRegistrationManager) SelfRegisterService(ctx context.Context) error {
+// register registers Consul-Terraform-Sync with Consul
+func (m *SelfRegistrationManager) register(ctx context.Context) error {
 	s := m.service
 	logger := m.logger.With("service_name", m.service.name, "id", m.service.id)
 	r := &consulapi.AgentServiceRegistration{
@@ -129,8 +129,8 @@ func (m *SelfRegistrationManager) SelfRegisterService(ctx context.Context) error
 	return nil
 }
 
-// Deregister deregisters Consul-Terraform-Sync from Consul
-func (m *SelfRegistrationManager) Deregister(ctx context.Context) error {
+// deregister deregisters Consul-Terraform-Sync from Consul
+func (m *SelfRegistrationManager) deregister(ctx context.Context) error {
 	logger := m.logger.With("service_name", m.service.name, "id", m.service.id)
 	logger.Info("deregistering Consul-Terraform-Sync from Consul")
 	err := m.client.DeregisterService(ctx, m.service.id)

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -22,7 +22,7 @@ const (
 	defaultCheckStatus                    = consulapi.HealthCritical
 
 	// HTTP-specific check defaults
-	defaultEndpoint      = "/v1/status" // TODO: temporary until /v1/health is implemented
+	defaultEndpoint      = "/v1/health"
 	defaultMethod        = "GET"
 	defaultInterval      = "10s"
 	defaultTimeout       = "2s"

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -175,6 +175,7 @@ func TestSelfRegistrationManager_Start(t *testing.T) {
 			}
 		}()
 		cancel()
+		
 		select {
 		case err := <-errCh:
 			// Confirm that exit is due to context cancel
@@ -199,6 +200,7 @@ func TestSelfRegistrationManager_Start(t *testing.T) {
 				errCh <- err
 			}
 		}()
+		
 		select {
 		case err := <-errCh:
 			// Confirm that exit is due to mock error
@@ -252,10 +254,7 @@ func TestSelfRegistrationManager_Deregister(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		mockClient := new(mocks.ConsulClientInterface)
-		mockClient.On("DeregisterService", mock.Anything,
-			mock.MatchedBy(func(actual string) bool {
-				return actual == id
-			})).Return(nil)
+		mockClient.On("DeregisterService", ctx, id).Return(nil)
 		manager.client = mockClient
 
 		err := manager.Deregister(ctx)

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -237,7 +237,7 @@ func TestSelfRegistrationManager_Start(t *testing.T) {
 	})
 }
 
-func TestSelfRegistrationManager_Deregister(t *testing.T) {
+func TestSelfRegistrationManager_deregister(t *testing.T) {
 	t.Parallel()
 	id := "cts-123"
 	ctx := context.Background()
@@ -255,7 +255,7 @@ func TestSelfRegistrationManager_Deregister(t *testing.T) {
 		mockClient.On("DeregisterService", ctx, id).Return(nil)
 		manager.client = mockClient
 
-		err := manager.Deregister(ctx)
+		err := manager.deregister(ctx)
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
 	})
@@ -266,13 +266,13 @@ func TestSelfRegistrationManager_Deregister(t *testing.T) {
 			Return(errors.New("mock deregister error"))
 		manager.client = mockClient
 
-		err := manager.Deregister(ctx)
+		err := manager.deregister(ctx)
 		assert.Error(t, err)
 		mockClient.AssertExpectations(t)
 	})
 }
 
-func TestSelfRegistrationManager_SelfRegisterService(t *testing.T) {
+func TestSelfRegistrationManager_register(t *testing.T) {
 	t.Parallel()
 	id := "cts-123"
 	port := 8558
@@ -333,7 +333,7 @@ func TestSelfRegistrationManager_SelfRegisterService(t *testing.T) {
 				logger:  logging.NewNullLogger(),
 			}
 
-			err := m.SelfRegisterService(context.Background())
+			err := m.register(context.Background())
 
 			if !tc.expectErr {
 				require.NoError(t, err)

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -80,9 +80,8 @@ func TestNewSelfRegistrationManager(t *testing.T) {
 func TestSelfRegistrationManager_defaultHTTPCheck(t *testing.T) {
 	id := "cts-123"
 	port := 8558
-	// TODO: update these addresses when /v1/health implemented
-	httpAddress := fmt.Sprintf("http://localhost:%d/v1/status", port)
-	httpsAddress := fmt.Sprintf("https://localhost:%d/v1/status", port)
+	httpAddress := fmt.Sprintf("http://localhost:%d/v1/health", port)
+	httpsAddress := fmt.Sprintf("https://localhost:%d/v1/health", port)
 	checkID := fmt.Sprintf("%s-health", id)
 
 	testcases := []struct {


### PR DESCRIPTION
Adds support for CTS to register itself with Consul when running in daemon mode.

- Updates the health check to use `/v1/health` now that has been implemented
- Adds a Start method to the self-registration manager which will register the service and then wait for an initiated shutdown to deregister the service
- Calls Start() in the daemon controller's Run() to start the registration and monitoring.
  - Does not error and exit if there are registration issues, relies on the error logging from the self-registration manager.
  - Explicitly deregister CTS if once-mode fails

End-to-end tests will be added in a follow up PR after the remaining work is complete (new configurations, improved retry logic).