### PR TITLE
Handle Missing ACL Errors in Consul Client

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -214,12 +214,8 @@ func (c *ConsulClient) RegisterService(ctx context.Context, r *consulapi.AgentSe
 		return nil
 	}
 
-	var missingConsulACLError *MissingConsulACLError
 	err := c.retry.Do(ctx, f, desc)
 	if err != nil {
-		if errors.As(err, &missingConsulACLError) {
-			c.logger.Warn("Unable to register service, this is most likely caused by CTS missing an ACL with `service:write` policy")
-		}
 		return err
 	}
 
@@ -253,12 +249,8 @@ func (c *ConsulClient) DeregisterService(ctx context.Context, serviceID string) 
 		return nil
 	}
 
-	var missingConsulACLError *MissingConsulACLError
 	err := c.retry.Do(ctx, f, desc)
 	if err != nil {
-		if errors.As(err, &missingConsulACLError) {
-			c.logger.Warn("Unable to deregister service, this is most likely caused by CTS missing an ACL with `service:write` policy", "service_id", serviceID)
-		}
 		return err
 	}
 

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -125,8 +125,16 @@ func (m *SelfRegistrationManager) register(ctx context.Context) error {
 	// Ignore error and continue if due to a missing ACL
 	var missingConsulACLError *client.MissingConsulACLError
 	err := m.client.RegisterService(ctx, r)
-	if err != nil && !errors.As(err, &missingConsulACLError) {
-		logger.Error("error self-registering Consul-Terraform-Sync as a service with Consul", "error", err)
+	if err != nil {
+		baseErrMsg := "error self-registering Consul-Terraform-Sync as a service with Consul"
+		if errors.As(err, &missingConsulACLError) {
+			logger.Error(fmt.Sprintf("%s: "+
+				"configure CTS with an ACL including `service:write` or "+
+				"disable registration in configuration", baseErrMsg), "error", err)
+		} else {
+			logger.Error(baseErrMsg)
+		}
+
 		return err
 	}
 
@@ -142,8 +150,16 @@ func (m *SelfRegistrationManager) deregister(ctx context.Context) error {
 	// Ignore error and continue if due to a missing ACL
 	var missingConsulACLError *client.MissingConsulACLError
 	err := m.client.DeregisterService(ctx, m.service.id)
-	if err != nil && !errors.As(err, &missingConsulACLError) {
-		logger.Error("error deregistering Consul-Terraform-Sync from Consul", "error", err)
+	if err != nil {
+		baseErrMsg := "error deregistering Consul-Terraform-Sync from Consul"
+		if errors.As(err, &missingConsulACLError) {
+			logger.Error(fmt.Sprintf("%s: "+
+				"configure CTS with an ACL including `service:write` or "+
+				"disable registration in configuration", baseErrMsg), "error", err)
+		} else {
+			logger.Error(baseErrMsg, "error", err)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
#Summary
This ticket introduces handling of errors which can be interpreted as resulting from a missing ACL. In most cases this can be determined by checking for a `403` or `access forbidden` response code from the Consul server, however, Consul team has mentioned that the way ACL access is handled can be non standard, so this cannot be depended on across all endpoints.

## Investigating Register/Deregister Missing ACL Response
Both register and deregister require an ACL with a `service:write` policy, testing the following endpoints:
`/v1/agent/service/register`
`/v1/agent/service/deregister/{service-name}`

I have verified that both return a `403` in the instance where an ACL is used without the `service:write` policy.

## Solution
When a `403` is returned by the clients `Register` and `Deregister` retrying is stopped, and a `MissingConsulACLError` is returned. The caller is then responsible for handling this error, which in this case, is ignored by the manager.