### PR TITLE
Additional self-registration configurations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -312,6 +312,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := c.Consul.Validate(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -62,7 +62,7 @@ var (
 				Namespace:   String("test-ns"),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(true),
-					Address: String("cts"),
+					Address: String("http://cts"),
 				},
 			},
 		},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,6 +60,10 @@ var (
 				Enabled:     Bool(true),
 				ServiceName: String("test-service"),
 				Namespace:   String("test-ns"),
+				DefaultCheck: &DefaultCheckConfig{
+					Enabled: Bool(true),
+					Address: String("cts"),
+				},
 			},
 		},
 		TLS: &CTSTLSConfig{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,8 +57,9 @@ var (
 				TLSHandshakeTimeout: TimeDuration(10 * time.Second),
 			},
 			SelfRegistration: &SelfRegistrationConfig{
-				Enabled:   Bool(true),
-				Namespace: String("test-ns"),
+				Enabled:     Bool(true),
+				ServiceName: String("test-service"),
+				Namespace:   String("test-ns"),
 			},
 		},
 		TLS: &CTSTLSConfig{

--- a/config/consul.go
+++ b/config/consul.go
@@ -189,6 +189,22 @@ func (c *ConsulConfig) Finalize() {
 
 }
 
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *ConsulConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if c.SelfRegistration != nil {
+		if err := c.SelfRegistration.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GoString defines the printable version of this struct.
 // Sensitive information is redacted.
 func (c *ConsulConfig) GoString() string {

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -40,8 +40,9 @@ func TestConsulConfig_Copy(t *testing.T) {
 				TLS:         &TLSConfig{Enabled: Bool(true)},
 				Token:       String("abcd1234"),
 				SelfRegistration: &SelfRegistrationConfig{
-					Enabled:   Bool(false),
-					Namespace: String("test-ns"),
+					Enabled:     Bool(false),
+					ServiceName: String("test-service"),
+					Namespace:   String("test-ns"),
 				},
 			},
 		},
@@ -282,8 +283,9 @@ func TestConsulConfig_Finalize(t *testing.T) {
 					TLSHandshakeTimeout: TimeDuration(DefaultTLSHandshakeTimeout),
 				},
 				SelfRegistration: &SelfRegistrationConfig{
-					Enabled:   Bool(true),
-					Namespace: String(""),
+					Enabled:     Bool(true),
+					ServiceName: String(DefaultServiceName),
+					Namespace:   String(""),
 				},
 			},
 		},

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -43,6 +43,10 @@ func TestConsulConfig_Copy(t *testing.T) {
 					Enabled:     Bool(false),
 					ServiceName: String("test-service"),
 					Namespace:   String("test-ns"),
+					DefaultCheck: &DefaultCheckConfig{
+						Enabled: Bool(true),
+						Address: String("test"),
+					},
 				},
 			},
 		},
