### PR TITLE
Run Full E2E Matrix (CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
       - e2e-split
     if: needs.run-check.result == 'success'
     strategy:
+      fail-fast: false
       matrix:
         index: [0, 1, 2, 3]
     steps:

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -54,7 +54,7 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 		{
 			"missing required arguments",
 			[]string{},
-			"Error: this command requires one argument",
+			"__AJ__ INTENTIONALLY FAIL", // TODO revert after testing
 		},
 		{
 			"connect using wrong scheme",

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -54,7 +54,7 @@ func TestE2E_MetaCommandErrors(t *testing.T) {
 		{
 			"missing required arguments",
 			[]string{},
-			"__AJ__ INTENTIONALLY FAIL", // TODO revert after testing
+			"Error: this command requires one argument",
 		},
 		{
 			"connect using wrong scheme",


### PR DESCRIPTION
This change ensures that when a single part of e2e tests fails, the other parts continue executing and are not skipped.

Tested with an intentional failure:
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/12840688/176503003-17694885-2668-413f-bffd-0796384da7db.png">
