### PR TITLE
Support once-mode failing silently

### DIFF
--- a/controller/once.go
+++ b/controller/once.go
@@ -24,7 +24,7 @@ type Once struct {
 	monitor      *ConditionMonitor
 
 	// When true, does not handle errors beyond logging. Otherwise fails fast.
-	failSilently bool
+	allowFail bool
 }
 
 // NewOnce configures and initializes a new Once controller
@@ -51,7 +51,7 @@ func NewOnce(conf *config.Config) (*Once, error) {
 		tasksManager: tm,
 		watcher:      watcher,
 		monitor:      NewConditionMonitor(tm, watcher),
-		failSilently: false,
+		allowFail:    false,
 	}, nil
 }
 
@@ -110,8 +110,8 @@ func (ctrl *Once) onceConsecutive(ctx context.Context) error {
 			taskName := *task.Name
 			ctrl.logger.Info("running task once", taskNameLogKey, taskName)
 
-			if ctrl.failSilently {
-				ctrl.tasksManager.TaskFailSilently(ctx, *task)
+			if ctrl.allowFail {
+				ctrl.tasksManager.TaskCreateAndRunAllowFail(ctx, *task)
 				continue
 			}
 
@@ -122,7 +122,7 @@ func (ctrl *Once) onceConsecutive(ctx context.Context) error {
 		}
 	}
 
-	if ctrl.failSilently {
+	if ctrl.allowFail {
 		ctrl.logger.Info("attempted to run all tasks once")
 	} else {
 		ctrl.logger.Info("all tasks completed once")

--- a/controller/once.go
+++ b/controller/once.go
@@ -22,6 +22,9 @@ type Once struct {
 	tasksManager *TasksManager
 	watcher      templates.Watcher
 	monitor      *ConditionMonitor
+
+	// When true, does not handle errors beyond logging. Otherwise fails fast.
+	failSilently bool
 }
 
 // NewOnce configures and initializes a new Once controller
@@ -48,6 +51,7 @@ func NewOnce(conf *config.Config) (*Once, error) {
 		tasksManager: tm,
 		watcher:      watcher,
 		monitor:      NewConditionMonitor(tm, watcher),
+		failSilently: false,
 	}, nil
 }
 
@@ -105,6 +109,12 @@ func (ctrl *Once) onceConsecutive(ctx context.Context) error {
 		default:
 			taskName := *task.Name
 			ctrl.logger.Info("running task once", taskNameLogKey, taskName)
+
+			if ctrl.failSilently {
+				ctrl.tasksManager.TaskFailSilently(ctx, *task)
+				continue
+			}
+
 			if _, err := ctrl.tasksManager.TaskCreateAndRun(ctx, *task); err != nil {
 				return err
 			}
@@ -112,7 +122,12 @@ func (ctrl *Once) onceConsecutive(ctx context.Context) error {
 		}
 	}
 
-	ctrl.logger.Info("all tasks completed once")
+	if ctrl.failSilently {
+		ctrl.logger.Info("attempted to run all tasks once")
+	} else {
+		ctrl.logger.Info("all tasks completed once")
+	}
+
 	return nil
 }
 

--- a/controller/once_test.go
+++ b/controller/once_test.go
@@ -58,18 +58,18 @@ func Test_Once_Run_Terraform(t *testing.T) {
 
 func Test_Once_Run_Terraform_errors(t *testing.T) {
 	// Checks test cases where an error occurs. However, Run() itself may
-	// not return an error i.e. when we allow an error to fail silently
+	// not return an error i.e. when we log the error and move on
 
 	t.Parallel()
 
 	expectedErr := errors.New("test error")
 
 	testCases := []struct {
-		name         string
-		failSilently bool
+		name      string
+		allowFail bool
 	}{
 		{
-			"consecutive fail-silently",
+			"consecutive allow-fail",
 			true,
 		},
 		{
@@ -92,9 +92,9 @@ func Test_Once_Run_Terraform_errors(t *testing.T) {
 				return onceMockDriver(task, nil)
 			}
 
-			mockDrivers, err := testOnce(t, 5, driverConf, tc.failSilently, setupNewDriver)
+			mockDrivers, err := testOnce(t, 5, driverConf, tc.allowFail, setupNewDriver)
 
-			if tc.failSilently {
+			if tc.allowFail {
 				require.NoError(t, err)
 
 				// all drivers should have been created even if 03 errored
@@ -189,7 +189,7 @@ func Test_Once_onceConsecutive_context_canceled(t *testing.T) {
 
 // testOnce test running once-mode. Returns the mocked drivers for the caller
 // to assert expectations
-func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig, failSilently bool,
+func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig, allowFail bool,
 	setupNewDriver func(*driver.Task) driver.Driver) ([]*mocksD.Driver, error) {
 
 	conf := multipleTaskConfig(numTasks)
@@ -197,9 +197,9 @@ func testOnce(t *testing.T, numTasks int, driverConf *config.DriverConfig, failS
 	ss := state.NewInMemoryStore(conf)
 
 	ctrl := Once{
-		logger:       logging.NewNullLogger(),
-		state:        ss,
-		failSilently: failSilently,
+		logger:    logging.NewNullLogger(),
+		state:     ss,
+		allowFail: allowFail,
 	}
 
 	// Set up tasks manager

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -215,13 +215,14 @@ func (tm *TasksManager) TaskUpdate(ctx context.Context, updateConf config.TaskCo
 	return plan.ChangesPresent, plan.Plan, "", nil
 }
 
-// TaskFailSilently creates, runs, and adds a new task. It expects that this
-// task is highly unlikely to error because it has previously been created and
-// run before. Therefore it does not handle the error beyond logging.
+// TaskCreateAndRunAllowFail creates, runs, and adds a new task. It expects that
+// this task is highly unlikely to error because it has previously been created
+// and run before. Therefore it allows failure and does not handle error beyond
+// logging
 //
 // This method is used when we do not want the caller to error and exit when
 // creating, running, and adding a new task.
-func (tm *TasksManager) TaskFailSilently(ctx context.Context, taskConfig config.TaskConfig) {
+func (tm *TasksManager) TaskCreateAndRunAllowFail(ctx context.Context, taskConfig config.TaskConfig) {
 	logger := tm.logger.With(taskNameLogKey, *taskConfig.Name)
 
 	actionSteps := `

--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -110,7 +110,7 @@ func (tm *TasksManager) TaskCreateAndRun(ctx context.Context, taskConfig config.
 		return config.TaskConfig{}, err
 	}
 
-	if err := tm.runNewTask(ctx, d); err != nil {
+	if err := tm.runNewTask(ctx, d, false); err != nil {
 		return config.TaskConfig{}, err
 	}
 
@@ -213,6 +213,42 @@ func (tm *TasksManager) TaskUpdate(ctx context.Context, updateConf config.TaskCo
 	}
 
 	return plan.ChangesPresent, plan.Plan, "", nil
+}
+
+// TaskFailSilently creates, runs, and adds a new task. It expects that this
+// task is highly unlikely to error because it has previously been created and
+// run before. Therefore it does not handle the error beyond logging.
+//
+// This method is used when we do not want the caller to error and exit when
+// creating, running, and adding a new task.
+func (tm *TasksManager) TaskFailSilently(ctx context.Context, taskConfig config.TaskConfig) {
+	logger := tm.logger.With(taskNameLogKey, *taskConfig.Name)
+
+	actionSteps := `
+Please investigate this error. This may require re-creating the task using the
+Create Task API / CLI. https://www.consul.io/docs/nia/cli/task#task-create
+`
+
+	d, err := tm.createTask(ctx, taskConfig)
+	if err != nil {
+		logger.Error(fmt.Sprintf("error creating driver for task.%s", actionSteps),
+			"error", err)
+		return
+	}
+
+	if err := tm.runNewTask(ctx, d, true); err != nil {
+		// Expects that this task has run successfully before and any error is
+		// intermittent and next run will succeed
+		logger.Error("error while running task once after creation. will still "+
+			"add task to CTS", "error", err)
+	}
+
+	if _, err := tm.addTask(ctx, d); err != nil {
+		logger.Error(fmt.Sprintf("error adding task to CTS.%s", actionSteps),
+			"error", err)
+	}
+
+	logger.Info("task was created and run successfully")
 }
 
 func configFromDriverTask(t *driver.Task) (config.TaskConfig, error) {
@@ -547,7 +583,9 @@ func (tm *TasksManager) createTask(ctx context.Context, taskConfig config.TaskCo
 //
 // Stores an event in the state that should be cleaned up if the task is not
 // added to CTS.
-func (tm *TasksManager) runNewTask(ctx context.Context, d driver.Driver) error {
+func (tm *TasksManager) runNewTask(ctx context.Context, d driver.Driver,
+	allowApplyErr bool) error {
+
 	task := d.Task()
 	taskName := task.Name()
 	logger := tm.logger.With(taskNameLogKey, taskName)
@@ -572,7 +610,9 @@ func (tm *TasksManager) runNewTask(ctx context.Context, d driver.Driver) error {
 	err = d.ApplyTask(ctx)
 	if err != nil {
 		logger.Error("error applying task", "error", err)
-		return err
+		if !allowApplyErr {
+			return err
+		}
 	}
 
 	// Store event if apply was successful and task will be created

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -850,9 +850,10 @@ func Test_ConditionMonitor_EnableTaskRanNotify(t *testing.T) {
 	s.AssertExpectations(t)
 }
 
-func Test_TasksManager_TaskFailSilently(t *testing.T) {
-	// TaskFailSilently is similar to TaskCreateAndRun but with modified error
-	// handling. This tests what hasn't been tested in Test_TasksManager_TaskCreate
+func Test_TasksManager_TaskCreateAndRunAllowFail(t *testing.T) {
+	// TaskCreateAndRunAllowFail is similar to TaskCreateAndRun but with
+	// modified error handling. This tests what hasn't been tested in
+	// Test_TasksManager_TaskCreate
 	ctx := context.Background()
 
 	tm := newTestTasksManager()
@@ -885,7 +886,7 @@ func Test_TasksManager_TaskFailSilently(t *testing.T) {
 			return mockD, nil
 		}
 
-		tm.TaskFailSilently(ctx, validTaskConf)
+		tm.TaskCreateAndRunAllowFail(ctx, validTaskConf)
 
 		_, ok := tm.drivers.Get(validTaskName)
 		assert.True(t, ok, "driver is added even if run is unsuccessful")

--- a/controller/tasks_manager_test.go
+++ b/controller/tasks_manager_test.go
@@ -891,7 +891,9 @@ func Test_TasksManager_TaskFailSilently(t *testing.T) {
 		assert.True(t, ok, "driver is added even if run is unsuccessful")
 
 		events := tm.state.GetTaskEvents(validTaskName)
-		assert.Len(t, events, 1, "event is stored even on failed run")
+		taskEvents := events[validTaskName]
+		require.Len(t, taskEvents, 1, "event is stored even on failed run")
+		assert.False(t, taskEvents[0].Success, "event should have failed")
 	})
 }
 


### PR DESCRIPTION
We want to be able to support when once-mode does not exit on error. One use-case for this is when the tasks have been known to run successfully before. When CTS starts up, we expect the tasks to be successful and any errors are intermittent. In this case, we want CTS to not exit and just log the error.


Commits
 - 1 & 2: Split out error test case for `Test_Once_Run_Terraform` in preparation for new error case in commit 4
 - 3: Add TaskFailsSilently (open to better naming ideas) in tasks manager
 - 4: Update once-mode with a failSilently flag that calls TaskFailsSilently when true

Edit: from PR feedback changed "fail silently" language to "allow fail"