### PR TITLE
Allow cts run without initial task

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -439,6 +439,12 @@ func TestConfig_Validate(t *testing.T) {
 	*validMultiTask.TerraformProviders = append(*validMultiTask.TerraformProviders,
 		&TerraformProviderConfig{"Y": map[string]interface{}{}})
 
+	validNilTasks := longConfig.Copy()
+	*validNilTasks.Tasks = nil
+
+	validEmptyTasks := longConfig.Copy()
+	*validEmptyTasks.Tasks = TaskConfigs{}
+
 	cases := []struct {
 		name    string
 		i       *Config
@@ -459,6 +465,14 @@ func TestConfig_Validate(t *testing.T) {
 		}, {
 			"multi-task valid",
 			validMultiTask.Copy(),
+			true,
+		}, {
+			"nil tasks valid",
+			validNilTasks.Copy(),
+			true,
+		}, {
+			"empty tasks valid",
+			validEmptyTasks.Copy(),
 			true,
 		}, {
 			"empty provider",

--- a/config/task.go
+++ b/config/task.go
@@ -518,7 +518,8 @@ func (c *TaskConfigs) Finalize(bp *BufferPeriodConfig, wd string) {
 // Validate validates the values and nested values of the configuration struct
 func (c *TaskConfigs) Validate() error {
 	if c == nil || len(*c) == 0 {
-		return fmt.Errorf("missing tasks configuration")
+		// Acceptable for a list of task configurations to be empty
+		return nil
 	}
 
 	unique := make(map[string]bool)

--- a/config/task_test.go
+++ b/config/task_test.go
@@ -928,7 +928,7 @@ func TestTasksConfig_Validate(t *testing.T) {
 		{
 			name:    "nil",
 			i:       nil,
-			isValid: false,
+			isValid: true,
 		}, {
 			name: "one task",
 			i: []*TaskConfig{

--- a/controller/daemon.go
+++ b/controller/daemon.go
@@ -132,9 +132,10 @@ func (ctrl *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
-	// Run tasks in long-running mode
+	// Run long-running mode and monitor existing
+	// and created tasks
 	go func() {
-		ctrl.logger.Info("start monitoring tasks")
+		ctrl.logger.Info("start task monitoring")
 		err := ctrl.monitor.Run(ctx)
 		exitCh <- err
 	}()

--- a/controller/once.go
+++ b/controller/once.go
@@ -61,6 +61,14 @@ func (ctrl *Once) Init(ctx context.Context) error {
 }
 
 func (ctrl *Once) Run(ctx context.Context) error {
+	// Check if tasks are configured, if none are configured
+	// exit early
+	tasks := ctrl.state.GetAllTasks()
+	if tasks == nil || len(tasks) == 0 {
+		ctrl.logger.Info("no tasks configured")
+		return nil
+	}
+
 	ctrl.logger.Info("executing all tasks once through")
 
 	// Stop watching dependencies after once-ing tasks ends


### PR DESCRIPTION
This PR serves to remove the requirement that CTS be run with initial configuration tasks.

When CTS is run without initial configuration tasks, it will forgo running once mode and monitor for new tasks/serve the API. If a new task is created via the API/CLI, then CTS will monitor and trigger as before.

If CTS is run with initial configuration tasks, runs as usual.

