### PR TITLE
add warning log to indicate that CTS will still continue

### DIFF
--- a/registration/manager.go
+++ b/registration/manager.go
@@ -100,6 +100,7 @@ func (m *ServiceRegistrationManager) Start(ctx context.Context) error {
 	// Register CTS with Consul
 	err := m.register(ctx)
 	if err != nil {
+		m.logger.Warn("CTS will continue without registering itself as a service with Consul")
 		return err
 	}
 


### PR DESCRIPTION
Added a warning log to indicate that CTS will continue even if there is an error registering CTS with Consul