### PR TITLE
Add auto-approve flag to auto-completion for `task enable`

### DIFF
--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -87,7 +87,10 @@ func (c *taskEnableCommand) Synopsis() string {
 // options for this command. The map key for the Flags map should be the
 // complete flag such as "-foo" or "--foo".
 func (c *taskEnableCommand) AutocompleteFlags() complete.Flags {
-	return c.meta.autoCompleteFlags()
+	return mergeAutocompleteFlags(c.meta.autoCompleteFlags(),
+		complete.Flags{
+			fmt.Sprintf("-%s", FlagAutoApprove): complete.PredictNothing,
+		})
 }
 
 // AutocompleteArgs returns the argument predictor for this command.


### PR DESCRIPTION
`-auto-approve` flag is supported for `task enable`
https://www.consul.io/docs/nia/cli/task#usage-1

CLI output with this change:
```
$ ./consul-terraform-sync task enable task_a -
-auto-approve  -client-cert   -port
-ca-cert       -client-key    -ssl-verify
-ca-path       -http-addr
```