### PR TITLE
Updated the default service name to lower case

### DIFF
--- a/config/service_registration.go
+++ b/config/service_registration.go
@@ -3,7 +3,7 @@ package config
 import "fmt"
 
 const (
-	DefaultServiceName = "Consul-Terraform-Sync"
+	DefaultServiceName = "consul-terraform-sync"
 )
 
 // ServiceRegistrationConfig is a configuration that controls how CTS will


### PR DESCRIPTION
Service name is used in service registration it was previously proper case. Changed to lower case because of feedback; service names should never be capitalized in Consul so that they are valid hostnames.