### PR TITLE
added a configuration compatibility checker

### DIFF
--- a/compatibility/compatibility.go
+++ b/compatibility/compatibility.go
@@ -1,0 +1,119 @@
+package compatibility
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+)
+
+const (
+	fieldIgnoreKey = "cts-ha"
+	fieldIgnoreTag = "unshared"
+)
+
+// IsCompatibleConfig is a convenience method for calling IsCompatible with
+// config.Config configurations
+func IsCompatibleConfig(ctx context.Context, baseConf *config.Config, conf *config.Config) bool {
+	return IsCompatible(ctx, reflect.ValueOf(baseConf), reflect.ValueOf(conf))
+}
+
+// IsCompatible compares a pointer to a base configuration with a pointer to a configuration and returns true
+// if the two configurations are compatible with each other, and false otherwise
+func IsCompatible(ctx context.Context, baseConf reflect.Value, conf reflect.Value) bool {
+	// Make sure we are comparing the same type and that we are only comparing pointers
+	if baseConf.Type() != conf.Type() {
+		panic("types being compared are not the same")
+	}
+
+	// Only check if non-nil pointers, otherwise this is not being
+	// used as intended
+	if baseConf.Kind() != reflect.Pointer || baseConf.IsNil() {
+		panic("cannot check compatibility of non pointers")
+	}
+
+	rc := compatabilityChecker{
+		logger:         logging.FromContext(ctx),
+		fieldIgnoreKey: fieldIgnoreKey,
+		fieldIgnoreTag: fieldIgnoreTag,
+	}
+	return rc.check(baseConf, conf, "")
+}
+
+type compatabilityChecker struct {
+	logger         logging.Logger
+	fieldIgnoreKey string
+	fieldIgnoreTag string
+}
+
+func (rc compatabilityChecker) check(valueBase reflect.Value, value reflect.Value, fieldName string) bool {
+	// Only check into non-nil pointers
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return true
+	}
+
+	// Dereference the pointer to the struct
+	structValueBase := valueBase.Elem()
+	structValue := value.Elem()
+	structType := value.Type().Elem()
+
+	initName := fieldName
+	isCompatible := true
+
+	// Iterate through fields on the struct type
+	for i, f := range reflect.VisibleFields(structType) {
+		// Get the field on the struct value
+		vf := structValue.Field(i)
+		vb := structValueBase.Field(i)
+
+		// Ignore fields if they contain the ignore key/tag and return true
+		tag, ok := f.Tag.Lookup(rc.fieldIgnoreKey)
+		if ok && tag == rc.fieldIgnoreTag {
+			continue
+		}
+
+		// Concatenate field-names if necessary to give a
+		// full path in context of the struct
+		if fieldName != "" {
+			fieldName = fmt.Sprintf("%s.%s", fieldName, f.Name)
+		} else {
+			fieldName = f.Name
+		}
+
+		// If struct is shared check, do not check the root struct
+		if (f.Type.Kind() == reflect.Pointer && f.Type.Elem().Kind() == reflect.Struct) || f.Type.Kind() == reflect.Struct {
+			rc.check(vb, vf, fieldName)
+			fieldName = initName
+			continue
+		}
+
+		if vb.Interface() != vf.Interface() {
+			// Set isCompatible to false only on first incompatibility
+			// once incompatible once, it will always be incompatible
+			if isCompatible {
+				isCompatible = false
+			}
+			rc.logger.Error(fmt.Sprintf("Config %v does not equal %v for %v",
+				getPrintableValue(vb), getPrintableValue(vf), fieldName))
+		}
+
+		// Reset field name so that we do not concatenate unnecessarily
+		// in the future
+		fieldName = initName
+	}
+
+	return isCompatible
+}
+
+func getPrintableValue(v reflect.Value) interface{} {
+	var vp interface{}
+	if (v.Kind() == reflect.Pointer || v.Kind() == reflect.Interface) && v.IsNil() {
+		vp = "<nil>"
+	} else {
+		vp = reflect.Indirect(v)
+	}
+
+	return vp
+}

