### PR TITLE
Allow for 100 scheduled tasks during once-mode.

### DIFF
--- a/controller/tasks_manager.go
+++ b/controller/tasks_manager.go
@@ -59,8 +59,8 @@ func NewTasksManager(conf *config.Config, state state.Store, watcher templates.W
 		state:             state,
 		drivers:           driver.NewDrivers(),
 		retry:             retry.NewRetry(defaultRetry, time.Now().UnixNano()),
-		createdScheduleCh: make(chan string, 10), // arbitrarily chosen size
-		deletedScheduleCh: make(chan string, 10), // arbitrarily chosen size
+		createdScheduleCh: make(chan string, 100), // arbitrarily chosen size
+		deletedScheduleCh: make(chan string, 100), // arbitrarily chosen size
 	}, nil
 }
 


### PR DESCRIPTION
The old channel size would not allow for more than 10 scheduled
tasks to be defined on startup. Once-mode would hang, because the
scheduled channel consumer was not yet initialized. This tweak
allows for up to 100 scheduled tasks to be defined before blocking.