### PR TITLE
version not outputted anymore after fix running CTS without a command

### DIFF
--- a/command/cli_test.go
+++ b/command/cli_test.go
@@ -1,0 +1,109 @@
+package command
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCLI_Run(t *testing.T) {
+
+	cases := []struct {
+		name           string
+		args           []string
+		outputContains []string
+	}{
+		{
+			name: "version with single dash",
+			args: []string{"ignore", "-version"},
+			outputContains: []string{
+				"consul-terraform-sync",
+				"Compatible with Terraform",
+			},
+		},
+		{
+			name: "version with two dashes",
+			args: []string{"ignore", "--version"},
+			outputContains: []string{
+				"consul-terraform-sync",
+				"Compatible with Terraform",
+			},
+		},
+		{
+			name: "version with v",
+			args: []string{"ignore", "-v"},
+			outputContains: []string{
+				"consul-terraform-sync",
+				"Compatible with Terraform",
+			},
+		},
+		{
+			name: "no arguments help",
+			args: []string{"ignore"},
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync <command> [-help] [options]",
+				"Commands:",
+			},
+		},
+		{
+			name: "help with single dash",
+			args: []string{"ignore", "-help"},
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync <command> [-help] [options]",
+				"Commands:",
+			},
+		},
+		{
+			name: "help with two dashes",
+			args: []string{"ignore", "--help"},
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync <command> [-help] [options]",
+				"Commands:",
+			},
+		},
+		{
+			name: "version with h",
+			args: []string{"ignore", "-h"},
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync <command> [-help] [options]",
+				"Commands:",
+			},
+		},
+		{
+			name: "command task with help",
+			args: []string{"ignore", "task", "-h"},
+			outputContains: []string{
+				"This command is accessed by using one of the subcommands below.",
+			},
+		},
+		{
+			name: "command start with help",
+			args: []string{"ignore", "start", "-h"},
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync start [-help] [options]",
+			},
+		},
+		{
+			name: "command with version",
+			args: []string{"ignore", "start", "-version"},
+			outputContains: []string{
+				"flag provided but not defined: -version",
+				"Usage CLI: consul-terraform-sync start [-help] [options]",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bufOut bytes.Buffer
+			var bufErr bytes.Buffer
+			cli := NewCLI(&bufOut, &bufErr)
+			cli.Run(tc.args)
+			assert.Empty(t, bufErr)
+			for _, expect := range tc.outputContains {
+				assert.Contains(t, bufOut.String(), expect)
+			}
+		})
+	}
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io"
 	"os"
 
 	"github.com/mitchellh/cli"
@@ -11,25 +12,26 @@ const (
 	errCreatingClient  = "Error: unable to create client"
 )
 