@@ -286,6 +290,10 @@ func TestConsulConfig_Finalize(t *testing.T) {
 					Enabled:     Bool(true),
 					ServiceName: String(DefaultServiceName),
 					Namespace:   String(""),
+					DefaultCheck: &DefaultCheckConfig{
+						Enabled: Bool(true),
+						Address: String(""),
+					},
 				},
 			},
 		},

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConsulConfig_Copy(t *testing.T) {
@@ -303,6 +304,49 @@ func TestConsulConfig_Finalize(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_%s", i, tc.name), func(t *testing.T) {
 			tc.i.Finalize()
 			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestConsulConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		c         *ConsulConfig
+		expectErr bool
+	}{
+		{
+			"nil",
+			nil,
+			false,
+		},
+		{
+			"empty",
+			&ConsulConfig{},
+			false,
+		},
+		{
+			"invalid",
+			&ConsulConfig{
+				SelfRegistration: &SelfRegistrationConfig{
+					DefaultCheck: &DefaultCheckConfig{
+						Address: String("172.0.0.8:5000"),
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/config/default_check.go
+++ b/config/default_check.go
@@ -1,0 +1,78 @@
+package config
+
+import "fmt"
+
+// DefaultCheckConfig is a configuration that controls whether to
+// create a default health check on the CTS service in Consul. It
+// also allows for some modification of the health check to account
+// for different setups of CTS.
+type DefaultCheckConfig struct {
+	Enabled *bool   `mapstructure:"enabled"`
+	Address *string `mapstructure:"address"`
+}
+
+// Copy returns a deep copy of this configuration.
+func (c *DefaultCheckConfig) Copy() *DefaultCheckConfig {
+	if c == nil {
+		return nil
+	}
+
+	var o DefaultCheckConfig
+	o.Enabled = BoolCopy(c.Enabled)
+	o.Address = StringCopy(c.Address)
+
+	return &o
+}
+
+// Merge combines all values in this configuration with the values in the other
+// configuration, with values in the other configuration taking precedence.
+func (c *DefaultCheckConfig) Merge(o *DefaultCheckConfig) *DefaultCheckConfig {
+	if c == nil {
+		if o == nil {
+			return nil
+		}
+		return o.Copy()
+	}
+
+	if o == nil {
+		return c.Copy()
+	}
+
+	r := c.Copy()
+
+	if o.Enabled != nil {
+		r.Enabled = BoolCopy(o.Enabled)
+	}
+
+	if o.Address != nil {
+		r.Address = StringCopy(o.Address)
+	}
+
+	return r
+}
+
+// Finalize ensures that the receiver contains no nil pointers.
+func (c *DefaultCheckConfig) Finalize() {
+	if c.Enabled == nil {
+		c.Enabled = Bool(true)
+	}
+
+	if c.Address == nil {
+		c.Address = String("")
+	}
+}
+
+// GoString defines the printable version of this struct.
+func (c *DefaultCheckConfig) GoString() string {
+	if c == nil {
+		return "(*DefaultCheckConfig)(nil)"
+	}
+
+	return fmt.Sprintf("&DefaultCheckConfig{"+
+		"Enabled:%v, "+
+		"Address:%s"+
+		"}",
+		BoolVal(c.Enabled),
+		StringVal(c.Address),
+	)
+}

--- a/config/default_check_test.go
+++ b/config/default_check_test.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultCheckConfig_Copy(t *testing.T) {
+	t.Parallel()
+
+	finalizedConf := &DefaultCheckConfig{}
+	finalizedConf.Finalize()
+
+	cases := []struct {
+		name string
+		a    *DefaultCheckConfig
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"empty",
+			&DefaultCheckConfig{},
+		},
+		{
+			"finalized",
+			finalizedConf,
+		},
+		{
+			"fully_configured",
+			&DefaultCheckConfig{
+				Enabled: Bool(false),
+				Address: String("test"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Copy()
+			assert.Equal(t, tc.a, r)
+		})
+	}
+}
+
+func TestDefaultCheckConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    *DefaultCheckConfig
+		b    *DefaultCheckConfig
+		r    *DefaultCheckConfig
+	}{
+		{
+			"nil_a",
+			nil,
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{},
+		},
+		{
+			"nil_b",
+			&DefaultCheckConfig{},
+			nil,
+			&DefaultCheckConfig{},
+		},
+		{
+			"nil_both",
+			nil,
+			nil,
+			nil,
+		},
+		{
+			"empty",
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{},
+		},
+		{
+			"enabled_overrides",
+			&DefaultCheckConfig{Enabled: Bool(false)},
+			&DefaultCheckConfig{Enabled: Bool(true)},
+			&DefaultCheckConfig{Enabled: Bool(true)},
+		},
+		{
+			"enabled_empty_one",
+			&DefaultCheckConfig{Enabled: Bool(false)},
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_empty_two",
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{Enabled: Bool(false)},
+			&DefaultCheckConfig{Enabled: Bool(false)},
+		},
+		{
+			"enabled_same",
+			&DefaultCheckConfig{Enabled: Bool(false)},
+			&DefaultCheckConfig{Enabled: Bool(false)},
+			&DefaultCheckConfig{Enabled: Bool(false)},
+		},
+		{
+			"address_overrides",
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+			&DefaultCheckConfig{Address: String("test")},
+			&DefaultCheckConfig{Address: String("test")},
+		},
+		{
+			"address_empty_one",
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+		},
+		{
+			"address_empty_two",
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+		},
+		{
+			"address_same",
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+			&DefaultCheckConfig{Address: String("127.0.0.1:123")},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.a.Merge(tc.b)
+			assert.Equal(t, tc.r, r)
+		})
+	}
+}
+
+func TestDefaultCheckConfig_Finalize(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		i    *DefaultCheckConfig
+		r    *DefaultCheckConfig
+	}{
+		{
+			"empty",
+			&DefaultCheckConfig{},
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String(""),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.i.Finalize()
+			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestDefaultCheckConfig_GoString(t *testing.T) {
+	cases := []struct {
+		name     string
+		c        *DefaultCheckConfig
+		expected string
+	}{
+		{
+			"nil",
+			nil,
+			"(*DefaultCheckConfig)(nil)",
+		},
+		{
+			"fully_configured",
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String("test"),
+			},
+			"&DefaultCheckConfig{" +
+				"Enabled:true, " +
+				"Address:test" +
+				"}",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.c.GoString()
+			assert.Equal(t, tc.expected, r)
+		})
+	}
+}

--- a/config/default_check_test.go
+++ b/config/default_check_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefaultCheckConfig_Copy(t *testing.T) {
@@ -158,6 +159,70 @@ func TestDefaultCheckConfig_Finalize(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.i.Finalize()
 			assert.Equal(t, tc.r, tc.i)
+		})
+	}
+}
+
+func TestDefaultCheckConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		c         *DefaultCheckConfig
+		expectErr bool
+	}{
+		{
+			"nil",
+			nil,
+			false,
+		},
+		{
+			"empty",
+			&DefaultCheckConfig{},
+			false,
+		},
+		{
+			"defaults",
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String(""),
+			},
+			false,
+		},
+		{
+			"configured",
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String("https://cts"),
+			},
+			false,
+		},
+		{
+			"invalid_no_scheme",
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String("127.0.0.1"),
+			},
+			true,
+		},
+		{
+			"invalid_format",
+			&DefaultCheckConfig{
+				Enabled: Bool(true),
+				Address: String("http-not-a-uri"),
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/config/self_registration.go
+++ b/config/self_registration.go
@@ -2,19 +2,25 @@ package config
 
 import "fmt"
 
+const (
+	DefaultServiceName = "Consul-Terraform-Sync"
+)
+
 // SelfRegistrationConfig is a configuration that controls how CTS will
 // self-register itself as a service with Consul.
 type SelfRegistrationConfig struct {
-	Enabled   *bool   `mapstructure:"enabled"`
-	Namespace *string `mapstructure:"namespace"`
+	Enabled     *bool   `mapstructure:"enabled"`
+	ServiceName *string `mapstructure:"service_name"`
+	Namespace   *string `mapstructure:"namespace"`
 }
 
 // DefaultSelfRegistrationConfig returns a SelfRegistrationConfig with
 // default values.
 func DefaultSelfRegistrationConfig() *SelfRegistrationConfig {
 	return &SelfRegistrationConfig{
-		Enabled:   Bool(true),
-		Namespace: String(""),
+		Enabled:     Bool(true),
+		ServiceName: String(DefaultServiceName),
+		Namespace:   String(""),
 	}
 }
 
@@ -26,6 +32,7 @@ func (c *SelfRegistrationConfig) Copy() *SelfRegistrationConfig {
 
 	var o SelfRegistrationConfig
 	o.Enabled = BoolCopy(c.Enabled)
+	o.ServiceName = StringCopy(c.ServiceName)
 	o.Namespace = StringCopy(c.Namespace)
 
 	return &o
@@ -51,6 +58,10 @@ func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrat
 		r.Enabled = BoolCopy(o.Enabled)
 	}
 
+	if o.ServiceName != nil {
+		r.ServiceName = StringCopy(o.ServiceName)
+	}
+
 	if o.Namespace != nil {
 		r.Namespace = StringCopy(o.Namespace)
 	}
@@ -62,6 +73,10 @@ func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrat
 func (c *SelfRegistrationConfig) Finalize() {
 	if c.Enabled == nil {
 		c.Enabled = Bool(true)
+	}
+
+	if c.ServiceName == nil {
+		c.ServiceName = String(DefaultServiceName)
 	}
 
 	if c.Namespace == nil {
@@ -77,9 +92,11 @@ func (c *SelfRegistrationConfig) GoString() string {
 
 	return fmt.Sprintf("&SelfRegistrationConfig{"+
 		"Enabled:%v, "+
+		"ServiceName:%s, "+
 		"Namespace:%s"+
 		"}",
 		BoolVal(c.Enabled),
+		StringVal(c.ServiceName),
 		StringVal(c.Namespace),
 	)
 }

--- a/config/self_registration.go
+++ b/config/self_registration.go
@@ -9,9 +9,10 @@ const (
 // SelfRegistrationConfig is a configuration that controls how CTS will
 // self-register itself as a service with Consul.
 type SelfRegistrationConfig struct {
-	Enabled     *bool   `mapstructure:"enabled"`
-	ServiceName *string `mapstructure:"service_name"`
-	Namespace   *string `mapstructure:"namespace"`
+	Enabled      *bool               `mapstructure:"enabled"`
+	ServiceName  *string             `mapstructure:"service_name"`
+	Namespace    *string             `mapstructure:"namespace"`
+	DefaultCheck *DefaultCheckConfig `mapstructure:"default_check"`
 }
 
 // DefaultSelfRegistrationConfig returns a SelfRegistrationConfig with
@@ -21,6 +22,10 @@ func DefaultSelfRegistrationConfig() *SelfRegistrationConfig {
 		Enabled:     Bool(true),
 		ServiceName: String(DefaultServiceName),
 		Namespace:   String(""),
+		DefaultCheck: &DefaultCheckConfig{
+			Enabled: Bool(true),
+			Address: String(""),
+		},
 	}
 }
 
@@ -34,6 +39,10 @@ func (c *SelfRegistrationConfig) Copy() *SelfRegistrationConfig {
 	o.Enabled = BoolCopy(c.Enabled)
 	o.ServiceName = StringCopy(c.ServiceName)
 	o.Namespace = StringCopy(c.Namespace)
+
+	if c.DefaultCheck != nil {
+		o.DefaultCheck = c.DefaultCheck.Copy()
+	}
 
 	return &o
 }
@@ -66,6 +75,10 @@ func (c *SelfRegistrationConfig) Merge(o *SelfRegistrationConfig) *SelfRegistrat
 		r.Namespace = StringCopy(o.Namespace)
 	}
 
+	if o.DefaultCheck != nil {
+		r.DefaultCheck = r.DefaultCheck.Merge(o.DefaultCheck)
+	}
+
 	return r
 }
 
@@ -82,6 +95,11 @@ func (c *SelfRegistrationConfig) Finalize() {
 	if c.Namespace == nil {
 		c.Namespace = String("")
 	}
+
+	if c.DefaultCheck == nil {
+		c.DefaultCheck = &DefaultCheckConfig{}
+		c.DefaultCheck.Finalize()
+	}
 }
 
 // GoString defines the printable version of this struct.
@@ -93,10 +111,12 @@ func (c *SelfRegistrationConfig) GoString() string {
 	return fmt.Sprintf("&SelfRegistrationConfig{"+
 		"Enabled:%v, "+
 		"ServiceName:%s, "+
-		"Namespace:%s"+
+		"Namespace:%s, "+
+		"DefaultCheck: %s"+
 		"}",
 		BoolVal(c.Enabled),
 		StringVal(c.ServiceName),
 		StringVal(c.Namespace),
+		c.DefaultCheck.GoString(),
 	)
 }

--- a/config/self_registration.go
+++ b/config/self_registration.go
@@ -102,6 +102,22 @@ func (c *SelfRegistrationConfig) Finalize() {
 	}
 }
 
+// Validate validates the values and required options. This method is recommended
+// to run after Finalize() to ensure the configuration is safe to proceed.
+func (c *SelfRegistrationConfig) Validate() error {
+	if c == nil { // config not required, return early
+		return nil
+	}
+
+	if c.DefaultCheck != nil {
+		if err := c.DefaultCheck.Validate(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // GoString defines the printable version of this struct.
 func (c *SelfRegistrationConfig) GoString() string {
 	if c == nil {

--- a/config/self_registration_test.go
+++ b/config/self_registration_test.go
@@ -10,8 +10,9 @@ func TestSelfRegistrationConfig_DefaultSelfRegistrationConfig(t *testing.T) {
 	t.Parallel()
 	r := DefaultSelfRegistrationConfig()
 	expected := &SelfRegistrationConfig{
-		Enabled:   Bool(true),
-		Namespace: String(""),
+		Enabled:     Bool(true),
+		Namespace:   String(""),
+		ServiceName: String(DefaultServiceName),
 	}
 	assert.Equal(t, expected, r)
 }
@@ -41,8 +42,9 @@ func TestSelfRegistrationConfig_Copy(t *testing.T) {
 		{
 			"fully_configured",
 			&SelfRegistrationConfig{
-				Enabled:   Bool(false),
-				Namespace: String("test"),
+				Enabled:     Bool(false),
+				ServiceName: String("cts-service"),
+				Namespace:   String("test"),
 			},
 		},
 	}
@@ -136,6 +138,30 @@ func TestSelfRegistrationConfig_Merge(t *testing.T) {
 			&SelfRegistrationConfig{Namespace: String("ns_a")},
 			&SelfRegistrationConfig{Namespace: String("ns_a")},
 		},
+		{
+			"service_name_overrides",
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+			&SelfRegistrationConfig{ServiceName: String("service_b")},
+			&SelfRegistrationConfig{ServiceName: String("service_b")},
+		},
+		{
+			"service_name_empty_one",
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+		},
+		{
+			"service_name_empty_two",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+		},
+		{
+			"service_name_same",
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+			&SelfRegistrationConfig{ServiceName: String("service_a")},
+		},
 	}
 
 	for _, tc := range cases {
@@ -158,8 +184,9 @@ func TestSelfRegistrationConfig_Finalize(t *testing.T) {
 			"empty",
 			&SelfRegistrationConfig{},
 			&SelfRegistrationConfig{
-				Enabled:   Bool(true),
-				Namespace: String(""),
+				Enabled:     Bool(true),
+				ServiceName: String(DefaultServiceName),
+				Namespace:   String(""),
 			},
 		},
 	}
@@ -186,11 +213,13 @@ func TestSelfRegistrationConfig_GoString(t *testing.T) {
 		{
 			"fully_configured",
 			&SelfRegistrationConfig{
-				Enabled:   Bool(true),
-				Namespace: String("test"),
+				Enabled:     Bool(true),
+				ServiceName: String("cts-service"),
+				Namespace:   String("test"),
 			},
 			"&SelfRegistrationConfig{" +
 				"Enabled:true, " +
+				"ServiceName:cts-service, " +
 				"Namespace:test" +
 				"}",
 		},

--- a/config/self_registration_test.go
+++ b/config/self_registration_test.go
@@ -13,6 +13,10 @@ func TestSelfRegistrationConfig_DefaultSelfRegistrationConfig(t *testing.T) {
 		Enabled:     Bool(true),
 		Namespace:   String(""),
 		ServiceName: String(DefaultServiceName),
+		DefaultCheck: &DefaultCheckConfig{
+			Enabled: Bool(true),
+			Address: String(""),
+		},
 	}
 	assert.Equal(t, expected, r)
 }
@@ -45,6 +49,10 @@ func TestSelfRegistrationConfig_Copy(t *testing.T) {
 				Enabled:     Bool(false),
 				ServiceName: String("cts-service"),
 				Namespace:   String("test"),
+				DefaultCheck: &DefaultCheckConfig{
+					Enabled: Bool(false),
+					Address: String("test"),
+				},
 			},
 		},
 	}
@@ -162,6 +170,30 @@ func TestSelfRegistrationConfig_Merge(t *testing.T) {
 			&SelfRegistrationConfig{ServiceName: String("service_a")},
 			&SelfRegistrationConfig{ServiceName: String("service_a")},
 		},
+		{
+			"default_check_overrides",
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(true)}},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+		},
+		{
+			"default_check_empty_one",
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+		},
+		{
+			"default_check_empty_two",
+			&SelfRegistrationConfig{},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+		},
+		{
+			"default_check_same",
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+			&SelfRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
+		},
 	}
 
 	for _, tc := range cases {
@@ -187,6 +219,10 @@ func TestSelfRegistrationConfig_Finalize(t *testing.T) {
 				Enabled:     Bool(true),
 				ServiceName: String(DefaultServiceName),
 				Namespace:   String(""),
+				DefaultCheck: &DefaultCheckConfig{
+					Enabled: Bool(true),
+					Address: String(""),
+				},
 			},
 		},
 	}
