### PR TITLE
Add configuration option for CTS service address

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -60,6 +60,7 @@ var (
 				Enabled:     Bool(true),
 				ServiceName: String("test-service"),
 				Namespace:   String("test-ns"),
+				Address:     String("10.2.3.4"),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(true),
 					Address: String("http://cts"),

--- a/config/consul_test.go
+++ b/config/consul_test.go
@@ -43,6 +43,7 @@ func TestConsulConfig_Copy(t *testing.T) {
 				ServiceRegistration: &ServiceRegistrationConfig{
 					Enabled:     Bool(false),
 					ServiceName: String("test-service"),
+					Address:     String("10.2.3.4"),
 					Namespace:   String("test-ns"),
 					DefaultCheck: &DefaultCheckConfig{
 						Enabled: Bool(true),
@@ -290,6 +291,7 @@ func TestConsulConfig_Finalize(t *testing.T) {
 				ServiceRegistration: &ServiceRegistrationConfig{
 					Enabled:     Bool(true),
 					ServiceName: String(DefaultServiceName),
+					Address:     String(""),
 					Namespace:   String(""),
 					DefaultCheck: &DefaultCheckConfig{
 						Enabled: Bool(true),

--- a/config/service_registration.go
+++ b/config/service_registration.go
@@ -11,6 +11,7 @@ const (
 type ServiceRegistrationConfig struct {
 	Enabled      *bool               `mapstructure:"enabled"`
 	ServiceName  *string             `mapstructure:"service_name"`
+	Address      *string             `mapstructure:"address"`
 	Namespace    *string             `mapstructure:"namespace"`
 	DefaultCheck *DefaultCheckConfig `mapstructure:"default_check"`
 }
@@ -22,6 +23,7 @@ func DefaultServiceRegistrationConfig() *ServiceRegistrationConfig {
 		Enabled:     Bool(true),
 		ServiceName: String(DefaultServiceName),
 		Namespace:   String(""),
+		Address:     String(""),
 		DefaultCheck: &DefaultCheckConfig{
 			Enabled: Bool(true),
 			Address: String(""),
@@ -38,6 +40,7 @@ func (c *ServiceRegistrationConfig) Copy() *ServiceRegistrationConfig {
 	var o ServiceRegistrationConfig
 	o.Enabled = BoolCopy(c.Enabled)
 	o.ServiceName = StringCopy(c.ServiceName)
+	o.Address = StringCopy(c.Address)
 	o.Namespace = StringCopy(c.Namespace)
 
 	if c.DefaultCheck != nil {
@@ -71,6 +74,10 @@ func (c *ServiceRegistrationConfig) Merge(o *ServiceRegistrationConfig) *Service
 		r.ServiceName = StringCopy(o.ServiceName)
 	}
 
+	if o.Address != nil {
+		r.Address = StringCopy(o.Address)
+	}
+
 	if o.Namespace != nil {
 		r.Namespace = StringCopy(o.Namespace)
 	}
@@ -90,6 +97,10 @@ func (c *ServiceRegistrationConfig) Finalize() {
 
 	if c.ServiceName == nil {
 		c.ServiceName = String(DefaultServiceName)
+	}
+
+	if c.Address == nil {
+		c.Address = String("")
 	}
 
 	if c.Namespace == nil {
@@ -127,11 +138,13 @@ func (c *ServiceRegistrationConfig) GoString() string {
 	return fmt.Sprintf("&ServiceRegistrationConfig{"+
 		"Enabled:%v, "+
 		"ServiceName:%s, "+
+		"Address:%s, "+
 		"Namespace:%s, "+
 		"DefaultCheck: %s"+
 		"}",
 		BoolVal(c.Enabled),
 		StringVal(c.ServiceName),
+		StringVal(c.Address),
 		StringVal(c.Namespace),
 		c.DefaultCheck.GoString(),
 	)

--- a/config/service_registration_test.go
+++ b/config/service_registration_test.go
@@ -14,6 +14,7 @@ func TestServiceRegistrationConfig_DefaultServiceRegistrationConfig(t *testing.T
 		Enabled:     Bool(true),
 		Namespace:   String(""),
 		ServiceName: String(DefaultServiceName),
+		Address:     String(""),
 		DefaultCheck: &DefaultCheckConfig{
 			Enabled: Bool(true),
 			Address: String(""),
@@ -50,6 +51,7 @@ func TestServiceRegistrationConfig_Copy(t *testing.T) {
 				Enabled:     Bool(false),
 				ServiceName: String("cts-service"),
 				Namespace:   String("test"),
+				Address:     String("172.0.0.2"),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(false),
 					Address: String("test"),
@@ -172,6 +174,30 @@ func TestServiceRegistrationConfig_Merge(t *testing.T) {
 			&ServiceRegistrationConfig{ServiceName: String("service_a")},
 		},
 		{
+			"address_overrides",
+			&ServiceRegistrationConfig{Address: String("address_a")},
+			&ServiceRegistrationConfig{Address: String("address_b")},
+			&ServiceRegistrationConfig{Address: String("address_b")},
+		},
+		{
+			"address_empty_one",
+			&ServiceRegistrationConfig{Address: String("address_a")},
+			&ServiceRegistrationConfig{},
+			&ServiceRegistrationConfig{Address: String("address_a")},
+		},
+		{
+			"address_empty_two",
+			&ServiceRegistrationConfig{},
+			&ServiceRegistrationConfig{Address: String("address_a")},
+			&ServiceRegistrationConfig{Address: String("address_a")},
+		},
+		{
+			"address_same",
+			&ServiceRegistrationConfig{Address: String("address_a")},
+			&ServiceRegistrationConfig{Address: String("address_a")},
+			&ServiceRegistrationConfig{Address: String("address_a")},
+		},
+		{
 			"default_check_overrides",
 			&ServiceRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(true)}},
 			&ServiceRegistrationConfig{DefaultCheck: &DefaultCheckConfig{Enabled: Bool(false)}},
@@ -219,6 +245,7 @@ func TestServiceRegistrationConfig_Finalize(t *testing.T) {
 			&ServiceRegistrationConfig{
 				Enabled:     Bool(true),
 				ServiceName: String(DefaultServiceName),
+				Address:     String(""),
 				Namespace:   String(""),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(true),
@@ -259,6 +286,7 @@ func TestServiceRegistrationConfig_Validate(t *testing.T) {
 			&ServiceRegistrationConfig{
 				Enabled:     Bool(true),
 				ServiceName: String("cts-service"),
+				Address:     String("172.0.0.5"),
 				Namespace:   String("ns-1"),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(true),
@@ -306,6 +334,7 @@ func TestServiceRegistrationConfig_GoString(t *testing.T) {
 			&ServiceRegistrationConfig{
 				Enabled:     Bool(true),
 				ServiceName: String("cts-service"),
+				Address:     String("172.0.0.5"),
 				Namespace:   String("test"),
 				DefaultCheck: &DefaultCheckConfig{
 					Enabled: Bool(false),
@@ -315,6 +344,7 @@ func TestServiceRegistrationConfig_GoString(t *testing.T) {
 			"&ServiceRegistrationConfig{" +
 				"Enabled:true, " +
 				"ServiceName:cts-service, " +
+				"Address:172.0.0.5, " +
 				"Namespace:test, " +
 				"DefaultCheck: &DefaultCheckConfig{Enabled:false, Address:test}" +
 				"}",

--- a/config/testdata/long.hcl
+++ b/config/testdata/long.hcl
@@ -49,6 +49,7 @@ consul {
   service_registration {
     enabled = true
     service_name = "test-service"
+    address = "10.2.3.4"
     namespace = "test-ns"
     default_check {
       enabled = true

--- a/config/testdata/long.json
+++ b/config/testdata/long.json
@@ -46,6 +46,7 @@
     "service_registration": {
       "enabled": true,
       "service_name": "test-service",
+      "address": "10.2.3.4",
       "namespace": "test-ns",
       "default_check": {
         "enabled": true,

--- a/registration/manager.go
+++ b/registration/manager.go
@@ -55,6 +55,7 @@ type service struct {
 	name      string
 	id        string
 	tags      []string
+	address   string
 	port      int
 	namespace string
 
@@ -65,19 +66,20 @@ type service struct {
 // and Consul client. It sets default values where relevant, including a default HTTP check.
 func NewServiceRegistrationManager(conf *ServiceRegistrationManagerConfig, client client.ConsulClientInterface) *ServiceRegistrationManager {
 	logger := logging.Global().Named(logSystemName)
+	srConf := conf.ServiceRegistration
 
 	name := config.DefaultServiceName
-	if conf.ServiceRegistration.ServiceName != nil {
-		name = *conf.ServiceRegistration.ServiceName
+	if srConf.ServiceName != nil {
+		name = *srConf.ServiceName
 	}
 
 	ns := defaultNamespace
-	if conf.ServiceRegistration.Namespace != nil {
-		ns = *conf.ServiceRegistration.Namespace
+	if srConf.Namespace != nil {
+		ns = *srConf.Namespace
 	}
 
 	var checks []*consulapi.AgentServiceCheck
-	if *conf.ServiceRegistration.DefaultCheck.Enabled {
+	if *srConf.DefaultCheck.Enabled {
 		checks = append(checks, defaultHTTPCheck(conf))
 	}
 	return &ServiceRegistrationManager{
@@ -87,6 +89,7 @@ func NewServiceRegistrationManager(conf *ServiceRegistrationManagerConfig, clien
 			name:      name,
 			id:        conf.ID,
 			tags:      defaultServiceTags,
+			address:   *srConf.Address,
 			port:      conf.Port,
 			namespace: ns,
 			checks:    checks,
@@ -121,6 +124,7 @@ func (m *ServiceRegistrationManager) register(ctx context.Context) error {
 		ID:        s.id,
 		Name:      s.name,
 		Tags:      s.tags,
+		Address:   s.address,
 		Port:      s.port,
 		Checks:    s.checks,
 		Namespace: s.namespace,

--- a/registration/manager_test.go
+++ b/registration/manager_test.go
@@ -19,6 +19,11 @@ import (
 
 func TestNewServiceRegistrationManager(t *testing.T) {
 	t.Parallel()
+	id := "cts-123"
+	port := 123
+	serviceName := "cts"
+	serviceAddress := "172.1.2.3"
+	ns := "ns-1"
 	testcases := []struct {
 		name            string
 		conf            *ServiceRegistrationManagerConfig
@@ -27,39 +32,42 @@ func TestNewServiceRegistrationManager(t *testing.T) {
 		{
 			"defaults",
 			&ServiceRegistrationManagerConfig{
-				ID:                  "cts-123",
-				Port:                123,
+				ID:                  id,
+				Port:                port,
 				TLSEnabled:          false,
 				ServiceRegistration: config.DefaultServiceRegistrationConfig(),
 			},
 			&service{
 				name:      config.DefaultServiceName,
 				tags:      defaultServiceTags,
-				id:        "cts-123",
-				port:      123,
+				id:        id,
+				address:   "",
+				port:      port,
 				namespace: "",
 			},
 		},
 		{
 			"configured",
 			&ServiceRegistrationManagerConfig{
-				ID:         "cts-123",
-				Port:       123,
+				ID:         id,
+				Port:       port,
 				TLSEnabled: false,
 				ServiceRegistration: &config.ServiceRegistrationConfig{
-					ServiceName: config.String("cts-service"),
-					Namespace:   config.String("ns-1"),
+					ServiceName: &serviceName,
+					Address:     &serviceAddress,
+					Namespace:   &ns,
 					DefaultCheck: &config.DefaultCheckConfig{
 						Enabled: config.Bool(true),
 					},
 				},
 			},
 			&service{
-				name:      "cts-service",
+				name:      serviceName,
 				tags:      defaultServiceTags,
-				id:        "cts-123",
-				port:      123,
-				namespace: "ns-1",
+				id:        id,
+				address:   serviceAddress,
+				port:      port,
+				namespace: ns,
 			},
 		},
 	}

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -176,6 +176,7 @@ type ConsulService struct {
 	ID      string
 	Service string
 	Tags    []string
+	Address string
 	Port    int
 }
 


### PR DESCRIPTION
Adds a new `address` configuration to the `consul.service_registration` block. Note that this configuration is purposefully  different than the `address` under `default_check`.

```
consul {
  service_registration {
    address = "123.456.789"
  }
}
```