### PR TITLE
Fixed issue with flags when running CTS without start command

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -47,10 +47,7 @@ func Commands() map[string]cli.CommandFactory {
 			return newTaskCreateCommand(m), nil
 		},
 		cmdStartName: func() (cli.Command, error) {
-			return newStartCommand(m, false), nil
-		},
-		"": func() (cli.Command, error) {
-			return newStartCommand(m, true), nil
+			return newStartCommand(m), nil
 		},
 	}
 

--- a/command/commands_test.go
+++ b/command/commands_test.go
@@ -17,7 +17,6 @@ func Test_Commands(t *testing.T) {
 		cmdTaskDisableName: &taskDisableCommand{},
 		cmdTaskDeleteName:  &taskDeleteCommand{},
 		cmdStartName:       &startCommand{},
-		"":                 &startCommand{},
 	}
 
 	assert.Equal(t, len(expectedCommands), len(cf))

--- a/command/start_test.go
+++ b/command/start_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 func TestStartCommand_Name(t *testing.T) {
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 	assert.Equal(t, cmdStartName, cmd.Name())
 }
 
 func TestStartCommand_Help(t *testing.T) {
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 
 	contains := []string{
 		"Usage CLI: consul-terraform-sync start [-help] [options]",
@@ -44,7 +44,7 @@ func TestStartCommand_Help(t *testing.T) {
 }
 
 func TestStartCommand_HelpDefault(t *testing.T) {
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 
 	contains := []string{
 		"Usage CLI: consul-terraform-sync <command> [-help] [options]",
@@ -58,20 +58,20 @@ func TestStartCommand_HelpDefault(t *testing.T) {
 		"-once",
 	}
 
-	s := cmd.HelpDefault()
+	s := cmd.HelpDeprecated()
 	for _, c := range contains {
 		assert.Contains(t, s, c)
 	}
 }
 
 func TestStartCommand_Synopsis(t *testing.T) {
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 	assert.Equal(t, "", cmd.Synopsis())
 }
 
 func TestStartCommand_AutocompleteFlags(t *testing.T) {
 	t.Parallel()
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 
 	predictor := cmd.AutocompleteFlags()
 
@@ -80,9 +80,12 @@ func TestStartCommand_AutocompleteFlags(t *testing.T) {
 	res := predictor.Predict(args)
 
 	// Grab the list of flags from the Flag object
+	// We don't want to include the default flag explicitly in our comparison
 	flags := make([]string, 0)
 	cmd.flags.VisitAll(func(flag *flag.Flag) {
-		flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		if flag.Name != flagDeprecatedStartUp {
+			flags = append(flags, fmt.Sprintf("-%s", flag.Name))
+		}
 	})
 
 	// Verify that there is a prediction for each flag associated with the command
@@ -92,7 +95,7 @@ func TestStartCommand_AutocompleteFlags(t *testing.T) {
 }
 
 func TestStartCommand_AutocompleteArgs(t *testing.T) {
-	cmd := newStartCommand(meta{UI: cli.NewMockUi()}, false)
+	cmd := newStartCommand(meta{UI: cli.NewMockUi()})
 	c := cmd.AutocompleteArgs()
 	assert.Equal(t, complete.PredictNothing, c)
 }


### PR DESCRIPTION
# Background
When running CTS without a command, CLI space separate flag/value is not being interpreted correctly.

eg. `consul-terraform-sync -flag foo` `foo` is being interpreted as a command instead of as a value for `-flag`

When the the CLI library is invoke, it will attempt to find the command anywhere in the passed in args. That means that if no command is passed, it will interpret config.hcl as the command if `consul-terraform-sync -config-file config.hcl` is used to start the daemon.

We did not run into this issue previously as we used to only use the cli library if the first argument was not a flag (contained `-`). Now we use the CLI library for everything, and it will run the start command as the default command.

# Solution
Pre-process the args and tack on the default command (start). Not ideal, but also support for the command-less option will eventually go away (edited) 

Resolves #870 