### PR TITLE
Add openssh to docker image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.0 (Unreleased)
+
+IMPROVEMENTS:
+* Add `openssh` command to Docker image to support git over ssh for Terraform modules [[GH-940](https://github.com/hashicorp/consul-terraform-sync/issues/940)]
+
 ## 0.6.0 (May 25, 2022)
 
 KNOWN ISSUES:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV VERSION=$VERSION
 # TARGETARCH and TARGETOS are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH
 
-RUN apk add --no-cache dumb-init git
+RUN apk add --no-cache dumb-init git bash openssh
 
 # Create a non-root user to run the software.
 RUN addgroup ${NAME} && adduser -S -G ${NAME} ${NAME}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN addgroup ${NAME} && \
 
 # Set up certificates, base tools, and software.
 RUN set -eux && \
-    apk add --no-cache dumb-init git && \
+    apk add --no-cache dumb-init git bash openssh && \
     apk add --no-cache ca-certificates curl gnupg libcap openssl su-exec iputils && \
     BUILD_GPGKEY=C874011F0AB405110D02105534365D9472D7468F; \
     found=''; \


### PR DESCRIPTION
Add missing ssh command to docker image so that TF can utilize the protocol to download packages.

https://github.com/hashicorp/consul-terraform-sync/issues/940