### PR TITLE
Error if HA config provided

### DIFF
--- a/config/decode.go
+++ b/config/decode.go
@@ -46,6 +46,12 @@ Upgrade to Consul Enterprise to enable CTS Enterprise features.`, err)
 
 'license' is a Consul-Terraform-Sync (CTS) Enterprise configuration.`, err)
 
+		case "high_availability":
+			return fmt.Errorf(`%s
+
+High availability is a Consul-Terraform-Sync (CTS) Enterprise feature.
+Upgrade to Consul Enterprise to enable CTS Enterprise features.`, err)
+
 		}
 	}
 	return err


### PR DESCRIPTION
```
2022-07-28T16:51:48.116-0500 [ERROR] cli: error building configuration:
  error=
  | 'config.hcl' has invalid keys: high_availability
  | 
  | High availability is a Consul-Terraform-Sync (CTS) Enterprise feature.
  | Upgrade to Consul Enterprise to enable CTS Enterprise features.
```