### PR TITLE
Add e2e test for argument parsing variants.

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -123,7 +123,7 @@ func TestE2EArgumentParsing(t *testing.T) {
 		appendDBTask().appendWebTask()
 	config.write(t, configPath)
 
-	// Execute CTS with these extra parameters to ensure they parse correctly. For example:
+	// Execute CTS with these extra parameters to ensure they parse correctly.
 	testCases := [][]string{
 		{"start", "-config-dir", emptyDir, "-config-dir=" + emptyDir},
 		// TODO remove this line after the deprecated "default" implied subcommand is no longer supported.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -103,11 +103,13 @@ func TestE2EBasic(t *testing.T) {
 // argument parsing works properly for both `=` and space-delimited argument values.
 // For example, both `--a=b` and `--a b` should be acceptable ways to specify args.
 func TestE2EArgumentParsing(t *testing.T) {
+	setParallelism(t)
 	srv := newTestConsulServer(t)
 	defer srv.Stop()
 
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "cmd_parsing")
 	cleanupTemp := testutils.MakeTempDir(t, tempDir)
+	defer cleanupTemp()
 
 	// Create an extra, empty directory that will be searched for config files.
 	// This is done because the `StartCTS` function always includes its own
@@ -139,8 +141,6 @@ func TestE2EArgumentParsing(t *testing.T) {
 	defer stop(t)
 	err = cts.WaitForTestReadiness(defaultWaitForTestReadiness)
 	require.NoError(t, err)
-
-	_ = cleanupTemp()
 }
 
 // TestE2ERestart runs the CTS binary in daemon mode and tests restarting


### PR DESCRIPTION
Ensures that both `=` and space-delimited argument values are parsed correctly for subcommands and the "default" command.