--- a/compatibility/compatibility_test.go
+++ b/compatibility/compatibility_test.go
@@ -1,0 +1,249 @@
+package compatibility
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/consul-terraform-sync/config"
+	"github.com/hashicorp/consul-terraform-sync/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestConfig struct {
+	S  *string `cts-ha:"unshared"`
+	I  *int
+	Ii int `cts-ha:"unshared"`
+	C  *TestSubConfig
+	C2 *TestSubConfig `cts-ha:"unshared"`
+	C3 TestSubConfig
+}
+
+type TestSubConfig struct {
+	S *string
+	I *int `cts-ha:"unshared"`
+}
+
+func TestIsCompatibleConfig(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNullLogger()
+	ctx = logging.WithContext(ctx, logger)
+
+	isCompatible := IsCompatibleConfig(ctx, &config.Config{}, &config.Config{})
+
+	assert.True(t, isCompatible)
+}
+
+func TestIsCompatible(t *testing.T) {
+	t.Parallel()
+
+	s := "blah"
+	i := 123
+
+	testCases := []struct {
+		name                 string
+		baseConf             TestConfig
+		conf                 TestConfig
+		expectedIsCompatible bool
+		expectedNumLogs      int
+	}{
+		{
+			name: "compatible same",
+			baseConf: TestConfig{
+				S:  &s, // unshared
+				I:  &i,
+				Ii: 456, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+				C2: &TestSubConfig{ // unshared
+					S: &s,
+					I: &i, // unshared
+				},
+				C3: TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+			},
+			conf: TestConfig{
+				S:  &s,
+				I:  &i,
+				Ii: 456,
+				C: &TestSubConfig{
+					S: &s,
+					I: &i,
+				},
+				C2: &TestSubConfig{
+					S: &s,
+					I: &i,
+				},
+				C3: TestSubConfig{
+					S: &s,
+					I: &i,
+				},
+			},
+			expectedNumLogs:      0,
+			expectedIsCompatible: true,
+		},
+		{
+			name: "compatible different unshared only",
+			baseConf: TestConfig{
+				S:  &s, // unshared
+				I:  &i,
+				Ii: 456, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+				C2: &TestSubConfig{ // unshared
+					S: &s,
+					I: &i, // unshared
+				},
+				C3: TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+			},
+			conf: TestConfig{
+				S:  nil, // unshared
+				I:  &i,
+				Ii: 0, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: nil, // unshared
+				},
+				C2: &TestSubConfig{ // unshared
+					S: &s,
+					I: &i, // unshared
+				},
+				C3: TestSubConfig{
+					S: &s,
+					I: nil, // unshared
+				},
+			},
+			expectedNumLogs:      0,
+			expectedIsCompatible: true,
+		},
+		{
+			name: "incompatible different with nested structs",
+			baseConf: TestConfig{
+				S:  &s, // unshared
+				I:  &i,
+				Ii: 456, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+				C2: &TestSubConfig{ // unshared
+					S: &s,
+					I: &i,
+				},
+			},
+			conf: TestConfig{
+				S:  nil,
+				I:  nil,
+				Ii: 0,
+				C: &TestSubConfig{
+					S: nil,
+					I: nil,
+				},
+				C2: &TestSubConfig{
+					S: nil,
+					I: nil,
+				},
+			},
+			expectedNumLogs:      2,
+			expectedIsCompatible: false,
+		},
+		{
+			name: "incompatible different with same nested struct",
+			baseConf: TestConfig{
+				S:  &s, // unshared
+				I:  &i,
+				Ii: 456, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+			},
+			conf: TestConfig{
+				S:  &s, // unshared
+				I:  nil,
+				Ii: 456, // unshared
+				C: &TestSubConfig{
+					S: &s,
+					I: &i, // unshared
+				},
+			},
+			expectedNumLogs:      1,
+			expectedIsCompatible: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			tw := newTestWriter()
+			logger := logging.NewTestLogger("INFO", tw)
+			ctx = logging.WithContext(ctx, logger)
+
+			actualIsCompatible := IsCompatible(ctx, reflect.ValueOf(&tc.baseConf), reflect.ValueOf(&tc.conf))
+
+			assert.Equal(t, tc.expectedIsCompatible, actualIsCompatible)
+			assert.Equal(t, tc.expectedNumLogs, len(tw.Mem))
+		})
+	}
+}
+
+func TestCompatibility_Panics(t *testing.T) {
+	ctx := context.Background()
+	logger := logging.NewNullLogger()
+	logging.WithContext(ctx, logger)
+
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		val1 reflect.Value
+		val2 reflect.Value
+	}{
+		{
+			name: "different structs",
+			val1: reflect.ValueOf(&TestConfig{}),
+			val2: reflect.ValueOf(&config.Config{}),
+		},
+		{
+			name: "non pointers",
+			val1: reflect.ValueOf(TestConfig{}),
+			val2: reflect.ValueOf(TestConfig{}),
+		},
+		{
+			name: "non nil pointers",
+			val1: reflect.ValueOf(nil),
+			val2: reflect.ValueOf(nil),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Panics(t, func() { IsCompatible(ctx, tc.val1, tc.val2) })
+		})
+	}
+}
+
+type testWriter struct {
+	Mem []string
+}
+
+func newTestWriter() *testWriter {
+	return &testWriter{
+		Mem: make([]string, 0),
+	}
+}
+
+func (tw *testWriter) Write(p []byte) (n int, err error) {
+	s := string(p[:])
+	tw.Mem = append(tw.Mem, s)
+	return 0, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,12 @@
 module github.com/hashicorp/consul-terraform-sync
 
-go 1.16
+go 1.18
 
 require (
-	cloud.google.com/go v0.78.0 // indirect
-	cloud.google.com/go/storage v1.13.0 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/PaloAltoNetworks/pango v0.5.1
-	github.com/agext/levenshtein v1.2.3 // indirect
-	github.com/aws/aws-sdk-go v1.37.19 // indirect
 	github.com/deepmap/oapi-codegen v1.11.0
-	github.com/fatih/color v1.10.0 // indirect
 	github.com/getkin/kin-openapi v0.94.0
 	github.com/go-chi/chi/v5 v5.0.7
-	github.com/go-test/deep v1.0.7 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/consul/api v1.13.0
 	github.com/hashicorp/consul/sdk v0.9.0
@@ -22,7 +15,6 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-getter v1.6.1
 	github.com/hashicorp/go-hclog v0.16.2
-	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.2
@@ -35,24 +27,97 @@ require (
 	github.com/hashicorp/terraform-exec v0.17.0
 	github.com/hashicorp/terraform-json v0.14.0
 	github.com/hashicorp/vault/api v1.7.2
-	github.com/klauspost/compress v1.11.7 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mitchellh/cli v1.1.2
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mitchellh/reflectwalk v1.0.2
-	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
-	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.1
-	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/zclconf/go-cty v1.10.0
+)
+
+require (
+	cloud.google.com/go v0.78.0 // indirect
+	cloud.google.com/go/storage v1.13.0 // indirect
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/armon/go-metrics v0.3.9 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/aws/aws-sdk-go v1.37.19 // indirect
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/cenkalti/backoff/v3 v3.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.10.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/swag v0.21.1 // indirect
+	github.com/go-test/deep v1.0.7 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.3 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.0 // indirect
+	github.com/hashicorp/go-safetemp v1.0.0 // indirect
+	github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 // indirect
+	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/serf v0.9.6 // indirect
+	github.com/hashicorp/vault/sdk v0.5.1 // indirect
+	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/klauspost/compress v1.11.7 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
+	github.com/mitchellh/pointerstructure v1.1.0 // indirect
+	github.com/oklog/run v1.0.0 // indirect
+	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
+	github.com/ulikunitz/xz v0.5.10 // indirect
 	go.opencensus.io v0.22.6 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.0.0-20220513210258-46612604a0f9 // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+	golang.org/x/net v0.0.0-20220513224357-95641704303c // indirect
 	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93 // indirect
+	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
+	golang.org/x/tools v0.1.10 // indirect
+	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
+	google.golang.org/api v0.40.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210222212404-3e1e516060db // indirect
+	google.golang.org/grpc v1.41.0 // indirect
+	google.golang.org/protobuf v1.28.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 
 	// v3.0 has a CVE. Force dependencies github.com/deepmap/oapi-codegen to
 	// use latest version of go-yaml

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,6 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -125,7 +124,6 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
@@ -134,9 +132,7 @@ github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.4.0/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
-github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
-github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/getkin/kin-openapi v0.94.0 h1:bAxg2vxgnHHHoeefVdmGbR+oxtJlcv5HsJJa3qmAHuo=
 github.com/getkin/kin-openapi v0.94.0/go.mod h1:LWZfzOd7PRy8GJ1dJ6mCU6tNdSfOwRac1BUPam4aw6Q=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -144,7 +140,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-asn1-ber/asn1-ber v1.3.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-chi/chi/v5 v5.0.7 h1:rDTPXLDHGATaeHvVlLcR4Qe0zftYethFucbjVQ1PxU8=
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -161,7 +156,6 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-ldap/ldap v3.0.2+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
-github.com/go-ldap/ldap/v3 v3.1.10/go.mod h1:5Zun81jBTabRaI8lzN7E1JjyEl1g6zI6u9pd8luAK4Q=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
@@ -178,7 +172,6 @@ github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn
 github.com/go-playground/validator/v10 v10.11.0/go.mod h1:i+3WkQ1FvaUjjxh1kSvIA4dMGDBiPU55YFDl0WbKdWU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.7 h1:/VSMRlnY/JSyqxQUzQLKVMAskpY/NZKFA5j2P+0pP2M=
 github.com/go-test/deep v1.0.7/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
@@ -297,7 +290,6 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-immutable-radix v1.2.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-kms-wrapping/entropy v0.1.0/go.mod h1:d1g9WGtAunDNpek8jUIEJnBlbgKS1N2Q61QkHiZyR1g=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
 github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
@@ -318,17 +310,13 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-secure-stdlib/base62 v0.1.1/go.mod h1:EdWO6czbmthiwZ3/PUsDV+UD1D5IRU4ActiaWGwt0Yw=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1 h1:cCRo8gK7oq6A2L6LICkUZ+/a5rLiRXFMf1Qd4xSwxTc=
 github.com/hashicorp/go-secure-stdlib/mlock v0.1.1/go.mod h1:zq93CJChV6L9QTfGKtfBxKqD7BqqXx5O04A/ns2p5+I=
-github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 h1:om4Al8Oy7kCm/B86rLCLah4Dt5Aa0Fr5rYBG60OzwHQ=
 github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6/go.mod h1:QmrqtbKuxxSWTN3ETMPuB+VtEiBJ/A9XhoYGv8E1uD8=
-github.com/hashicorp/go-secure-stdlib/password v0.1.1/go.mod h1:9hH302QllNwu1o2TGYtSk8I8kTAN0ca1EHpwhm5Mmzo=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.1/go.mod h1:gKOamz3EwoIoJq7mlMIRBpVTAUn8qPCrEclOKKWhD3U=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9CdjCtrXrXGuOpxEA7Ts=
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
-github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
@@ -339,7 +327,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.5.0 h1:O293SZ2Eg+AAYijkVK3jR786Am1bhDEh2GHT0tIVE5E=
 github.com/hashicorp/go-version v1.5.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
@@ -392,7 +379,6 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
@@ -556,7 +542,6 @@ github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdk
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
-github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -626,7 +611,6 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=


### PR DESCRIPTION
Introduced logic for producing a compatibility check.

### Reflection
This solution relies heavily on reflection because:
1) Our config can be expanded, so this is one less place things will need to be altered if it does
2) Our config is large, so performing manual checks was not ideal

### Struct Tag Usage
The code uses the concept of struct tags (`cts-ha:"unshared"`) to be able to indicate which fields should be compared against, and which shouldn't.

The following test structs demonstrate how these tags are used
```Go
type TestConfig struct {
	S  *string `cts-ha:"unshared"`
	I  *int
	Ii int `cts-ha:"unshared"`
	C  *TestSubConfig
	C2 *TestSubConfig `cts-ha:"unshared"`
	C3 TestSubConfig
}

type TestSubConfig struct {
	S *string
	I *int `cts-ha:"unshared"`
}
```

An `unshared` value will not effect compatibility, however, if a `shared` value (one without a tag) differs, then compatibility will fail

For example:
``` Go
s := "blah"
i := 123

tc1 := TestConfig {
  S:  &s, // unshared
   I:  &i,
}

tc2 := TestConfig {
  S:  &s, // unshared
   I:  nil,
}
```
Will fail compatibility because `I` is different and `shared`

``` Go
s := "blah"
i := 123

tc1 := TestConfig {
  S:  &s, // unshared
   I:  &i,
}

tc2 := TestConfig {
  S:  nil, // unshared
   I:  &i,
}
```
Will succeed compatibility because although `S` is different, `S` is `unshared`

### Logs
The compatibility check will log a message for each field that fails compatibility (including fields in nested structs)

Example 
``` Console
2022-06-28T15:24:13.018-0700 [ERROR] Config 123 does not equal <nil> for Field1
2022-06-28T15:24:13.018-0700 [ERROR] Config blah does not equal <nil> for Struct1.Field1
```