### PR TITLE
Support for sessions, locks, and KV get in Consul client

### DIFF
--- a/client/consul.go
+++ b/client/consul.go
@@ -183,14 +183,13 @@ func (c *ConsulClient) GetLicense(ctx context.Context, q *consulapi.QueryOptions
 
 // RegisterService registers a service through the Consul agent.
 func (c *ConsulClient) RegisterService(ctx context.Context, r *consulapi.AgentServiceRegistration) error {
-	logger := c.logger
-	logger.Debug("registering service")
-
 	desc := "AgentServiceRegister"
 
+	logger := c.logger
 	if r != nil {
 		logger = logger.With("service_name", r.Name, "service_id", r.ID)
 	}
+	logger.Debug("registering service")
 
 	f := func(context.Context) error {
 		err := c.Agent().ServiceRegister(r)
@@ -226,7 +225,7 @@ func (c *ConsulClient) RegisterService(ctx context.Context, r *consulapi.AgentSe
 
 // DeregisterService removes a service through the Consul agent.
 func (c *ConsulClient) DeregisterService(ctx context.Context, serviceID string, q *consulapi.QueryOptions) error {
-	c.logger.Debug("deregistering service")
+	c.logger.Debug("deregistering service", "service_id", serviceID)
 	desc := "AgentServiceDeregister"
 
 	f := func(context.Context) error {
@@ -261,6 +260,7 @@ func (c *ConsulClient) DeregisterService(ctx context.Context, serviceID string, 
 
 // SessionCreate initializes a new session, retrying creation requests on server errors and rate limit errors.
 func (c *ConsulClient) SessionCreate(ctx context.Context, se *consulapi.SessionEntry, q *consulapi.WriteOptions) (string, *consulapi.WriteMeta, error) {
+	c.logger.Debug("creating session")
 	desc := "SessionCreate"
 	var id string
 	var meta *consulapi.WriteMeta
@@ -312,6 +312,7 @@ func (c *ConsulClient) Unlock(l *consulapi.Lock) error {
 
 // KVGet fetches a Consul KV pair, retrying the request on server errors and rate limit errors.
 func (c *ConsulClient) KVGet(ctx context.Context, key string, q *consulapi.QueryOptions) (*consulapi.KVPair, *consulapi.QueryMeta, error) {
+	c.logger.Debug("getting KV pair", "key", key)
 	desc := "KVGet"
 	var kv *consulapi.KVPair
 	var meta *consulapi.QueryMeta

--- a/client/consul.go
+++ b/client/consul.go
@@ -71,6 +71,11 @@ type ConsulClientInterface interface {
 	GetLicense(ctx context.Context, q *consulapi.QueryOptions) (string, error)
 	RegisterService(ctx context.Context, s *consulapi.AgentServiceRegistration) error
 	DeregisterService(ctx context.Context, serviceID string, q *consulapi.QueryOptions) error
+	SessionCreate(ctx context.Context, se *consulapi.SessionEntry, q *consulapi.WriteOptions) (string, *consulapi.WriteMeta, error)
+	SessionRenewPeriodic(initialTTL string, id string, q *consulapi.WriteOptions, doneCh <-chan struct{}) error
+	LockOpts(opts *consulapi.LockOptions) (*consulapi.Lock, error)
+	Lock(l *consulapi.Lock, stopCh <-chan struct{}) (<-chan struct{}, error)
+	Unlock(l *consulapi.Lock) error
 }
 
 // ConsulClient is a client to the Consul API
@@ -251,6 +256,57 @@ func (c *ConsulClient) DeregisterService(ctx context.Context, serviceID string, 
 	}
 
 	return nil
+}
+
+// SessionCreate initializes a new session, retrying creation requests on server errors and rate limit errors.
+func (c *ConsulClient) SessionCreate(ctx context.Context, se *consulapi.SessionEntry, q *consulapi.WriteOptions) (string, *consulapi.WriteMeta, error) {
+	desc := "SessionCreate"
+	var id string
+	var meta *consulapi.WriteMeta
+	f := func(context.Context) error {
+		var err error
+		id, meta, err = c.Session().Create(se, q)
+		if err != nil {
+			statusCode := getResponseCodeFromError(ctx, err)
+
+			// If we get a StatusForbidden assume that this is because CTS
+			// does not have the correct ACLs to access this resource in Consul
+			// and wrap in the appropriate error
+			if statusCode == http.StatusForbidden {
+				err = &MissingConsulACLError{Err: err}
+			}
+
+			// non-retryable errors allows for termination of retries
+			if !isResponseCodeRetryable(statusCode) {
+				err = &retry.NonRetryableError{Err: err}
+			}
+
+			return err
+		}
+		return nil
+	}
+
+	err := c.retry.Do(ctx, f, desc)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return id, meta, err
+}
+
+// SessionRenewPeriodic renews a session on a given cadence.
+func (c *ConsulClient) SessionRenewPeriodic(initialTTL string, id string, q *consulapi.WriteOptions, doneCh <-chan struct{}) error {
+	return c.Session().RenewPeriodic(initialTTL, id, q, doneCh)
+}
+
+// Lock attempts to acquire the given lock.
+func (c *ConsulClient) Lock(l *consulapi.Lock, stopCh <-chan struct{}) (<-chan struct{}, error) {
+	return l.Lock(stopCh)
+}
+
+// Unlock releases the given lock.
+func (c *ConsulClient) Unlock(l *consulapi.Lock) error {
+	return l.Unlock()
 }
 
 func getResponseCodeFromError(ctx context.Context, err error) int {

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -362,7 +362,7 @@ func TestKVGet(t *testing.T) {
 		{
 			name:         "key_does_not_exist",
 			responseCode: http.StatusNotFound,
-			// do not expect error
+			// do not expect error since KV().Get() does not error
 		},
 		{
 			name:                "non_retryable_error",

--- a/client/consul_test.go
+++ b/client/consul_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/consul-terraform-sync/testutils"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_GetLicense_API_Failure(t *testing.T) {
@@ -264,4 +265,68 @@ type testError struct {
 // Error returns an error string
 func (e *testError) Error() string {
 	return "this is a test error"
+}
+
+func TestSessionCreate(t *testing.T) {
+	t.Parallel()
+
+	var nonRetryableError *retry.NonRetryableError
+	var missingConsulACLError *MissingConsulACLError
+	cases := []struct {
+		name                string
+		responseCode        int
+		expectErr           bool
+		isNonRetryableError bool
+		isMissingAClError   bool
+	}{
+		{
+			name:         "success",
+			responseCode: http.StatusOK,
+		},
+		{
+			name:         "retryable_error",
+			responseCode: http.StatusInternalServerError,
+			expectErr:    true,
+		},
+		{
+			name:                "non_retryable_error",
+			responseCode:        http.StatusBadRequest,
+			expectErr:           true,
+			isNonRetryableError: true,
+		},
+		{
+			name:                "acl_error",
+			responseCode:        http.StatusForbidden,
+			expectErr:           true,
+			isNonRetryableError: true,
+			isMissingAClError:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Configure Consul client with intercepts
+			intercepts := []*testutils.HttpIntercept{
+				{
+					Path:               "/v1/session/create",
+					ResponseStatusCode: tc.responseCode,
+					ResponseData:       []byte(`{"ID": "adf4238a-882b-9ddc-4a9d-5b6758e4159e"}`),
+				},
+			}
+			c := newTestConsulClient(t, testutils.NewHttpClient(t, intercepts), 1)
+
+			// Create session
+			id, meta, err := c.SessionCreate(context.Background(), &consulapi.SessionEntry{}, nil)
+			if !tc.expectErr {
+				require.NoError(t, err)
+				assert.NotEmpty(t, id)
+				assert.NotNil(t, meta)
+			} else {
+				assert.Error(t, err)
+				// Verify the error types
+				assert.Equal(t, tc.isNonRetryableError, errors.As(err, &nonRetryableError))
+				assert.Equal(t, tc.isMissingAClError, errors.As(err, &missingConsulACLError))
+			}
+		})
+	}
 }

--- a/mocks/client/consul.go
+++ b/mocks/client/consul.go
@@ -50,6 +50,52 @@ func (_m *ConsulClientInterface) GetLicense(ctx context.Context, q *api.QueryOpt
 	return r0, r1
 }
 
+// Lock provides a mock function with given fields: l, stopCh
+func (_m *ConsulClientInterface) Lock(l *api.Lock, stopCh <-chan struct{}) (<-chan struct{}, error) {
+	ret := _m.Called(l, stopCh)
+
+	var r0 <-chan struct{}
+	if rf, ok := ret.Get(0).(func(*api.Lock, <-chan struct{}) <-chan struct{}); ok {
+		r0 = rf(l, stopCh)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan struct{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*api.Lock, <-chan struct{}) error); ok {
+		r1 = rf(l, stopCh)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// LockOpts provides a mock function with given fields: opts
+func (_m *ConsulClientInterface) LockOpts(opts *api.LockOptions) (*api.Lock, error) {
+	ret := _m.Called(opts)
+
+	var r0 *api.Lock
+	if rf, ok := ret.Get(0).(func(*api.LockOptions) *api.Lock); ok {
+		r0 = rf(opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Lock)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*api.LockOptions) error); ok {
+		r1 = rf(opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RegisterService provides a mock function with given fields: ctx, s
 func (_m *ConsulClientInterface) RegisterService(ctx context.Context, s *api.AgentServiceRegistration) error {
 	ret := _m.Called(ctx, s)
@@ -57,6 +103,64 @@ func (_m *ConsulClientInterface) RegisterService(ctx context.Context, s *api.Age
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *api.AgentServiceRegistration) error); ok {
 		r0 = rf(ctx, s)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SessionCreate provides a mock function with given fields: ctx, se, q
+func (_m *ConsulClientInterface) SessionCreate(ctx context.Context, se *api.SessionEntry, q *api.WriteOptions) (string, *api.WriteMeta, error) {
+	ret := _m.Called(ctx, se, q)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(context.Context, *api.SessionEntry, *api.WriteOptions) string); ok {
+		r0 = rf(ctx, se, q)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 *api.WriteMeta
+	if rf, ok := ret.Get(1).(func(context.Context, *api.SessionEntry, *api.WriteOptions) *api.WriteMeta); ok {
+		r1 = rf(ctx, se, q)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*api.WriteMeta)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, *api.SessionEntry, *api.WriteOptions) error); ok {
+		r2 = rf(ctx, se, q)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// SessionRenewPeriodic provides a mock function with given fields: initialTTL, id, q, doneCh
+func (_m *ConsulClientInterface) SessionRenewPeriodic(initialTTL string, id string, q *api.WriteOptions, doneCh <-chan struct{}) error {
+	ret := _m.Called(initialTTL, id, q, doneCh)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string, *api.WriteOptions, <-chan struct{}) error); ok {
+		r0 = rf(initialTTL, id, q, doneCh)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Unlock provides a mock function with given fields: l
+func (_m *ConsulClientInterface) Unlock(l *api.Lock) error {
+	ret := _m.Called(l)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*api.Lock) error); ok {
+		r0 = rf(l)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/client/consul.go
+++ b/mocks/client/consul.go
@@ -50,6 +50,38 @@ func (_m *ConsulClientInterface) GetLicense(ctx context.Context, q *api.QueryOpt
 	return r0, r1
 }
 
+// KVGet provides a mock function with given fields: ctx, key, q
+func (_m *ConsulClientInterface) KVGet(ctx context.Context, key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta, error) {
+	ret := _m.Called(ctx, key, q)
+
+	var r0 *api.KVPair
+	if rf, ok := ret.Get(0).(func(context.Context, string, *api.QueryOptions) *api.KVPair); ok {
+		r0 = rf(ctx, key, q)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.KVPair)
+		}
+	}
+
+	var r1 *api.QueryMeta
+	if rf, ok := ret.Get(1).(func(context.Context, string, *api.QueryOptions) *api.QueryMeta); ok {
+		r1 = rf(ctx, key, q)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*api.QueryMeta)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(context.Context, string, *api.QueryOptions) error); ok {
+		r2 = rf(ctx, key, q)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // Lock provides a mock function with given fields: l, stopCh
 func (_m *ConsulClientInterface) Lock(l *api.Lock, stopCh <-chan struct{}) (<-chan struct{}, error) {
 	ret := _m.Called(l, stopCh)


### PR DESCRIPTION
Adds the following to the Consul client interface:

- Creating a session with retries
- Periodically renewing a session
- Creating a lock handler
- Locking a lock
- Unlocking a lock
- Getting a Consul KV pair

Periodic session renewal, creating a lock handler, locking, and unlocking are methods that the Consul API library provides for common use cases and not direct API requests. They're added in this interface for easier testing, but just call the underlying Consul API client method.