### PR TITLE
Increase time.Sleep

### DIFF
--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -201,7 +201,7 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	// Without this delay, CatalogServices may have services that are not yet
 	// propagated to HealthServices as healthy services since services are initially
 	// set as critical. https://www.consul.io/docs/discovery/checks#initial-health-check-status
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	var services []*dep.HealthService
 	for _, s := range matchServices {

--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -201,7 +201,7 @@ func (d *servicesRegexQuery) Fetch(clients dep.Clients) (interface{}, *dep.Respo
 	// Without this delay, CatalogServices may have services that are not yet
 	// propagated to HealthServices as healthy services since services are initially
 	// set as critical. https://www.consul.io/docs/discovery/checks#initial-health-check-status
-	time.Sleep(1 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	var services []*dep.HealthService
 	for _, s := range matchServices {


### PR DESCRIPTION
Issue - NET-4886

Issue - 
When services are registered with checks, initially they are in `critical` status. When health check passes, they get in `passing` status.  Without this delay, CatalogServices may have services that are not yet propagated to HealthServices as healthy services since services are initially set as critical. 

The API call from CTS to Consul has `passing` [set to true](https://github.com/hashicorp/consul-terraform-sync/blob/main/templates/tftmpl/tmplfunc/services_regex.go#L209). It only returns passing health check services or healthy services.

The delay is small. It might take more time to make service healthy. Hence this PR increases the delay.


Tests - 
Manually tested it using Nomad and Consul + CTS setup using Terraform Cloud driver. Changes in PR has resolved the issue.
Also verified by @maksimnosal 