### PR TITLE
Added pipefail to GHA run commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Split E2E tests
         run: |
+          set -euo pipefail
           ./build-scripts/list-tests.sh e2e ./e2e | ./build-scripts/split-lines.sh ${{ env.E2E_TESTS_PARALLELISM }} .build/tests
 
       - uses: actions/upload-artifact@v3
@@ -149,6 +150,7 @@ jobs:
 
       - name: Run E2E tests
         run: |
+          set -euo pipefail
           cat .build/tests/part.${{ matrix.index }} | ./build-scripts/make-tests-regex.sh > .build/regex
           TESTS_REGEX_PATH=.build/regex make test-e2e-ci
 

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -78,11 +78,13 @@ jobs:
 
       - name: Run benchmarks tests
         run: |
+          set -euo pipefail
           mkdir -p .build
           make test-benchmarks | tee .build/benchmarks-output.json
 
       - name: Parse benchmarks output
         run: |
+          set -euo pipefail
           grep 'ns/op' .build/benchmarks-output.json | \
             jq -r .Output \
             | sed 's/\t/ /g' \


### PR DESCRIPTION
Failing benchmark make command now correctly fails the GH action. See https://github.com/hashicorp/consul-terraform-sync/runs/6905394540?check_suite_focus=true