### PR TITLE
E2E test results and concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,52 +8,37 @@ executors:
     docker:
       - image: docker.mirror.hashicorp.services/cimg/go:${GO_VERSION}
     environment:
-      CONSUL_VERSION: "1.10.3"
       GOMAXPROCS: 4
       GO111MODULE: "on"
       GOPROXY: https://proxy.golang.org/
       GO_VERSION: 1.16
+      CONSUL_VERSION: "1.10.3"
       TERRAFORM_VERSION: "1.0.8"
       VAULT_VERSION: "1.8.3"
+      GOTESTSUM_VERSION: "1.8.1"
+      E2E_TESTS_PARALLELISM: 3
 
-jobs:
-  unit_integration_tests:
-    executor:
-      name: go
+commands:
+  setup-consul:
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - ct-modcache-v2-{{ checksum "go.mod" }}
-      - run: |
-          curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
-          unzip consul.zip
-          sudo cp consul /usr/local/bin/
-      - run: |
-          make test-integration
-      - when:
-          condition:
-            or:
-              - equal: [ main, <<pipeline.git.branch>> ]
-              - matches: { pattern: "release/.+", value: <<pipeline.git.branch>> }
-          steps:
-            - slack/notify:
-                event: fail
-                template: basic_fail_1
-                branch_pattern: main,release/.+
-      - save_cache:
-          key: ct-modcache-v2-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
+      - run:
+          name: Install Consul
+          command: |
+            curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+            unzip consul.zip
+            sudo cp consul /usr/local/bin/
 
-  vault_integration_tests:
-    executor:
-      name: go
+  setup-terraform:
     steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - ct-modcache-v2-{{ checksum "go.mod" }}
+      - run:
+          name: Install Terraform
+          command: |
+            curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+            unzip terraform.zip
+            sudo cp terraform /usr/local/bin/
+
+  setup-vault:
+    steps:
       - run:
           name: Install Vault
           command: |
@@ -61,28 +46,26 @@ jobs:
             unzip vault.zip
             sudo cp vault /usr/local/bin/
             vault version
-      - run: |
-          go test -count=1 -timeout=80s -tags 'integration vault' ./... -run Vault
-      - save_cache:
-          key: ct-modcache-v2-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
 
-  e2e_tests:
+  setup-gotestsum:
+    steps:
+      - run:
+          name: Install gotestsum
+          command: |
+            curl -sLo gotestsum.tar.gz https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/gotestsum_${GOTESTSUM_VERSION}_linux_amd64.tar.gz
+            tar -xzf gotestsum.tar.gz gotestsum
+            sudo cp gotestsum /usr/local/bin/
+
+jobs:
+  unit-and-integration-tests:
     executor:
       name: go
-    resource_class: medium+
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - ct-modcache-v2-{{ checksum "go.mod" }}
-      - run: |
-          curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
-          unzip consul.zip
-          sudo cp consul /usr/local/bin/
-      - run: |
-          make test-e2e-cirecleci
+      - setup-consul
+      - run: make test-unit-and-integration
+      - store_test_results:
+          path: .build/test-results
       - when:
           condition:
             or:
@@ -93,28 +76,53 @@ jobs:
                 event: fail
                 template: basic_fail_1
                 branch_pattern: main,release/.+
-      - save_cache:
-          key: ct-modcache-v2-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
 
-  consul_compatibility_tests:
+  vault-integration-tests:
     executor:
       name: go
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - ct-modcache-v2-{{ checksum "go.mod" }}
-      - run: |
-          make test-compat
+      - setup-vault
+      - run: go test -count=1 -timeout=80s -tags 'integration vault' ./... -run Vault
+
+  e2e-tests:
+    executor:
+      name: go
+    resource_class: medium+
+    parameters:
+      part_index:
+        type: integer
+    steps:
+      - checkout
+      - setup-consul
+      - setup-gotestsum
+      - run:
+          name: E2E tests
+          command: |
+            ./build-scripts/split-tests.sh e2e ./e2e ${E2E_TESTS_PARALLELISM} ${PWD}/.build/chunks
+            CHUNK_INDEX=<< parameters.part_index >> make test-e2e-circleci
+      - store_test_results:
+          path: .build/test-results
+      - when:
+          condition:
+            or:
+              - equal: [ main, <<pipeline.git.branch>> ]
+              - matches: { pattern: "release/.+", value: <<pipeline.git.branch>> }
+          steps:
+            - slack/notify:
+                event: fail
+                template: basic_fail_1
+                branch_pattern: main,release/.+
+
+  consul-compatibility-tests:
+    executor:
+      name: go
+    steps:
+      - checkout
+      - run: make test-compat
       - slack/notify:
           event: fail
           template: basic_fail_1
-      - save_cache:
-          key: ct-modcache-v2-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
 
   benchmarks:
     executor:
@@ -126,18 +134,8 @@ jobs:
         default: 30m
     steps:
       - checkout
-      - run:
-          name: Install Consul
-          command: |
-            curl -sLo consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
-            unzip consul.zip
-            sudo cp consul /usr/local/bin/
-      - run:
-          name: Install Terraform
-          command: |
-            curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-            unzip terraform.zip
-            sudo cp terraform /usr/local/bin/
+      - setup-consul
+      - setup-terraform
       - run:
           name: Copy terraform to benchmark directory
           command: /bin/cp /usr/local/bin/terraform ./e2e/
@@ -150,8 +148,7 @@ jobs:
       - run:
           name: Run benchmark suite
           no_output_timeout: << parameters.no_output_timeout >>
