### PR TITLE
Add codeowners file for releng dirs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # default PR reviews to the team
 * @hashicorp/cat-cts-review
+
+# release configuration
+/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-ecosystem
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,0 @@
-# release configuration
-
-/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-ecosystem
-/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-ecosystem

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# release configuration
+
+/.release/                              @hashicorp/release-engineering @hashicorp/github-consul-ecosystem
+/.github/workflows/build.yml            @hashicorp/release-engineering @hashicorp/github-consul-ecosystem


### PR DESCRIPTION
This locks down changes to release directories so that they require approval from release engineering, and so they have service account rights for pipeline runs and backport-assistant functionality.