-func configureMeta() meta {
+func configureMeta(writer io.Writer, errorWriter io.Writer) meta {
 	return meta{
 		UI: &cli.PrefixedUi{
 			InfoPrefix:   "==> ",
 			OutputPrefix: "    ",
 			ErrorPrefix:  "==> ",
 			Ui: &cli.BasicUi{
-				Writer: os.Stdout,
-				Reader: os.Stdin,
+				Writer:      writer,
+				Reader:      os.Stdin,
+				ErrorWriter: errorWriter,
 			},
 		},
+		writer: writer,
 	}
 }
 
 // Commands returns the mapping of CLI commands for CTS. The meta
 // parameter lets you set meta options for all commands.
-func Commands() map[string]cli.CommandFactory {
-	// Disable logging, we want to control what is output
-	m := configureMeta()
+func Commands(writer io.Writer, errorWriter io.Writer) map[string]cli.CommandFactory {
+	m := configureMeta(writer, errorWriter)
 
 	// The command factory will use the run command as the default
 	// an empty string key ("") is interpreted as the default command

--- a/command/commands_test.go
+++ b/command/commands_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -8,7 +9,7 @@ import (
 )
 
 func Test_Commands(t *testing.T) {
-	cf := Commands()
+	cf := Commands(ioutil.Discard, ioutil.Discard)
 
 	// map of commands to synopsis
 	expectedCommands := map[string]cli.Command{

--- a/command/meta.go
+++ b/command/meta.go
@@ -3,6 +3,7 @@ package command
 import (
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/url"
 	"strings"
@@ -26,7 +27,8 @@ type meta struct {
 	port        *int
 	addr        *string
 
-	tls tls
+	tls    tls
+	writer io.Writer
 }
 
 type tls struct {

--- a/command/start.go
+++ b/command/start.go
@@ -55,6 +55,7 @@ type startCommand struct {
 
 func (c *startCommand) startFlags() *flag.FlagSet {
 	flags := flag.NewFlagSet(cmdStartName, flag.ContinueOnError)
+	flags.SetOutput(c.meta.writer)
 
 	var configFiles, inspectTasks config.FlagAppendSliceValue
 	var isInspect, isOnce, autocompleteInstall, autocompleteUninstall, isDeprecatedStartup bool

--- a/command/task_create.go
+++ b/command/task_create.go
@@ -33,6 +33,7 @@ type taskCreateCommand struct {
 func newTaskCreateCommand(m meta) *taskCreateCommand {
 	logging.DisableLogging()
 	flags := m.defaultFlagSet(cmdTaskCreateName)
+	flags.SetOutput(m.writer)
 	a := flags.Bool(FlagAutoApprove, false, "Skip interactive approval of inspect plan")
 	f := flags.String(flagTaskFile, "", "[Required] A file containing the hcl or json definition of a task")
 	return &taskCreateCommand{

--- a/command/task_delete.go
+++ b/command/task_delete.go
@@ -26,6 +26,7 @@ type taskDeleteCommand struct {
 func newTaskDeleteCommand(m meta) *taskDeleteCommand {
 	logging.DisableLogging()
 	flags := m.defaultFlagSet(cmdTaskDeleteName)
+	flags.SetOutput(m.writer)
 	a := flags.Bool(FlagAutoApprove, false, "Skip interactive approval of deleting a task")
 	return &taskDeleteCommand{
 		meta:        m,

--- a/command/task_disable.go
+++ b/command/task_disable.go
@@ -27,6 +27,7 @@ type taskDisableCommand struct {
 func newTaskDisableCommand(m meta) *taskDisableCommand {
 	logging.DisableLogging()
 	flags := m.defaultFlagSet(cmdTaskDisableName)
+	flags.SetOutput(m.writer)
 	return &taskDisableCommand{
 		meta:  m,
 		flags: flags,

--- a/command/task_enable.go
+++ b/command/task_enable.go
@@ -29,6 +29,7 @@ type taskEnableCommand struct {
 func newTaskEnableCommand(m meta) *taskEnableCommand {
 	logging.DisableLogging()
 	flags := m.defaultFlagSet(cmdTaskEnableName)
+	flags.SetOutput(m.writer)
 	a := flags.Bool(FlagAutoApprove, false, "Skip interactive approval of inspect plan")
 	return &taskEnableCommand{
 		meta:        m,

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -908,3 +908,40 @@ func TestE2E_TaskCommand_Help(t *testing.T) {
 		})
 	}
 }
+
+func TestE2E_CommandlessFlags(t *testing.T) {
+	setParallelism(t)
+	cases := []struct {
+		name           string
+		flag           string
+		outputContains []string
+	}{
+		{
+			name: "help",
+			flag: "-help",
+			outputContains: []string{
+				"Usage CLI: consul-terraform-sync <command> [-help] [options]",
+				"Commands:",
+			},
+		},
+		{
+			name: "version",
+			flag: "-version",
+			outputContains: []string{
+				"consul-terraform-sync",
+				"Compatible with Terraform",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := runSubcommand(t, "", tc.flag)
+			assert.NoError(t, err)
+
+			for _, expect := range tc.outputContains {
+				assert.Contains(t, output, expect)
+			}
+		})
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -124,17 +124,28 @@ func TestE2EArgumentParsing(t *testing.T) {
 	config.write(t, configPath)
 
 	// Execute CTS with these extra parameters to ensure they parse correctly.
-	testCases := [][]string{
-		{"start", "-config-dir", emptyDir, "-config-dir=" + emptyDir},
-		// TODO remove this line after the deprecated "default" implied subcommand is no longer supported.
-		{"-config-dir", emptyDir, "-config-dir=" + emptyDir},
+	testcases := []struct {
+		name string
+		args []string
+	}{
+		{
+			"with start command",
+			[]string{"start", "-config-dir", emptyDir, "-config-dir=" + emptyDir},
+		},
+		{
+			// TODO remove this line after the deprecated "default" implied subcommand is no longer supported.
+			"without start command",
+			[]string{"-config-dir", emptyDir, "-config-dir=" + emptyDir},
+		},
 	}
 
-	for _, args := range testCases {
-		cts, stop := api.StartCTS(t, configPath, args...)
-		err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
-		assert.NoError(t, err, "Execution failed for arguments: %v", args)
-		stop(t)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			cts, stop := api.StartCTS(t, configPath, tc.args...)
+			err := cts.WaitForTestReadiness(defaultWaitForTestReadiness)
+			assert.NoError(t, err, "Execution failed for arguments: %v", tc.args)
+			stop(t)
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
CTS does not behave as expected when attempting to get the version through the cli:

`consul-terraform-sync -version` 

outputs:
```linux
flag provided but not defined: -version
```

No variations of the version flag work correctly `-v`, `--version`, `--version`

This bug was introduced after fixing #870

## Investigation Results
To support pre-existing behavior in CTS where CTS can be run as a daemon without the `start` command, some preprocessing to arguments needed to be performed in order to make the CLI library believe a `start` command was used. This caused the CLI library to interpret `consul-terraform-sync -version` as `consul-terraform-sync start -version` which is invalid.


## Solution
Parse passed in args for `-v`, `--version` and `-version` and do not pre-process the args if present. Let the CLI library handle detection of the version after this.
