### PR TITLE
Update Test_TerraformExec_Leak to use tf-exec directly

### DIFF
--- a/client/terraform_exec_test.go
+++ b/client/terraform_exec_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/hc-install/product"
 	"github.com/hashicorp/hc-install/releases"
 	"github.com/hashicorp/hc-install/src"
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,17 +45,13 @@ func Test_TerraformExec_Leak(t *testing.T) {
 		_ = os.Remove("terraform")
 	}()
 
-	tfClient, err := NewTerraformCLI(&TerraformCLIConfig{
-		ExecPath:   ".",
-		WorkingDir: ".",
-	})
-	require.NoError(t, err)
+	tf, err := tfexec.NewTerraform(".", ".")
 
 	before := runtime.NumGoroutine()
 
 	// Mimics CTS calling terraform
-	tfClient.Init(ctx)
-	tfClient.Apply(ctx)
+	tf.Init(ctx)
+	tf.Apply(ctx)
 
 	after := runtime.NumGoroutine()
 	assert.Equal(t, before, after, "the number of goroutines after the terraform "+


### PR DESCRIPTION
Test_TerraformExec_Leak was a little flakey with GHA (see error below). Swap
from using the CTS wrapper around terraform-exec (which did other stuff like
change workspaces) and use terraform-exec directly to init and apply.

```
Error: -23T20:45:45.954Z [ERROR] client.terraformcli: unable to change workspace: workspace="" error="exit status 1"
    terraform_exec_test.go:60:
        	Error Trace:	terraform_exec_test.go:60
        	Error:      	Not equal:
        	            	expected: 22
        	            	actual  : 24
        	Test:       	Test_TerraformExec_Leak
        	Messages:   	the number of goroutines after the terraform requests should be the same as before
```


Testing:
 - Without this fix: 3/4 GHA runs failed ([Click through "Latest" drop down on left](https://github.com/hashicorp/consul-terraform-sync/actions/runs/2552170140))
 - With this fix: 0/4 GHA runs failed ([Click through "Latest" drop down on left](https://github.com/hashicorp/consul-terraform-sync/actions/runs/2552161937))