### PR TITLE
Add context to driver factory.

### DIFF
--- a/controller/daemon_test.go
+++ b/controller/daemon_test.go
@@ -157,7 +157,7 @@ func testOnceThenLong(t *testing.T, driverConf *config.DriverConfig) {
 	rw.tasksManager = tm
 
 	// Mock driver
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := new(mocksD.Driver)
 		d.On("Task").Return(task)
 		d.On("TemplateIDs").Return([]string{"{{tmpl}}"})

--- a/controller/driver_factory_test.go
+++ b/controller/driver_factory_test.go
@@ -78,7 +78,7 @@ func Test_driverFactory_Make(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		// Mock returned driver
 		d := new(mocksD.Driver)
-		f.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		f.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			d.On("InitTask", mock.Anything).Return(nil).Once()
 			return d, nil
 		}
@@ -94,7 +94,7 @@ func Test_driverFactory_Make(t *testing.T) {
 		// Mock returned driver
 		errStr := "init error"
 		d := new(mocksD.Driver)
-		f.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		f.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			d.On("InitTask", mock.Anything).Return(errors.New(errStr)).Once()
 			d.On("DestroyTask", mock.Anything).Return().Once()
 			return d, nil

--- a/controller/inspect_test.go
+++ b/controller/inspect_test.go
@@ -109,7 +109,7 @@ func Test_Inspect_Run_context_cancel(t *testing.T) {
 	// Set up driver factory
 	tm.factory.initConf = conf
 	drivers := make(map[string]driver.Driver)
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := new(mocksD.Driver)
 		d.On("RenderTemplate", mock.Anything).Return(true, nil)
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil).Once()
@@ -182,7 +182,7 @@ func Test_Inspect_Run_WatchDep_errors(t *testing.T) {
 
 	// Set up driver factory
 	tm.factory.initConf = conf
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := new(mocksD.Driver)
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil)
 		// Always return false on render template to mock what happens when
@@ -247,7 +247,7 @@ func testInspect(t *testing.T, numTasks int, setupNewDriver func(*driver.Task) d
 	// Set up driver factory
 	tm.factory.initConf = conf
 	drivers := make(map[string]driver.Driver)
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := setupNewDriver(task)
 		drivers[task.Name()] = d
 		return d, nil

--- a/controller/once_test.go
+++ b/controller/once_test.go
@@ -119,7 +119,7 @@ func Test_Once_onceConsecutive_context_canceled(t *testing.T) {
 
 	// Set up driver factory
 	tm.factory.initConf = conf
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := new(mocksD.Driver)
 		d.On("Task").Return(task).Times(4)
 		d.On("TemplateIDs").Return(nil)
@@ -178,7 +178,7 @@ func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig,
 
 	// Set up driver factory
 	tm.factory.initConf = conf
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		return setupNewDriver(task), nil
 	}
 
@@ -242,7 +242,7 @@ func testOnceWatchDepErrors(t *testing.T, driverConf *config.DriverConfig) {
 
 	// Set up driver factory
 	tm.factory.initConf = conf
-	tm.factory.newDriver = func(c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
+	tm.factory.newDriver = func(ctx context.Context, c *config.Config, task *driver.Task, w templates.Watcher) (driver.Driver, error) {
 		d := new(mocksD.Driver)
 		d.On("InitTask", mock.Anything, mock.Anything).Return(nil)
 		// Always return false on render template to mock what happens when

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -132,7 +132,7 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 		mockD.On("SetBufferPeriod").Return()
 		mockD.On("OverrideNotifier").Return()
 		mockDriver(ctx, mockD, driverTask)
-		tm.factory.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		tm.factory.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
 
@@ -164,7 +164,7 @@ func Test_TasksManager_TaskCreate(t *testing.T) {
 		mockD.On("InitTask", mock.Anything).Return(fmt.Errorf("init err"))
 		mockD.On("DestroyTask", mock.Anything).Return()
 		tm.drivers = driver.NewDrivers()
-		tm.factory.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		tm.factory.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
 
@@ -205,7 +205,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		mockDriver(ctx, mockD, task)
 		tm.state = state.NewInMemoryStore(conf)
 		tm.drivers = driver.NewDrivers()
-		tm.factory.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		tm.factory.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
 
@@ -235,7 +235,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 		mockDriver(ctx, mockD, task)
 		tm.state = state.NewInMemoryStore(conf)
 		tm.drivers = driver.NewDrivers()
-		tm.factory.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		tm.factory.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
 
@@ -266,7 +266,7 @@ func Test_TasksManager_TaskCreateAndRun(t *testing.T) {
 			On("ApplyTask", ctx).Return(fmt.Errorf("apply err"))
 		tm.state = state.NewInMemoryStore(conf)
 		tm.drivers = driver.NewDrivers()
-		tm.factory.newDriver = func(*config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
+		tm.factory.newDriver = func(context.Context, *config.Config, *driver.Task, templates.Watcher) (driver.Driver, error) {
 			return mockD, nil
 		}
 


### PR DESCRIPTION
This change is necessary to better support TerraformCloud and
enterprise. There may be scenarios where we need to perform
I/O during initialization of a driver. Adding a context will
allow for proper cancellation.