### PR TITLE
Refactor monitoring/triggering out of TasksManager (pt2)

### DIFF
--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -76,10 +76,6 @@ func (cm *ConditionMonitor) Run(ctx context.Context) error {
 		}
 		cm.watcherCh = make(chan string, len(tasks)+10)
 	}
-	if cm.scheduleStartCh == nil {
-		// Size of channel is an arbitrarily chosen value.
-		cm.scheduleStartCh = make(chan driver.Driver, 10)
-	}
 	if cm.deleteCh == nil {
 		// Size of channel is an arbitrarily chosen value.
 		cm.deleteCh = make(chan string, 10)
@@ -110,9 +106,11 @@ func (cm *ConditionMonitor) Run(ctx context.Context) error {
 
 			go cm.runDynamicTask(ctx, d) // errors are logged for now
 
-		case d := <-cm.scheduleStartCh:
+		case taskName := <-cm.tasksManager.WatchCreatedScheduleTasks():
 			// Run newly created scheduled tasks
 			stopCh := make(chan struct{}, 1)
+
+			// TODO: next commit fixes issue where driver no longer returned
 			cm.scheduleStopChs[d.Task().Name()] = stopCh
 			go cm.runScheduledTask(ctx, d, stopCh)
 

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/config"
 	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/logging"
 	"github.com/hashicorp/consul-terraform-sync/templates"
 	"github.com/hashicorp/cronexpr"
 )
@@ -15,7 +16,19 @@ import (
 // responsible for triggering a task to execute. It uses the task manager to
 // inform of starting / stopping task monitoring as well as executing a task
 type ConditionMonitor struct {
-	// TODO: placeholder. Will convert TaskManager methods to ConditionMonitor
+	logger logging.Logger
+
+	tasksManager *TasksManager
+}
+
+// NewConditionMonitor configures a new condition monitor
+func NewConditionMonitor(tm *TasksManager) *ConditionMonitor {
+	logger := logging.Global().Named(tasksManagerSystemName)
+
+	return &ConditionMonitor{
+		logger:       logger,
+		tasksManager: tm,
+	}
 }
 
 // WatchDep is a helper method to start watching dependencies to allow templates

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -18,15 +18,17 @@ import (
 type ConditionMonitor struct {
 	logger logging.Logger
 
+	watcher      templates.Watcher
 	tasksManager *TasksManager
 }
 
 // NewConditionMonitor configures a new condition monitor
-func NewConditionMonitor(tm *TasksManager) *ConditionMonitor {
+func NewConditionMonitor(tm *TasksManager, w templates.Watcher) *ConditionMonitor {
 	logger := logging.Global().Named(tasksManagerSystemName)
 
 	return &ConditionMonitor{
 		logger:       logger,
+		watcher:      w,
 		tasksManager: tm,
 	}
 }

--- a/controller/condition_monitor.go
+++ b/controller/condition_monitor.go
@@ -75,10 +75,6 @@ func (cm *ConditionMonitor) Run(ctx context.Context) error {
 		}
 		cm.watcherCh = make(chan string, len(tasks)+10)
 	}
-	if cm.deleteCh == nil {
-		// Size of channel is an arbitrarily chosen value.
-		cm.deleteCh = make(chan string, 10)
-	}
 	if cm.scheduleStopChs == nil {
 		cm.scheduleStopChs = make(map[string](chan struct{}))
 	}
@@ -110,9 +106,6 @@ func (cm *ConditionMonitor) Run(ctx context.Context) error {
 			stopCh := make(chan struct{}, 1)
 			cm.scheduleStopChs[taskName] = stopCh
 			go cm.runScheduledTask(ctx, taskName, stopCh)
-
-		case n := <-cm.deleteCh:
-			go cm.deleteTask(ctx, n)
 
 		case err := <-errCh:
 			return err

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -29,7 +29,7 @@ var (
 	}
 )
 
-func Test_TasksManager_runDynamicTask(t *testing.T) {
+func Test_ConditionMonitor_runDynamicTask(t *testing.T) {
 	t.Run("simple-success", func(t *testing.T) {
 		tm := newTestTasksManager()
 
@@ -109,7 +109,7 @@ func Test_TasksManager_runDynamicTask(t *testing.T) {
 
 }
 
-func Test_TasksManager_runScheduledTask(t *testing.T) {
+func Test_ConditionMonitor_runScheduledTask(t *testing.T) {
 	t.Run("happy-path", func(t *testing.T) {
 		tm := newTestTasksManager()
 
@@ -232,7 +232,7 @@ func Test_TasksManager_runScheduledTask(t *testing.T) {
 	})
 }
 
-func Test_TasksManager_Run_context_cancel(t *testing.T) {
+func Test_ConditionMonitor_Run_context_cancel(t *testing.T) {
 	w := new(mocks.Watcher)
 	w.On("Watch", mock.Anything, mock.Anything).Return(nil).
 		On("Size").Return(5).
@@ -261,7 +261,7 @@ func Test_TasksManager_Run_context_cancel(t *testing.T) {
 	}
 }
 
-func Test_TasksManager_Run_ActiveTask(t *testing.T) {
+func Test_ConditionMonitor_Run_ActiveTask(t *testing.T) {
 	// Set up tm with two tasks
 	tm := newTestTasksManager()
 	tm.watcherCh = make(chan string, 5)
@@ -337,7 +337,7 @@ func Test_TasksManager_Run_ActiveTask(t *testing.T) {
 	}
 }
 
-func Test_TasksManager_Run_ScheduledTasks(t *testing.T) {
+func Test_ConditionMonitor_Run_ScheduledTasks(t *testing.T) {
 	tm := newTestTasksManager()
 	tm.watcherCh = make(chan string, 5)
 	tm.scheduleStartCh = make(chan driver.Driver, 1)
@@ -374,7 +374,7 @@ func Test_TasksManager_Run_ScheduledTasks(t *testing.T) {
 	assert.NotNil(t, stopCh, "expected stop channel not to be nil")
 }
 
-func Test_TasksManager_WatchDep_context_cancel(t *testing.T) {
+func Test_ConditionMonitor_WatchDep_context_cancel(t *testing.T) {
 	t.Parallel()
 
 	t.Run("cancel exits successfully", func(t *testing.T) {

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -40,7 +40,7 @@ func Test_ConditionMonitor_runDynamicTask(t *testing.T) {
 		tm.drivers.Add(validTaskName, d)
 
 		cm := newTestConditionMonitor(tm)
-		err := cm.runDynamicTask(ctx, d)
+		err := cm.runDynamicTask(ctx, validTaskName)
 		assert.NoError(t, err)
 	})
 
@@ -57,7 +57,7 @@ func Test_ConditionMonitor_runDynamicTask(t *testing.T) {
 		tm.drivers.Add(validTaskName, d)
 
 		cm := newTestConditionMonitor(tm)
-		err := cm.runDynamicTask(context.Background(), d)
+		err := cm.runDynamicTask(context.Background(), validTaskName)
 		assert.Contains(t, err.Error(), testErr.Error())
 	})
 
@@ -71,7 +71,7 @@ func Test_ConditionMonitor_runDynamicTask(t *testing.T) {
 		tm.drivers.Add(schedTaskName, d)
 
 		cm := newTestConditionMonitor(tm)
-		err := cm.runDynamicTask(context.Background(), d)
+		err := cm.runDynamicTask(context.Background(), schedTaskName)
 		assert.NoError(t, err)
 	})
 }
@@ -93,7 +93,7 @@ func Test_ConditionMonitor_runScheduledTask(t *testing.T) {
 		errCh := make(chan error)
 		stopCh := make(chan struct{}, 1)
 		go func() {
-			err := cm.runScheduledTask(ctx, d, stopCh)
+			err := cm.runScheduledTask(ctx, schedTaskName, stopCh)
 			if err != nil {
 				errCh <- err
 			}
@@ -123,7 +123,7 @@ func Test_ConditionMonitor_runScheduledTask(t *testing.T) {
 		errCh := make(chan error)
 		stopCh := make(chan struct{}, 1)
 		go func() {
-			err := cm.runScheduledTask(ctx, d, stopCh)
+			err := cm.runScheduledTask(ctx, validTaskName, stopCh)
 			if err != nil {
 				errCh <- err
 			}
@@ -156,7 +156,7 @@ func Test_ConditionMonitor_runScheduledTask(t *testing.T) {
 		errCh := make(chan error)
 		stopCh := make(chan struct{}, 1)
 		go func() {
-			err := cm.runScheduledTask(ctx, d, stopCh)
+			err := cm.runScheduledTask(ctx, schedTaskName, stopCh)
 			errCh <- err
 		}()
 		stopCh <- struct{}{}
@@ -186,7 +186,7 @@ func Test_ConditionMonitor_runScheduledTask(t *testing.T) {
 		tm.scheduleStopChs[schedTaskName] = stopCh
 		done := make(chan bool)
 		go func() {
-			err := cm.runScheduledTask(ctx, d, stopCh)
+			err := cm.runScheduledTask(ctx, schedTaskName, stopCh)
 			if err != nil {
 				errCh <- err
 			}

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -74,45 +74,6 @@ func Test_ConditionMonitor_runDynamicTask(t *testing.T) {
 		err := cm.runDynamicTask(context.Background(), d)
 		assert.NoError(t, err)
 	})
-
-	t.Run("active-task", func(t *testing.T) {
-		tm := newTestTasksManager()
-		tm.EnableTestMode()
-
-		ctx := context.Background()
-		d := new(mocksD.Driver)
-		mockDriver(ctx, d, enabledTestTask(t, validTaskName))
-		drivers := tm.drivers
-		drivers.Add(validTaskName, d)
-		drivers.SetActive(validTaskName)
-
-		cm := newTestConditionMonitor(tm)
-
-		// Attempt to run the active task
-		ch := make(chan error)
-		go func() {
-			err := cm.runDynamicTask(ctx, d)
-			ch <- err
-		}()
-
-		// Check that the task did not run while active
-		select {
-		case <-tm.taskNotify:
-			t.Fatal("task ran even though active")
-		case <-time.After(250 * time.Millisecond):
-			break
-		}
-
-		// Set task to inactive, wait for run to happen
-		drivers.SetInactive(validTaskName)
-		select {
-		case <-time.After(250 * time.Millisecond):
-			t.Fatal("task did not run after it became inactive")
-		case <-tm.taskNotify:
-			break
-		}
-	})
-
 }
 
 func Test_ConditionMonitor_runScheduledTask(t *testing.T) {

--- a/controller/condition_monitor_test.go
+++ b/controller/condition_monitor_test.go
@@ -317,7 +317,7 @@ func Test_ConditionMonitor_Run_ActiveTask(t *testing.T) {
 
 func Test_ConditionMonitor_Run_ScheduledTasks(t *testing.T) {
 	tm := newTestTasksManager()
-	tm.scheduleStartCh = make(chan driver.Driver, 1)
+	tm.createdScheduleCh = make(chan string, 1)
 	tm.EnableTestMode()
 
 	// Set up condition monitor

--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -49,6 +49,8 @@ func Test_Daemon_Run_long(t *testing.T) {
 	w := new(mocksTmpl.Watcher)
 	w.On("Watch", mock.Anything, mock.Anything).Return(nil)
 	cm.watcher = w
+	ctl.monitor = cm
+
 	t.Run("cancel exits successfully", func(t *testing.T) {
 		errCh := make(chan error)
 		ctx, cancel := context.WithCancel(context.Background())

--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -151,7 +151,6 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 
 	// Setup taskmanager
 	tm := newTestTasksManager()
-	tm.watcherCh = make(chan string, 5)
 	tm.state = st
 	completedTasksCh := tm.EnableTestMode()
 	rw.tasksManager = tm
@@ -175,6 +174,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	defer cancel()
 
 	cm := newTestConditionMonitor(tm)
+	cm.watcherCh = make(chan string, 5)
 	rw.monitor = cm
 
 	// Mock watcher
@@ -184,7 +184,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	go func() { errCh <- nil }()
 	w.On("WaitCh", mock.Anything).Return(waitErrChRc).Once()
 	w.On("Size").Return(5)
-	w.On("Watch", ctx, tm.watcherCh).Return(nil)
+	w.On("Watch", ctx, cm.watcherCh).Return(nil)
 	cm.watcher = w
 
 	go func() {
@@ -196,7 +196,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 
 	// Emulate triggers to evaluate task completion
 	for i := 0; i < 5; i++ {
-		tm.watcherCh <- "{{tmpl}}"
+		cm.watcherCh <- "{{tmpl}}"
 		select {
 		case taskName := <-completedTasksCh:
 			assert.Equal(t, "task", taskName)

--- a/controller/inspect.go
+++ b/controller/inspect.go
@@ -25,6 +25,7 @@ type Inspect struct {
 	state        state.Store
 	tasksManager *TasksManager
 	watcher      templates.Watcher
+	monitor      *ConditionMonitor
 }
 
 // NewInspect configures and initializes a new inspect controller
@@ -50,6 +51,7 @@ func NewInspect(conf *config.Config) (*Inspect, error) {
 		state:        s,
 		tasksManager: tm,
 		watcher:      watcher,
+		monitor:      NewConditionMonitor(tm, watcher),
 	}, nil
 }
 
@@ -72,7 +74,7 @@ func (ctrl *Inspect) Run(ctx context.Context) error {
 
 	// start watching dependencies in order to render templates to plan tasks
 	go func() {
-		exitCh <- ctrl.tasksManager.WatchDep(ctxWatch)
+		exitCh <- ctrl.monitor.WatchDep(ctxWatch)
 		cancelInspect()
 	}()
 

--- a/controller/inspect_test.go
+++ b/controller/inspect_test.go
@@ -83,7 +83,7 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	conf := multipleTaskConfig(5)
 	ss := state.NewInMemoryStore(conf)
 
-	ro := Inspect{
+	ctrl := Inspect{
 		logger: logging.NewNullLogger(),
 		state:  ss,
 	}
@@ -91,10 +91,12 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = tm
+	ctrl.tasksManager = tm
 
 	// Set up condition monitor
 	cm := newTestConditionMonitor(tm)
+	ctrl.monitor = cm
+
 	// Mock watcher
 	waitErrCh := make(chan error)
 	var waitErrChRc <-chan error = waitErrCh
@@ -123,7 +125,7 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error)
 	go func() {
-		err := ro.Run(ctx)
+		err := ctrl.Run(ctx)
 		if err != nil {
 			errCh <- err
 		}
@@ -155,7 +157,7 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 
 	ss := state.NewInMemoryStore(conf)
 
-	ro := Inspect{
+	ctrl := Inspect{
 		logger: logging.NewNullLogger(),
 		state:  ss,
 	}
@@ -163,10 +165,12 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = tm
+	ctrl.tasksManager = tm
 
 	// Set up condition monitor
 	cm := newTestConditionMonitor(tm)
+	ctrl.monitor = cm
+
 	// Mock watcher
 	expectedErr := errors.New("error!")
 	waitErrCh := make(chan error)
@@ -192,7 +196,7 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 	defer cancel()
 	errCh := make(chan error)
 	go func() {
-		err := ro.Run(ctx)
+		err := ctrl.Run(ctx)
 		if err != nil {
 			errCh <- err
 		}
@@ -217,7 +221,7 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	conf := multipleTaskConfig(numTasks)
 	ss := state.NewInMemoryStore(conf)
 
-	ro := Inspect{
+	ctrl := Inspect{
 		logger: logging.NewNullLogger(),
 		state:  ss,
 	}
@@ -225,10 +229,12 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	ro.tasksManager = tm
+	ctrl.tasksManager = tm
 
 	// Set up condition monitor
 	cm := newTestConditionMonitor(tm)
+	ctrl.monitor = cm
+
 	// Mock watcher
 	errCh := make(chan error)
 	var errChRc <-chan error = errCh
@@ -247,7 +253,7 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 		return d, nil
 	}
 
-	err := ro.Run(context.Background())
+	err := ctrl.Run(context.Background())
 
 	// Don't w.AssertExpectations(). Race condition on inspection completion
 	// and if watcher.Size() is called

--- a/controller/inspect_test.go
+++ b/controller/inspect_test.go
@@ -93,6 +93,8 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	tm.state = ss
 	ro.tasksManager = tm
 
+	// Set up condition monitor
+	cm := newTestConditionMonitor(tm)
 	// Mock watcher
 	waitErrCh := make(chan error)
 	var waitErrChRc <-chan error = waitErrCh
@@ -100,7 +102,7 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	w := new(mocksTmpl.Watcher)
 	w.On("WaitCh", mock.Anything).Return(waitErrChRc)
 	w.On("Size").Return(5)
-	tm.watcher = w
+	cm.watcher = w
 
 	// Set up driver factory
 	tm.factory.initConf = conf
@@ -163,6 +165,8 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 	tm.state = ss
 	ro.tasksManager = tm
 
+	// Set up condition monitor
+	cm := newTestConditionMonitor(tm)
 	// Mock watcher
 	expectedErr := errors.New("error!")
 	waitErrCh := make(chan error)
@@ -170,7 +174,7 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 	go func() { waitErrCh <- expectedErr }()
 	w := new(mocksTmpl.Watcher)
 	w.On("WaitCh", mock.Anything).Return(waitErrChRc)
-	tm.watcher = w
+	cm.watcher = w
 
 	// Set up driver factory
 	tm.factory.initConf = conf
@@ -223,6 +227,8 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	tm.state = ss
 	ro.tasksManager = tm
 
+	// Set up condition monitor
+	cm := newTestConditionMonitor(tm)
 	// Mock watcher
 	errCh := make(chan error)
 	var errChRc <-chan error = errCh
@@ -230,7 +236,7 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	w := new(mocksTmpl.Watcher)
 	w.On("WaitCh", mock.Anything).Return(errChRc)
 	w.On("Size").Return(numTasks)
-	tm.watcher = w
+	cm.watcher = w
 
 	// Set up driver factory
 	tm.factory.initConf = conf

--- a/controller/once.go
+++ b/controller/once.go
@@ -21,6 +21,7 @@ type Once struct {
 	state        state.Store
 	tasksManager *TasksManager
 	watcher      templates.Watcher
+	monitor      *ConditionMonitor
 }
 
 // NewOnce configures and initializes a new Once controller
@@ -46,6 +47,7 @@ func NewOnce(conf *config.Config) (*Once, error) {
 		state:        s,
 		tasksManager: tm,
 		watcher:      watcher,
+		monitor:      NewConditionMonitor(tm, watcher),
 	}, nil
 }
 
@@ -68,7 +70,7 @@ func (ctrl *Once) Run(ctx context.Context) error {
 
 	// start watching dependencies in order to render templates to apply tasks
 	go func() {
-		exitCh <- ctrl.tasksManager.WatchDep(ctxWatch)
+		exitCh <- ctrl.monitor.WatchDep(ctxWatch)
 		cancelOnce()
 	}()
 

--- a/controller/once_test.go
+++ b/controller/once_test.go
@@ -174,7 +174,6 @@ func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig,
 	// Set up tasks manager
 	tm := newTestTasksManager()
 	tm.state = ss
-	tm.deleteCh = make(chan string, 1)
 	ctrl.tasksManager = tm
 
 	// Set up driver factory

--- a/controller/once_test.go
+++ b/controller/once_test.go
@@ -185,6 +185,8 @@ func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig,
 
 	// Set up condition monitor
 	cm := newTestConditionMonitor(tm)
+	ctrl.monitor = cm
+
 	// Mock watcher
 	errCh := make(chan error)
 	var errChRc <-chan error = errCh
@@ -228,6 +230,8 @@ func testOnceWatchDepErrors(t *testing.T, driverConf *config.DriverConfig) {
 
 	// Set up condition monitor
 	cm := newTestConditionMonitor(tm)
+	ctrl.monitor = cm
+
 	// Mock watcher
 	expectedErr := errors.New("error!")
 	waitErrCh := make(chan error)

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -28,8 +28,6 @@ type TasksManager struct {
 
 	retry retry.Retry
 
-	watcherCh chan string
-
 	// scheduleStartCh is used to coordinate scheduled tasks created via the API
 	scheduleStartCh chan driver.Driver
 

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -32,8 +32,9 @@ type TasksManager struct {
 	// that will need to be monitored
 	createdScheduleCh chan string
 
-	// scheduleStopChs is a map of channels used to stop scheduled tasks
-	scheduleStopChs map[string]chan struct{}
+	// deletedScheduleCh sends the task name of deleted scheduled tasks that
+	// should stop being monitored
+	deletedScheduleCh chan string
 
 	// taskNotify is only initialized if EnableTestMode() is used. It provides
 	// tests insight into which tasks were triggered and had completed
@@ -60,7 +61,7 @@ func NewTasksManager(conf *config.Config, state state.Store, watcher templates.W
 		drivers:           driver.NewDrivers(),
 		retry:             retry.NewRetry(defaultRetry, time.Now().UnixNano()),
 		createdScheduleCh: make(chan string, 10), // arbitrarily chosen size
-		scheduleStopChs:   make(map[string]chan struct{}),
+		deletedScheduleCh: make(chan string, 10), // arbitrarily chosen size
 	}, nil
 }
 
@@ -465,6 +466,12 @@ func (tm TasksManager) WatchCreatedScheduleTasks() <-chan string {
 	return tm.createdScheduleCh
 }
 
+// WatchDeletedScheduleTask returns a channel to inform any watcher that a new
+// scheduled task has been deleted and removed from CTS.
+func (tm TasksManager) WatchDeletedScheduleTask() <-chan string {
+	return tm.deletedScheduleCh
+}
+
 // createTask creates and initializes a singular task from configuration
 func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskConfig) (driver.Driver, error) {
 	conf := tm.state.GetConfig()
@@ -608,11 +615,7 @@ func (tm *TasksManager) deleteTask(ctx context.Context, name string) error {
 	logger.Trace("task is inactive, deleting")
 	if d.Task().IsScheduled() {
 		// Notify the scheduled task to stop
-		stopCh := tm.scheduleStopChs[name]
-		if stopCh != nil {
-			stopCh <- struct{}{}
-		}
-		delete(tm.scheduleStopChs, name)
+		tm.deletedScheduleCh <- name
 	}
 
 	// Delete task from drivers

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -303,7 +303,7 @@ func (tm TasksManager) addTask(ctx context.Context, d driver.Driver) (config.Tas
 }
 
 // cleanupTask cleans up a newly created task that has not yet been added to CTS
-// and started monitoring. Use TaskDelete added and monitored tasks
+// and started monitoring. Use TaskDelete for added and monitored tasks
 func (tm TasksManager) cleanupTask(ctx context.Context, d driver.Driver) {
 	// at the moment, only the driver needs to destroy its dependencies
 	d.DestroyTask(ctx)

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -116,7 +116,7 @@ func (tm *TasksManager) TaskCreateAndRun(ctx context.Context, taskConfig config.
 		return config.TaskConfig{}, err
 	}
 
-	if err := tm.runTask(ctx, d); err != nil {
+	if err := tm.runNewTask(ctx, d); err != nil {
 		return config.TaskConfig{}, err
 	}
 
@@ -493,10 +493,17 @@ func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskCo
 	}
 }
 
-// runTask will set the driver to active, apply it, and store a run event.
-// This method will run the task as-is with current values of templates that
-// have already been resolved and rendered. This does not handle any templating.
-func (tm *TasksManager) runTask(ctx context.Context, d driver.Driver) error {
+// runNewTask runs a new task that has not been added to CTS yet. This differs
+// from TaskRunNow which runs existing tasks that have been added to CTS.
+// runNewTask has reduced complexity because the task driver has not been added
+// to CTS
+//
+// Applies the task as-is with current values of the template that has already
+// been resolved and rendered. This does not handle any templating.
+//
+// Stores an event in the state that should be cleaned up if the task is not
+// added to CTS.
+func (tm *TasksManager) runNewTask(ctx context.Context, d driver.Driver) error {
 	task := d.Task()
 	taskName := task.Name()
 	logger := tm.logger.With(taskNameLogKey, taskName)
@@ -504,19 +511,6 @@ func (tm *TasksManager) runTask(ctx context.Context, d driver.Driver) error {
 		logger.Trace("skipping disabled task")
 		return nil
 	}
-
-	if tm.drivers.IsMarkedForDeletion(taskName) {
-		logger.Trace("task is marked for deletion, skipping")
-		return nil
-	}
-
-	err := tm.waitForTaskInactive(ctx, taskName)
-	if err != nil {
-		return err
-	}
-
-	tm.drivers.SetActive(taskName)
-	defer tm.drivers.SetInactive(taskName)
 
 	// Create new event for task run
 	ev, err := event.NewEvent(taskName, &event.Config{

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -317,14 +317,19 @@ func (tm TasksManager) cleanupTask(ctx context.Context, name string) {
 // Note on #2: no event is stored when a dynamic task renders but does not apply.
 // This can occur because driver.RenderTemplate() may need to be called multiple
 // times before a template is ready to be applied.
-func (tm *TasksManager) TaskRunNow(ctx context.Context, d driver.Driver) error {
-	task := d.Task()
-	taskName := task.Name()
-
+func (tm *TasksManager) TaskRunNow(ctx context.Context, taskName string) error {
 	if tm.drivers.IsMarkedForDeletion(taskName) {
 		tm.logger.Trace("task is marked for deletion, skipping", taskNameLogKey, taskName)
 		return nil
 	}
+
+	d, ok := tm.drivers.Get(taskName)
+	if !ok {
+		return fmt.Errorf("task '%s' does not have a driver. task may have been"+
+			" deleted", taskName)
+	}
+
+	task := d.Task()
 
 	// For scheduled tasks, do not wait if task is active
 	if tm.drivers.IsActive(taskName) && task.IsScheduled() {
@@ -420,6 +425,16 @@ func (tm *TasksManager) TaskRunNow(ctx context.Context, d driver.Driver) error {
 	}
 
 	return nil
+}
+
+// TaskByTemplate returns the name of the task associated with a template id.
+// If no task is associated with the template id, returns false.
+func (tm TasksManager) TaskByTemplate(tmplID string) (string, bool) {
+	driver, ok := tm.drivers.GetTaskByTemplate(tmplID)
+	if !ok {
+		return "", false
+	}
+	return driver.Task().Name(), true
 }
 
 // EnableTestMode is a helper for testing which tasks were triggered and

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -282,13 +282,13 @@ func (tm TasksManager) addTask(ctx context.Context, d driver.Driver) (config.Tas
 
 	name := d.Task().Name()
 	if err := tm.drivers.Add(name, d); err != nil {
-		tm.cleanupTask(ctx, name)
+		tm.cleanupTask(ctx, d)
 		return config.TaskConfig{}, err
 	}
 
 	conf, err := configFromDriverTask(d.Task())
 	if err != nil {
-		tm.cleanupTask(ctx, name)
+		tm.cleanupTask(ctx, d)
 		return config.TaskConfig{}, err
 	}
 
@@ -301,11 +301,11 @@ func (tm TasksManager) addTask(ctx context.Context, d driver.Driver) (config.Tas
 	return conf, nil
 }
 
-func (tm TasksManager) cleanupTask(ctx context.Context, name string) {
-	err := tm.TaskDelete(ctx, name)
-	if err != nil {
-		tm.logger.Error("unable to cleanup task after error", "task_name", name)
-	}
+// cleanupTask cleans up a newly created task that has not yet been added to CTS
+// and started monitoring. Use TaskDelete added and monitored tasks
+func (tm TasksManager) cleanupTask(ctx context.Context, d driver.Driver) {
+	// at the moment, only the driver needs to destroy its dependencies
+	d.DestroyTask(ctx)
 }
 
 // TaskRunNow forces an existing task to run with a retry. It assumes that the

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -23,7 +23,6 @@ type TasksManager struct {
 	logger logging.Logger
 
 	factory *driverFactory
-	watcher templates.Watcher
 	state   state.Store
 	drivers *driver.Drivers
 
@@ -57,7 +56,6 @@ func NewTasksManager(conf *config.Config, state state.Store, watcher templates.W
 	return &TasksManager{
 		logger:          logger,
 		factory:         factory,
-		watcher:         watcher,
 		state:           state,
 		drivers:         driver.NewDrivers(),
 		retry:           retry.NewRetry(defaultRetry, time.Now().UnixNano()),

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -662,7 +662,7 @@ func Test_TasksManager_TaskRunNow(t *testing.T) {
 			tm := newTestTasksManager()
 			ctx := context.Background()
 
-			err := tm.TaskRunNow(ctx, d)
+			err := tm.TaskRunNow(ctx, tc.taskName)
 			data := tm.state.GetTaskEvents(tc.taskName)
 			events := data[tc.taskName]
 
@@ -708,7 +708,7 @@ func Test_TasksManager_TaskRunNow(t *testing.T) {
 
 		// Daemon-mode - confirm an event is stored
 		ctx := context.Background()
-		err := tm.TaskRunNow(ctx, d)
+		err := tm.TaskRunNow(ctx, schedTaskName)
 		require.NoError(t, err)
 		data := tm.state.GetTaskEvents(schedTaskName)
 		events := data[schedTaskName]
@@ -728,7 +728,7 @@ func Test_TasksManager_TaskRunNow(t *testing.T) {
 		tm.drivers.MarkForDeletion(schedTaskName)
 
 		ctx := context.Background()
-		err := tm.TaskRunNow(ctx, d)
+		err := tm.TaskRunNow(ctx, schedTaskName)
 		assert.NoError(t, err)
 		d.AssertExpectations(t)
 
@@ -752,7 +752,7 @@ func Test_TasksManager_TaskRunNow(t *testing.T) {
 		tm.drivers.SetActive(schedTaskName)
 
 		ctx := context.Background()
-		err := tm.TaskRunNow(ctx, d)
+		err := tm.TaskRunNow(ctx, schedTaskName)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "is active")
 		d.AssertExpectations(t)
@@ -779,7 +779,7 @@ func Test_TasksManager_TaskRunNow(t *testing.T) {
 		// Attempt to run the active task
 		ch := make(chan error)
 		go func() {
-			err := tm.TaskRunNow(ctx, d)
+			err := tm.TaskRunNow(ctx, validTaskName)
 			ch <- err
 		}()
 
@@ -820,12 +820,12 @@ func Test_TasksManager_TaskRunNow_Store(t *testing.T) {
 		tm.drivers.Add("task_b", disabledD)
 		ctx := context.Background()
 
-		tm.TaskRunNow(ctx, d)
-		tm.TaskRunNow(ctx, disabledD)
-		tm.TaskRunNow(ctx, d)
-		tm.TaskRunNow(ctx, d)
-		tm.TaskRunNow(ctx, d)
-		tm.TaskRunNow(ctx, disabledD)
+		tm.TaskRunNow(ctx, "task_a")
+		tm.TaskRunNow(ctx, "task_b")
+		tm.TaskRunNow(ctx, "task_a")
+		tm.TaskRunNow(ctx, "task_a")
+		tm.TaskRunNow(ctx, "task_a")
+		tm.TaskRunNow(ctx, "task_b")
 
 		taskStatuses := tm.state.GetTaskEvents("")
 

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -505,7 +505,6 @@ func Test_TasksManager_addTask(t *testing.T) {
 	t.Parallel()
 
 	tm := newTestTasksManager()
-	tm.deleteCh = make(chan string, 1)
 	tm.createdScheduleCh = make(chan string, 1)
 
 	t.Run("success", func(t *testing.T) {
@@ -565,6 +564,7 @@ func Test_TasksManager_addTask(t *testing.T) {
 		d := new(mocksD.Driver)
 		d.On("SetBufferPeriod").Return().Once()
 		d.On("Task").Return(driverTask)
+		d.On("DestroyTask", mock.Anything).Return().Once()
 
 		// Create an error by already adding the task to the drivers list
 		tm.drivers.Add(taskName, d)
@@ -577,16 +577,6 @@ func Test_TasksManager_addTask(t *testing.T) {
 
 		// Confirm that this second driver was not added to drivers list
 		assert.Equal(t, 1, tm.drivers.Len())
-
-		// Confirm received from delete channel for cleanup
-		select {
-		case <-tm.createdScheduleCh:
-			t.Fatal("should not have received from createdScheduleCh")
-		case <-tm.deleteCh:
-			break
-		case <-time.After(time.Second * 5):
-			t.Fatal("did not receive from deleteCh as expected")
-		}
 	})
 }
 

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -499,7 +499,7 @@ func Test_TasksManager_addTask(t *testing.T) {
 
 	tm := newTestTasksManager()
 	tm.deleteCh = make(chan string, 1)
-	tm.scheduleStartCh = make(chan driver.Driver, 1)
+	tm.createdScheduleCh = make(chan string, 1)
 
 	t.Run("success", func(t *testing.T) {
 		// Set up driver's task object
@@ -536,12 +536,12 @@ func Test_TasksManager_addTask(t *testing.T) {
 		s.AssertExpectations(t)
 		d.AssertExpectations(t)
 
-		// Confirm received from scheduleStartCh
+		// Confirm received from createdScheduleCh
 		select {
-		case <-tm.scheduleStartCh:
+		case <-tm.createdScheduleCh:
 			break
 		case <-time.After(time.Second * 5):
-			t.Fatal("did not receive from scheduleStartCh as expected")
+			t.Fatal("did not receive from createdScheduleCh as expected")
 		}
 	})
 
@@ -573,8 +573,8 @@ func Test_TasksManager_addTask(t *testing.T) {
 
 		// Confirm received from delete channel for cleanup
 		select {
-		case <-tm.scheduleStartCh:
-			t.Fatal("should not have received from scheduleStartCh")
+		case <-tm.createdScheduleCh:
+			t.Fatal("should not have received from createdScheduleCh")
 		case <-tm.deleteCh:
 			break
 		case <-time.After(time.Second * 5):


### PR DESCRIPTION
Refactor monitoring/triggering out of TasksManager. The intent is to keep TasksManager scoped to managing tasks (crud + run). A separate ConditionMonitor struct will be used to monitor changes and trigger task runs using the TasksManager.

Previous PR https://github.com/hashicorp/consul-terraform-sync/pull/831: contained miscellaneous commits that could be separated out without breaking tests and compilation.

Changes: slowly disentangles variables in TasksManager that are used by ConditionMonitor. Approximate overview of changes:
 - Setup ConditionMonitor struct
 - Move `watcher` from TasksManager to ConditionMonitor
 - Move `watcherCh` from TasksManager to ConditionMonitor
 - Remove ConditionMonitor dependency on `drivers` field and drivers in general
 - Refactor how newly created schedule tasks are started
 - Refactor how tasks are deleted
 - Refactor how deleted schedule tasks are stopped