### PR TITLE
Added missing new line at the end of help output

### DIFF
--- a/command/cli.go
+++ b/command/cli.go
@@ -116,6 +116,7 @@ func (cli *CLI) Run(args []string) int {
 		fmt.Fprintf(cli.errStream, "Error running the CLI command '%s': %s",
 			strings.Join(args, " "), err)
 	}
+
 	return exitCode
 }
 
@@ -125,6 +126,7 @@ func isVersion(args []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -161,7 +163,8 @@ func generateHelp(commands map[string]string, usage string, omitFlags []string) 
 
 	tw.Flush()
 
-	return strings.TrimSpace(b.String())
+	helpOutput := strings.TrimSpace(b.String()) + "\n"
+	return helpOutput
 }
 
 func generateCommandHelp(cmdName string, cmdFactory mcli.CommandFactory) string {

--- a/command/start.go
+++ b/command/start.go
@@ -136,12 +136,12 @@ func (c *startCommand) Help() string {
 
 // HelpDeprecated returns the usage when this command is used because CTS was not invoked with a command
 func (c *startCommand) HelpDeprecated() string {
-
 	// Create a command factor for common commands
 	commands := make(map[string]string)
 	for _, v := range commonCommands {
 		commands[v] = fmt.Sprintf("%s\t\n", v)
 	}
+
 	return generateHelp(commands, "Usage CLI: consul-terraform-sync <command> [-help] [options]\n", nil)
 }
 


### PR DESCRIPTION
Help output was missing a new line at the end, resulting in this output
```
bash-3.2$ consul-terraform-sync -h
Usage CLI: consul-terraform-sync <command> [-help] [options]
...
        Render templates and run tasks once. Does not run the process 
        as a daemon and disables buffer periods.bash-3.2$ 
```

After adding the new line at the end, this is the output
```
bash-3.2$ consul-terraform-sync -h
Usage CLI: consul-terraform-sync <command> [-help] [options]
...
        Render templates and run tasks once. Does not run the process 
        as a daemon and disables buffer periods.
bash-3.2$ 
```