### PR TITLE
Simpler No-Duplicate CI Runs in GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           test-results: .build/test-results.json
 
   slack-notification:
-    name: Slack notification
+    name: Slack Notification
     if: ${{ failure() && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release')) }}
     needs:
       - checks

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   compatability:
-    name: Compatability tests
+    name: Compatability Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -33,7 +33,7 @@ jobs:
           make test-compat
 
   vault-integration:
-    name: Vault integration tests
+    name: Vault Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,7 +53,7 @@ jobs:
           make test-vault-integration
 
   benchmarks:
-    name: Benchmarks tests
+    name: Benchmarks Tests
     runs-on: ubuntu-latest
     timeout-minutes: 150
     steps:
@@ -97,7 +97,7 @@ jobs:
           path: .build/benchmarks-results*.csv
 
   slack-notification:
-    name: Slack notification
+    name: Slack Notification
     if: ${{ failure() }}
     needs:
       - compatability


### PR DESCRIPTION
Instead of using a custom GH action to skip duplicate builds, we are relying on native GH config to only run the CI workflow on push (any branch) and PR open/reopen to main.