### PR TITLE
move registration before once mode

### DIFF
--- a/controller/daemon.go
+++ b/controller/daemon.go
@@ -93,13 +93,6 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 		exitCh <- err
 	}()
 
-	// Run tasks once through once-mode
-	if !ctrl.once {
-		if err := ctrl.Once(ctx); err != nil {
-			return err
-		}
-	}
-
 	var rm *registration.ServiceRegistrationManager
 	if *conf.Consul.ServiceRegistration.Enabled {
 		// Expect one more long-running goroutine
@@ -130,6 +123,13 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 			rm.Start(ctx)
 			exitCh <- nil // registration errors are logged only
 		}()
+	}
+
+	// Run tasks once through once-mode
+	if !ctrl.once {
+		if err := ctrl.Once(ctx); err != nil {
+			return err
+		}
 	}
 
 	// Run tasks in long-running mode

--- a/e2e/registration_test.go
+++ b/e2e/registration_test.go
@@ -140,7 +140,7 @@ func TestE2E_ServiceRegistration_DeregisterWhenStopped(t *testing.T) {
 	config := baseConfig(tempDir).appendID(id).
 		appendConsulBlock(srv).appendTerraformBlock().
 		appendModuleTask("disabled_task", "mkam/hello/cts",
-			"enabled = false") // optimization since task running is not relevant to test
+			"enabled = true")
 	config.write(t, configPath)
 
 	// Start CTS, verify that service is registered
@@ -223,7 +223,7 @@ service_registration {
 }
 
 // TestE2E_ServiceRegistration_InitError tests that if the initial run
-// of all tasks fails, then CTS is not registered.
+// of all tasks fails, then CTS is still registered.
 func TestE2E_ServiceRegistration_InitError(t *testing.T) {
 	setParallelism(t)
 	srv := newTestConsulServer(t)
@@ -264,11 +264,11 @@ func TestE2E_ServiceRegistration_InitError(t *testing.T) {
 		t.Fatal("timed out waiting for CTS initialization to fail")
 	}
 
-	// Verify no attempt at registration and no service registered
+	// Verify registration and deregistration occurred
 	output := buf.String()
-	assert.NotContains(t, output, "registering Consul-Terraform-Sync as a service with Consul")
+	assert.Contains(t, output, "registering Consul-Terraform-Sync as a service with Consul")
 	registered := testutils.ConsulServiceRegistered(t, srv, id)
-	assert.False(t, registered)
+	assert.True(t, registered)
 }
 
 func getServiceInstancesByName(t testing.TB, srv *testutil.TestServer, serviceName string) map[string]testutils.ConsulService {

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/go-version v1.3.0
-	github.com/hashicorp/hcat v0.2.1-0.20220425195220-6cc4c61e1ba1
+	github.com/hashicorp/hcat v0.2.1-0.20220519190242-5b1deea3fce6
 	github.com/hashicorp/hcl v1.0.1-vault-2
 	github.com/hashicorp/hcl/v2 v2.8.2
 	github.com/hashicorp/logutils v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -361,8 +361,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/hcat v0.2.1-0.20220425195220-6cc4c61e1ba1 h1:WrzgmF7baIvK7GkCueORFosVCyoZgMwYJ18CRNNuURQ=
-github.com/hashicorp/hcat v0.2.1-0.20220425195220-6cc4c61e1ba1/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
+github.com/hashicorp/hcat v0.2.1-0.20220519190242-5b1deea3fce6 h1:8+3BUmaPAnP7B2e9koA149nirG/yMEvI0AWNFwEL6ZU=
+github.com/hashicorp/hcat v0.2.1-0.20220519190242-5b1deea3fce6/go.mod h1:8whVXKNd9s0/dmuQZI/tfanG+sudN3H5NaqT3qZZZ0s=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl v1.0.1-vault-2 h1:j0lTHGBdaU13Pc3GaTCdWjmsT22X98bsHnA+ShzIOtg=
 github.com/hashicorp/hcl v1.0.1-vault-2/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=


### PR DESCRIPTION
Registration moved before once mode runs

To accommodate this change, HCAT has been upgraded with a fix for #884 as placing the registration before once mode made this issue occur more frequently.

This PR resolves #884 