### PR TITLE
Fix TestTaskStatus_ServeHTTP

### DIFF
--- a/api/task_status_test.go
+++ b/api/task_status_test.go
@@ -60,7 +60,8 @@ func TestTaskStatus_ServeHTTP(t *testing.T) {
 	ctrl := new(serverMocks.Server)
 	confs := make(config.TaskConfigs, 0, len(configs))
 	for taskName, conf := range configs {
-		confs = append(confs, &conf)
+		taskConf := conf // create a locally scoped var to avoid problems with pointer
+		confs = append(confs, &taskConf)
 		eventResp := make(map[string][]event.Event)
 		if es, ok := events[taskName]; ok {
 			eventResp[taskName] = es


### PR DESCRIPTION
This test was ocasionally failing because of the for-loop to create
config.TaskConfigs would occasionally return config.TaskConfigs set with all
only the last configuration

For example if the `configs` has task a, b, c, and d, then `confs` would return
[d, d, d, d]

```
	for taskName, conf := range configs {
		confs = append(confs, &conf)
		// ...
	}
```

Fix this by creating a locally scoped variable