### PR TITLE
Removed old Consul versions from compatibility tests

### DIFF
--- a/e2e/compatibility/consul_test.go
+++ b/e2e/compatibility/consul_test.go
@@ -52,9 +52,6 @@ func TestCompatibility_Consul(t *testing.T) {
 		"1.10.3",
 		"1.9.10",
 		"1.8.16",
-		"1.7.14",
-		"1.6.10",
-		"1.5.3",
 	}
 
 	cases := []struct {


### PR DESCRIPTION
Per CTS compatibility [documentation](https://www.consul.io/docs/nia/compatibility#consul), Consul 1.8+ are supported. I removed older/no-longer-supported Consul versions from the compatibility tests.