### PR TITLE
set PRODUCT_VERSION for default docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM alpine:3 as default
 
-# NAME and VERSION are the name of the software in releases.hashicorp.com
-# and the version to download. Example: NAME=consul VERSION=1.2.3.
+# NAME and PRODUCT_VERSION are the name of the software in releases.hashicorp.com
+# and the version to download. Example: NAME=consul PRODUCT_VERSION=1.2.3.
 ARG NAME=consul-terraform-sync
-ARG VERSION
+ARG PRODUCT_VERSION
 
 LABEL maintainer="Consul Team <consul@hashicorp.com>"
-LABEL version=$VERSION
+LABEL version=$PRODUCT_VERSION
 
 # Set ARGs as ENV so that they can be used in ENTRYPOINT/CMD
 ENV NAME=$NAME
-ENV VERSION=$VERSION
+ENV VERSION=$PRODUCT_VERSION
 
 # TARGETARCH and TARGETOS are set automatically when --platform is provided.
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
Changes proposed in this PR:

In `actions-docker-build` we [pass](https://github.com/hashicorp/actions-docker-build/blob/05c370a26e61b06be46c5095d6e914c9f0ea4f3d/scripts/docker_build#L49) `PRODUCT_VERSION` to the docker build command. Since this was not set, the label did not populate properly which is used in a comparison to determine the `minor-latest` and `latest` docker image tags. 

```
docker inspect hashicorp/consul-terraform-sync:latest -f={{json '.Config.Labels'}} | jq

{
  "maintainer": "Consul Team <consul@hashicorp.com>",
  "version": ""
}

```