### PR TITLE
Remove incorrect path lookup for terraform install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,8 @@ test-e2e-local: test-setup-e2e
 test-compat: test-setup-e2e
 	@echo "==> Testing ${NAME} compatibility with Consul"
 	@go test ./e2e/compatibility -timeout 30m -tags=e2e -v -run TestCompatibility_Consul
+	@echo "==> Testing ${NAME} Terraform Downloads"
+	@go test ./e2e/compatibility -timeout 1m -tags=e2e -v -run TestCompatibility_TFDownload
 .PHONY: test-compat
 
 # test-benchmarks requires Terraform in the path of execution and Consul in $PATH.

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-compat: test-setup-e2e
 	@echo "==> Testing ${NAME} compatibility with Consul"
 	@go test ./e2e/compatibility -timeout 30m -tags=e2e -v -run TestCompatibility_Consul
 	@echo "==> Testing ${NAME} Terraform Downloads"
-	@go test ./e2e/compatibility -timeout 1m -tags=e2e -v -run TestCompatibility_TFDownload
+	@go test ./e2e/compatibility -timeout 5m -tags=e2e -v -run TestCompatibility_TFDownload
 .PHONY: test-compat
 
 # test-benchmarks requires Terraform in the path of execution and Consul in $PATH.

--- a/driver/terraform_download.go
+++ b/driver/terraform_download.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-checkpoint"
 	goVersion "github.com/hashicorp/go-version"
 	hcinstall "github.com/hashicorp/hc-install"
-	"github.com/hashicorp/hc-install/fs"
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/hc-install/src"
@@ -196,11 +195,6 @@ func installTerraform(ctx context.Context, conf *config.TerraformConfig) (*goVer
 
 	installer := hcinstall.NewInstaller()
 	installedPath, err := installer.Ensure(ctx, []src.Source{
-		&fs.ExactVersion{
-			Product:    product.Terraform,
-			Version:    tfVersion,
-			ExtraPaths: []string{*conf.Path},
-		},
 		&releases.ExactVersion{
 			Product:    product.Terraform,
 			Version:    tfVersion,

--- a/e2e/compatibility/terraform_download_test.go
+++ b/e2e/compatibility/terraform_download_test.go
@@ -1,0 +1,80 @@
+//go:build e2e
+// +build e2e
+
+package compatibility
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/driver"
+	"github.com/hashicorp/consul-terraform-sync/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This technically isn't an e2e test, but it downloads a file from the internet,
+// so it likely shouldn't be run frequently with other tests.
+func TestCompatibility_TFDownload(t *testing.T) {
+	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "Compatibility_TFDownload")
+	cleanup := testutils.MakeTempDir(t, tempDir)
+	defer cleanup()
+
+	conf := config.DefaultTerraformConfig()
+	conf.Path = &tempDir
+	// Use blank as a default value. Nil results in a panic.
+	tfVersion := ""
+	conf.Version = &tfVersion
+
+	binaryPath := path.Join(tempDir, "terraform")
+	info, err := os.Stat(binaryPath)
+	// We want to ensure the file does not exist and remove it if found.
+	if !os.IsNotExist(err) {
+		require.NoError(t, err, "An unexpected error occurred while checking for old terraform executable.")
+	}
+
+	if info != nil {
+		err = os.Remove(binaryPath)
+		require.NoError(t, err, "An unexpected error occurred while removing an old terraform executable.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	err = driver.InstallTerraform(ctx, conf)
+	require.NoError(t, err, "Unable to download terraform executable.")
+
+	// Check to ensure the terraform binary exists.
+	info, err = os.Stat(binaryPath)
+	require.NoError(t, err, "Unable to find terraform executable that was expected to be installed.")
+
+	ensureTFVersionExecutes(t, binaryPath)
+
+	// Trigger install again. It shouldn't re-download the file.
+	firstInstallTime := info.ModTime()
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err = driver.InstallTerraform(ctx, conf)
+	require.NoError(t, err, "Unexpected error while checking for existing terraform install.")
+	info, err = os.Stat(binaryPath)
+	require.NoError(t, err, "Unable to find terraform executable that was expected to be installed.")
+	assert.Equal(t, firstInstallTime, info.ModTime(), "The Terraform installer should not have downloaded twice.")
+
+	ensureTFVersionExecutes(t, binaryPath)
+}
+
+// ensureTFVersionExecutes calls the terraform executable at the provided path.
+// Results in a test failure if `terraform version` returns a non-zero status code
+// or if the text "Terraform" is not found in the output.
+func ensureTFVersionExecutes(t *testing.T, binaryPath string) {
+	cmd := exec.Command(binaryPath, "version")
+	output, err := cmd.Output()
+	require.NoError(t, err, "An error occurred while attempting to execute the downloaded terraform binary.")
+	assert.Equal(t, 0, cmd.ProcessState.ExitCode(), "Bad exit code encountered while checking the terraform binary.")
+	assert.Contains(t, string(output), "Terraform", "The `terraform version` call did not provide the expected output.")
+}


### PR DESCRIPTION
The configuration provided to hc-install caused issues
whenever a version of terraform was located on the PATH
but not the application workdir. Since logic already
exists to check the workdir and version of the executable
prior to hc-install execution, the fs-check can be removed.