@@ -216,11 +252,16 @@ func TestSelfRegistrationConfig_GoString(t *testing.T) {
 				Enabled:     Bool(true),
 				ServiceName: String("cts-service"),
 				Namespace:   String("test"),
+				DefaultCheck: &DefaultCheckConfig{
+					Enabled: Bool(false),
+					Address: String("test"),
+				},
 			},
 			"&SelfRegistrationConfig{" +
 				"Enabled:true, " +
 				"ServiceName:cts-service, " +
-				"Namespace:test" +
+				"Namespace:test, " +
+				"DefaultCheck: &DefaultCheckConfig{Enabled:false, Address:test}" +
 				"}",
 		},
 	}

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -50,6 +50,10 @@ consul {
     enabled = true
     service_name = "test-service"
     namespace = "test-ns"
+    default_check {
+      enabled = true
+      address = "cts"
+    }
   }
 }
 

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -52,7 +52,7 @@ consul {
     namespace = "test-ns"
     default_check {
       enabled = true
-      address = "cts"
+      address = "http://cts"
     }
   }
 }

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -48,6 +48,7 @@ consul {
   }
   self_registration {
     enabled = true
+    service_name = "test-service"
     namespace = "test-ns"
   }
 }

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -49,7 +49,7 @@
       "namespace": "test-ns",
       "default_check": {
         "enabled": true,
-        "address": "cts"
+        "address": "http://cts"
       }
     }
   },

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -45,6 +45,7 @@
     },
     "self_registration": {
       "enabled": true,
+      "service_name": "test-service",
       "namespace": "test-ns"
     }
   },

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -46,7 +46,11 @@
     "self_registration": {
       "enabled": true,
       "service_name": "test-service",
-      "namespace": "test-ns"
+      "namespace": "test-ns",
+      "default_check": {
+        "enabled": true,
+        "address": "cts"
+      }
     }
   },
   "driver": {

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -12,8 +12,7 @@ import (
 
 const (
 	// Service defaults
-	defaultServiceName = "Consul-Terraform-Sync"
-	defaultNamespace   = ""
+	defaultNamespace = ""
 
 	// Check defaults
 	defaultCheckName                      = "CTS Health Status"
@@ -64,7 +63,10 @@ type service struct {
 func NewSelfRegistrationManager(conf *SelfRegistrationManagerConfig, client client.ConsulClientInterface) *SelfRegistrationManager {
 	logger := logging.Global().Named(logSystemName)
 
-	name := defaultServiceName
+	name := config.DefaultServiceName
+	if conf.SelfRegistration.ServiceName != nil {
+		name = *conf.SelfRegistration.ServiceName
+	}
 
 	ns := defaultNamespace
 	if conf.SelfRegistration.Namespace != nil {

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -32,7 +32,7 @@ func TestNewSelfRegistrationManager(t *testing.T) {
 				SelfRegistration: config.DefaultSelfRegistrationConfig(),
 			},
 			&service{
-				name:      defaultServiceName,
+				name:      config.DefaultServiceName,
 				tags:      defaultServiceTags,
 				id:        "cts-123",
 				port:      123,
@@ -40,17 +40,18 @@ func TestNewSelfRegistrationManager(t *testing.T) {
 			},
 		},
 		{
-			"namespace",
+			"configured",
 			&SelfRegistrationManagerConfig{
 				ID:         "cts-123",
 				Port:       123,
 				TLSEnabled: false,
 				SelfRegistration: &config.SelfRegistrationConfig{
-					Namespace: config.String("ns-1"),
+					ServiceName: config.String("cts-service"),
+					Namespace:   config.String("ns-1"),
 				},
 			},
 			&service{
-				name:      defaultServiceName,
+				name:      "cts-service",
 				tags:      defaultServiceTags,
 				id:        "cts-123",
 				port:      123,
@@ -145,9 +146,10 @@ func TestSelfRegistrationManager_defaultHTTPCheck(t *testing.T) {
 func TestSelfRegistrationManager_Start(t *testing.T) {
 	t.Parallel()
 	id := "cts-123"
+	name := "cts-service"
 	manager := &SelfRegistrationManager{
 		service: &service{
-			name: defaultServiceName,
+			name: name,
 			id:   id,
 		},
 		logger: logging.NewNullLogger(),
@@ -159,7 +161,7 @@ func TestSelfRegistrationManager_Start(t *testing.T) {
 		mockClient.On("RegisterService", mock.Anything,
 			&consulapi.AgentServiceRegistration{
 				ID:   id,
-				Name: defaultServiceName,
+				Name: name,
 			},
 		).Return(nil)
 		mockClient.On("DeregisterService", mock.Anything, id).Return(nil)
@@ -243,7 +245,7 @@ func TestSelfRegistrationManager_deregister(t *testing.T) {
 	ctx := context.Background()
 	manager := &SelfRegistrationManager{
 		service: &service{
-			name: defaultServiceName,
+			name: config.DefaultServiceName,
 			id:   id,
 		},
 		logger: logging.NewNullLogger(),
@@ -275,6 +277,7 @@ func TestSelfRegistrationManager_deregister(t *testing.T) {
 func TestSelfRegistrationManager_register(t *testing.T) {
 	t.Parallel()
 	id := "cts-123"
+	name := "cts-service"
 	port := 8558
 	ns := "ns-1"
 	check := defaultHTTPCheck(&SelfRegistrationManagerConfig{
@@ -285,7 +288,7 @@ func TestSelfRegistrationManager_register(t *testing.T) {
 		},
 	})
 	service := &service{
-		name:      defaultServiceName,
+		name:      name,
 		tags:      defaultServiceTags,
 		port:      port,
 		id:        id,
@@ -304,7 +307,7 @@ func TestSelfRegistrationManager_register(t *testing.T) {
 					// expect these values for the service registration request
 					&consulapi.AgentServiceRegistration{
 						ID:        id,
-						Name:      defaultServiceName,
+						Name:      name,
 						Port:      port,
 						Namespace: ns,
 						Tags:      defaultServiceTags,

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -48,6 +48,9 @@ func TestNewSelfRegistrationManager(t *testing.T) {
 				SelfRegistration: &config.SelfRegistrationConfig{
 					ServiceName: config.String("cts-service"),
 					Namespace:   config.String("ns-1"),
+					DefaultCheck: &config.DefaultCheckConfig{
+						Enabled: config.Bool(true),
+					},
 				},
 			},
 			&service{
@@ -123,6 +126,31 @@ func TestSelfRegistrationManager_defaultHTTPCheck(t *testing.T) {
 			},
 			&consulapi.AgentServiceCheck{
 				HTTP:                           httpsAddress,
+				Name:                           defaultCheckName,
+				CheckID:                        checkID,
+				Notes:                          defaultCheckNotes,
+				DeregisterCriticalServiceAfter: defaultDeregisterCriticalServiceAfter,
+				Status:                         defaultCheckStatus,
+				Method:                         defaultMethod,
+				Interval:                       defaultInterval,
+				Timeout:                        defaultTimeout,
+				TLSSkipVerify:                  defaultTLSSkipVerify,
+			},
+		},
+		{
+			"address_configured",
+			&SelfRegistrationManagerConfig{
+				ID:         id,
+				Port:       port,
+				TLSEnabled: true,
+				SelfRegistration: &config.SelfRegistrationConfig{
+					DefaultCheck: &config.DefaultCheckConfig{
+						Address: config.String("http://127.0.0.1:5885"),
+					},
+				},
+			},
+			&consulapi.AgentServiceCheck{
+				HTTP:                           "http://127.0.0.1:5885" + defaultHealthEndpoint,
 				Name:                           defaultCheckName,
 				CheckID:                        checkID,
 				Notes:                          defaultCheckNotes,
@@ -285,6 +313,9 @@ func TestSelfRegistrationManager_register(t *testing.T) {
 		Port: port,
 		SelfRegistration: &config.SelfRegistrationConfig{
 			Namespace: &ns,
+			DefaultCheck: &config.DefaultCheckConfig{
+				Enabled: config.Bool(true),
+			},
 		},
 	})
 	service := &service{


### PR DESCRIPTION
Add support for configuring the service name and the default health check, allowing users to disable the check and to specify an address if `localhost` does not work in their system.

```
  self_registration {
    service_name = "test-service"
    default_check {
      enabled = true
      address = "http://172.0.1.23:8080"
    }
  }

```

Note: Still have `self_registration` for now even though there are discussions to change this.