### PR TITLE
removed warn logging from GetLicense, leave it to the caller

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -168,15 +167,12 @@ func (c *ConsulClient) GetLicense(ctx context.Context, q *consulapi.QueryOptions
 		return nil
 	}
 
-	var nonEnterpriseConsulError *NonEnterpriseConsulError
 	err = c.retry.Do(ctx, f, desc)
 	if err != nil {
-		if errors.As(err, &nonEnterpriseConsulError) {
-			c.logger.Warn("Unable to get license, this is most likely caused by CTS connecting to OSS Consul")
-		}
+		return "", err
 	}
 
-	return license, err
+	return license, nil
 }
 
 // RegisterService registers a service through the Consul agent.


### PR DESCRIPTION
After discussion, it makes sense for the warning log in the Consul Client GetLicense to be removed. The caller of this method would handle the error and perform logging accordingly. The context of the error is not lost as it is wrapped in a NonEnterpriseConsulError.