### PR TITLE
Added dependabot config for go modules version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "dependabot-test"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     target-branch: "dependabot-test"
     schedule:
       interval: "daily"
+      time: "17:00"
+      timezone: "America/Chicago"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,3 @@ updates:
     target-branch: "dependabot-test"
     schedule:
       interval: "daily"
-      time: "17:00"
-      timezone: "America/Chicago"


### PR DESCRIPTION
This PR adds a dependabot config that targets `dependabot-test` branch for gomod version management. It is experimental for now and will start targeting `main` after evaluating the results.