### PR TITLE
Remove logging from health endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -94,11 +94,13 @@ func NewAPI(conf Config) (*API, error) {
 	r := chi.NewRouter()
 
 	// add the middleware for all endpoints
-	r.Use(withLogging)
 	r.Use(withCORS)
+	r.Use(withRequestID)
 
 	// add the base path route then mount the endpoints
 	r.Route(fmt.Sprintf("/%s", defaultAPIVersion), func(r chi.Router) {
+		lm := newLoggingMiddleware(nil)
+		r.Use(lm.withLogging)
 		// Legacy Endpoints
 		// retrieve overall status
 		r.Mount(fmt.Sprintf("/%s", overallStatusPath),
@@ -116,6 +118,8 @@ func NewAPI(conf Config) (*API, error) {
 	r.Group(func(r chi.Router) {
 		// Use our validation middleware to check all requests against the
 		// OpenAPI schema.
+		lm := newLoggingMiddleware([]string{healthPath})
+		r.Use(lm.withLogging)
 		r.Use(withPlaintextErrorToJson)
 		r.Use(withSwaggerValidate)
 

--- a/api/health.go
+++ b/api/health.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
 	"github.com/hashicorp/consul-terraform-sync/health"
-	"github.com/hashicorp/consul-terraform-sync/logging"
 )
 
 const (
-	getHealthSubsystemName = "gethealth"
+	healthPath = "/v1/health"
 )
 
 // HealthHandler handles the health endpoints
@@ -29,36 +28,28 @@ func NewHealthHandler(hc health.Checker) *HealthHandler {
 }
 
 // GetHealth returns the health status
+// Logging is explicitly left out of this method to avoid flooding the logs
+// as this endpoint is expected to be hit often by external entities
 func (hh *HealthHandler) GetHealth(w http.ResponseWriter, r *http.Request) {
 	hh.mu.RLock()
 	defer hh.mu.RUnlock()
-
-	logger := logging.FromContext(r.Context()).Named(getHealthSubsystemName)
-	logger.Trace("get health")
 
 	err := hh.checker.Check()
 
 	// use error type to determine if service is considered unhealthy and return
 	// a 503: service unavailable response if the system is unhealthy
-	var status int
+	status := http.StatusOK
 	resp := oapigen.HealthCheckResponse{RequestId: requestIDFromContext(r.Context())}
 
 	if err != nil {
 		resp.Error = &oapigen.Error{Message: err.Error()}
-
 		var unhealthyErr *health.UnhealthySystemError
 		if errors.As(err, &unhealthyErr) {
 			status = http.StatusServiceUnavailable
-			logger.Error("system is unhealthy", "error", err)
 		} else {
 			status = http.StatusInternalServerError
-			logger.Error("error checking health", "error", err)
 		}
-	} else {
-		status = http.StatusOK
-		logger.Trace("system is healthy")
 	}
 
 	writeResponse(w, r, status, resp)
-	logger.Trace("health retrieved")
 }

--- a/api/health_test.go
+++ b/api/health_test.go
@@ -3,11 +3,11 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"github.com/google/uuid"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/consul-terraform-sync/api/oapigen"
 	"github.com/hashicorp/consul-terraform-sync/health"
 	mockHealth "github.com/hashicorp/consul-terraform-sync/mocks/health"
@@ -47,7 +47,7 @@ func Test_HealthHandler_GetHealth(t *testing.T) {
 			checker.On("Check").Return(tc.checkReturn)
 			handler := NewHealthHandler(checker)
 
-			path := "/v1/health"
+			path := healthPath
 			req, err := http.NewRequest(http.MethodGet, path, nil)
 			require.NoError(t, err)
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -31,10 +31,13 @@ func withRequestID(next http.Handler) http.Handler {
 
 type loggingMiddleware struct {
 	uriExclusions map[string]bool
+	logger        logging.Logger
 }
 
-func newLoggingMiddleware(uriExclusions []string) loggingMiddleware {
-	lm := loggingMiddleware{}
+func newLoggingMiddleware(uriExclusions []string, logger logging.Logger) loggingMiddleware {
+	lm := loggingMiddleware{
+		logger: logger,
+	}
 	lm.uriExclusions = make(map[string]bool)
 	for _, v := range uriExclusions {
 		lm.uriExclusions[v] = true
@@ -53,7 +56,7 @@ func (lm loggingMiddleware) withLogging(next http.Handler) http.Handler {
 			return
 		}
 
-		logger := logging.Global().Named(logSystemName)
+		logger := lm.logger
 
 		// Add a UUID from the context if available
 		logger = logger.With("request_id", requestIDFromContext(r.Context()))

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -126,7 +126,7 @@ func TestStatus(t *testing.T) {
 	port := testutils.FreePort(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	api, err := NewAPI(Config{
+	api, err := NewAPI(ctx, Config{
 		Controller: ctrl,
 		Port:       port,
 	})
@@ -296,7 +296,7 @@ func TestWaitForTestReadiness(t *testing.T) {
 		port := testutils.FreePort(t)
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		api, err := NewAPI(Config{
+		api, err := NewAPI(ctx, Config{
 			Controller: ctrl,
 			Port:       port,
 		})

--- a/controller/daemon.go
+++ b/controller/daemon.go
@@ -59,7 +59,7 @@ func (ctrl *Daemon) Init(ctx context.Context) error {
 func (ctrl *Daemon) Run(ctx context.Context) error {
 	// Serve API
 	conf := ctrl.tasksManager.state.GetConfig()
-	s, err := api.NewAPI(api.Config{
+	s, err := api.NewAPI(ctx, api.Config{
 		Controller: ctrl.tasksManager,
 		Health:     &health.BasicChecker{},
 		Port:       config.IntVal(conf.Port),

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -139,3 +139,13 @@ func validateLogLevel(minLevel string) bool {
 	}
 	return false
 }
+
+// NewTestLogger configures a new logger using a provided logLevel and output and
+// returns the new hclog.Logger as type Logger
+func NewTestLogger(logLevel string, output io.Writer) Logger {
+	return hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.LevelFromString(logLevel),
+		Output:     output,
+		TimeFormat: hclog.TimeFormat,
+	})
+}


### PR DESCRIPTION
# Summary
Remove logging from `GET v1/health` endpoint call. This is required since we expect the health endpoint to get a lot of "hits" and we do not want to flood the logs

# Challenges
Oapi-codegen generated servers take an all or nothing approach to applying middleware to URIs. We can separate middleware application into groups, however, application of middleware to the oapi-codegen handler is done all at once, with no real way to exclude certain URIs from the middleware (i.e. `v1/health`)

### How we apply middleware to the group
https://github.com/hashicorp/consul-terraform-sync/blob/1bcc8ac9c73847da6f0bc256bd73f249fdcafbbd/api/api.go#L116-L129

### How routing is handled in the generated server
https://github.com/hashicorp/consul-terraform-sync/blob/1bcc8ac9c73847da6f0bc256bd73f249fdcafbbd/api/oapigen/server.go#L258-L292

# Solution
I've opted to handle the exclusion in the middleware itself, the logging middleware now has an associated object and constructor. The constructor can take a list of URIs to be excluded. 

Ideally it would be better to apply the middleware only to the paths that require it, however, with the code generation we are limited in how we can handle this.