-          command:
-            make test-benchmarks | /usr/bin/tee /tmp/benchmarks.json
+          command: make test-benchmarks | /usr/bin/tee /tmp/benchmarks.json
       - slack/notify:
           event: fail
           template: basic_fail_1
@@ -160,7 +157,7 @@ jobs:
           command: |
             mkdir /tmp/benchmark_results
             grep 'ns/op' /tmp/benchmarks.json | awk -F '"Output":"'  '{print $2}' | sort \
-             > /tmp/benchmark_results/results-${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}.txt
+              > /tmp/benchmark_results/results-${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}.txt
             cat /tmp/benchmark_results/results-${CIRCLE_SHA1}-${CIRCLE_BUILD_NUM}.txt
       - store_artifacts:
           path: /tmp/benchmarks.json
@@ -169,18 +166,14 @@ jobs:
           path: /tmp/benchmark_results
           destination: benchmark_results
 
-  compile_weekly_tests:
+  compile-weekly-tests:
     executor:
       name: go
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - ct-modcache-v2-{{ checksum "go.mod" }}
       - run:
           name: Check that weekly tests can compile
-          command:
-            make compile-weekly-tests
+          command: make compile-weekly-tests
       - when:
           condition:
             or:
@@ -191,10 +184,6 @@ jobs:
                 event: fail
                 template: basic_fail_1
                 branch_pattern: main,release/.+
-      - save_cache:
-          key: ct-modcache-v2-{{ checksum "go.mod" }}
-          paths:
-            - /go/pkg/mod
 
   go-checks:
     executor:
@@ -203,7 +192,7 @@ jobs:
       - checkout
       - run: make go-fmt-check
       - run:
-          name: verify go.mod and go.sum are correct
+          name: Verify go.mod and go.sum are correct
           command: |
             go mod tidy
             git diff --quiet && exit 0
@@ -215,28 +204,27 @@ jobs:
       name: go
     steps:
       - checkout
-      - run:
-          name: Install Terraform
-          command: |
-            curl -sLo terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-            unzip terraform.zip
-            sudo cp terraform /usr/local/bin/
+      - setup-terraform
       - run: make terraform-fmt-check
 
 workflows:
-  version: 2
   build-test:
     jobs:
       - go-checks
       - terraform-checks
-      - compile_weekly_tests
-      - unit_integration_tests
-      - e2e_tests
+      - compile-weekly-tests
+      - unit-and-integration-tests
+      - e2e-tests:
+          name: "E2E Tests - Part: << matrix.part_index >>"
+          matrix:
+            parameters:
+              part_index: [ 0, 1, 2 ]
+
   weekly-benchmarks:
     jobs:
-      - vault_integration_tests
       - benchmarks
-      - consul_compatibility_tests
+      - vault-integration-tests
+      - consul-compatibility-tests
     triggers:
       - schedule:
           # 02:10 UTC every Wednesday

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ e2e/benchmarks/sync-tasks
 
 # ignore builds
 /pkg
+.build/

--- a/build-scripts/split-tests.sh
+++ b/build-scripts/split-tests.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# ----------------- Functions ------------------
+
+function list_tests() {
+    local build_tags=$1
+    local pkg=$2
+
+    go test -tags="${build_tags}" -list . "${pkg}" | grep "^Test" | sort
+}
+
+function split_list() {
+    local chunks_count=$1
+    local input_file=$2
+    local output_dir=$3
+
+    local total_lines
+    local lines_per_file
+
+    total_lines=$(wc -l < "${input_file}" | xargs)
+    ((lines_per_file = (total_lines + chunks_count - 1) / chunks_count))
+
+    echo ">> Tests total count: ${total_lines}"
+    mkdir -p "${output_dir}"
+    split -d -a 1 -l "${lines_per_file}" "${input_file}" "${output_dir}/chunk."
+    echo ">> Chunks files line counts:"
+    wc -l "${output_dir}"/*
+}
+
+function join_lists() {
+  local chunks_dir=$1
+
+  local joined
+
+  for f in "${chunks_dir}"/*; do
+    joined=$(paste -sd '|' "${f}")
+    printf "^(%s)$" "${joined}" > "${f}"
+  done
+}
+
+function validate() {
+  local chunks_count=$1
+
+  if [ "${chunks_count}" -gt 10 ]; then
+    >&2 echo ">> ERROR: Chunks count (${chunks_count}) exceeded max value (10)"
+    exit 1
+  fi
+}
+
+# ----------------- Main Logic ------------------
+
+if [ "$#" -ne 4 ]; then
+    >&2 echo ">> ERROR: Incorrect number of parameters. Usage: $0 <build-tags> <package> <chunks-count> <chunks-output-dir>"
+    exit 1
+fi
+
+build_tags=$1
+package=$2
+chunks_count=$3
+chunks_dir=$4
+
+all_tests_file=$(mktemp /tmp/split.XXXXX)
+
+validate "${chunks_count}"
+list_tests "${build_tags}" "${package}" > "${all_tests_file}"
+split_list "${chunks_count}" "${all_tests_file}" "${chunks_dir}"
+join_lists "${chunks_dir}"
+
+# ----------------- Clean up ------------------
+
+rm "${all_tests_file}"
+unset build_tags package chunks_count chunks_dir


### PR DESCRIPTION
- Introduced a test splitter that finds all tests in a package (e2e in our case) and creates N files each with a regex that only runs 1/N of the tests.
- Added parallelism to the e2e-tests step in CircleCI. 3 jobs run in parallel, each running a different set of tests.
- Switched from go test to gotestsum for running e2e tests, unit and integration tests
   - Cleaner colorful output
   - Test results xml generation
- Added a step to upload test-results to CircleCI
- Refactored circleci config
- Removed obsolete go modules cache