### PR TITLE
added list of known secret matchers

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -5,9 +5,13 @@ container {
 }
 
 binary {
-	secrets      = true
 	go_modules   = true
 	osv          = true
 	oss_index    = true
 	nvd          = false
+    secrets {
+      matchers {
+    	  known = ["tfc", "hcp", "tfe", "github", "artifactory", "slack", "aws", "google", "azure"]
+      }
+    }
 }


### PR DESCRIPTION
We have a failing CRT security scan that is being looked into by the release engineering team

https://github.com/hashicorp/crt-workflows-common/runs/7025669481?check_suite_focus=true

It's complaining about a secret, a vault token, contained within the binary. To my knowledge we haven't added anything, so was hoping to look at the binary to see if it contained any clues.

Highly suspect this is a false positive, suggestion was to provide a list of secret scanning only for the secret types we're interested in.

[List of secret matchers](https://github.com/hashicorp/security-scanner/blob/f9ef022e3ba7801f867ded9ef4a717c1d06a7ebe/pkg/scanner/secrets.go#L90-L125)