### PR TITLE
loosen schedule condition checks

### DIFF
--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -120,9 +120,9 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 			taskSchedule := 10 * time.Second
 			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
-			// 0. Confirm one event for once-mode
+			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)
-			assert.Equal(t, 1, eventCountBase)
+			assert.GreaterOrEqual(t, 1, eventCountBase)
 
 			// 1. Wait and confirm that the task was triggered at the scheduled time
 			// Special confirmation case: when task is run in once-mode, it runs on
@@ -213,9 +213,9 @@ func TestCondition_Schedule_Dynamic(t *testing.T) {
 	port := cts.Port()
 	scheduledWait := taskSchedule + 5*time.Second // buffer for task to execute
 
-	// 0. Confirm one event for once-mode
+	// 0. Confirm at least one event for once-mode
 	schedEventCount := eventCount(t, schedTaskName, port)
-	require.Equal(t, 1, schedEventCount)
+	require.GreaterOrEqual(t, 1, schedEventCount)
 	dynaEventCounter := eventCount(t, dbTaskName, port)
 	require.Equal(t, 1, dynaEventCounter)
 
@@ -313,10 +313,10 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	require.NoError(t, err, fmt.Sprintf("command '%s' failed:\n %s", subcmd, out))
 	require.Contains(t, out, fmt.Sprintf("Task '%s' created", taskName))
 
-	// 0. Confirm one event for when the task was created
+	// 0. Confirm at least one event for when the task was created
 	port := cts.Port()
 	eventCountBase := eventCount(t, taskName, port)
-	assert.Equal(t, 1, eventCountBase, "expected a scheduled task event after creation")
+	assert.GreaterOrEqual(t, 1, eventCountBase, "expected a scheduled task event after creation")
 
 	// 1. Wait and confirm that the task was triggered at the scheduled time
 	beforeEvent := time.Now()
@@ -499,10 +499,10 @@ func TestCondition_Schedule_SuppressTriggers_SharedDependencies(t *testing.T) {
 	require.NoError(t, err, fmt.Sprintf("command '%s' failed:\n %s", subcmd, out))
 	require.Contains(t, out, fmt.Sprintf("Task '%s' created", taskName))
 
-	// Confirm one event at creation, no services or KV registered yet
+	// Confirm at least one event at creation, no services or KV registered yet
 	count := eventCount(t, taskName, cts.Port())
 	expectedCount := 1
-	require.Equal(t, expectedCount, count)
+	require.GreaterOrEqual(t, expectedCount, count)
 
 	// Wait for scheduled task to have just ran
 	taskSchedule := 10 * time.Second


### PR DESCRIPTION
- tasks with schedule condition can create 1 or more events depending on how close to the trigger time creation occurs due to when the test runs