### PR TITLE
NET 6318 - Go/Terraform Version Upgrade + E2E passing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,3 @@ updates:
       interval: "daily"
       time: "05:00"
       timezone: "UTC"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.18", goos: "linux", goarch: "386"}
-          - {go: "1.18", goos: "linux", goarch: "amd64"}
-          - {go: "1.18", goos: "linux", goarch: "arm"}
-          - {go: "1.18", goos: "linux", goarch: "arm64"}
-          - {go: "1.18", goos: "freebsd", goarch: "386"}
-          - {go: "1.18", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.18", goos: "windows", goarch: "386"}
-          - {go: "1.18", goos: "windows", goarch: "amd64"}
-          - {go: "1.18", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.10", goos: "linux", goarch: "386"}
+          - {go: "1.20.10", goos: "linux", goarch: "amd64"}
+          - {go: "1.20.10", goos: "linux", goarch: "arm"}
+          - {go: "1.20.10", goos: "linux", goarch: "arm64"}
+          - {go: "1.20.10", goos: "freebsd", goarch: "386"}
+          - {go: "1.20.10", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.10", goos: "windows", goarch: "386"}
+          - {go: "1.20.10", goos: "windows", goarch: "amd64"}
+          - {go: "1.20.10", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -147,7 +147,7 @@ jobs:
       matrix:
         goos: [darwin]
         goarch: ["amd64"]
-        go: ["1.18"]
+        go: ["1.20.10"]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20", goos: "linux", goarch: "386"}
-          - {go: "1.20", goos: "linux", goarch: "amd64"}
-          - {go: "1.20", goos: "linux", goarch: "arm"}
-          - {go: "1.20", goos: "linux", goarch: "arm64"}
-          - {go: "1.20", goos: "freebsd", goarch: "386"}
-          - {go: "1.20", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20", goos: "windows", goarch: "386"}
-          - {go: "1.20", goos: "windows", goarch: "amd64"}
-          - {go: "1.20", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20.10", goos: "linux", goarch: "386"}
+          - {go: "1.20.10", goos: "linux", goarch: "amd64"}
+          - {go: "1.20.10", goos: "linux", goarch: "arm"}
+          - {go: "1.20.10", goos: "linux", goarch: "arm64"}
+          - {go: "1.20.10", goos: "freebsd", goarch: "386"}
+          - {go: "1.20.10", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20.10", goos: "windows", goarch: "386"}
+          - {go: "1.20.10", goos: "windows", goarch: "amd64"}
+          - {go: "1.20.10", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -147,7 +147,7 @@ jobs:
       matrix:
         goos: [darwin]
         goarch: ["amd64"]
-        go: ["1.20"]
+        go: ["1.20.10"]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,15 +71,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - {go: "1.20.10", goos: "linux", goarch: "386"}
-          - {go: "1.20.10", goos: "linux", goarch: "amd64"}
-          - {go: "1.20.10", goos: "linux", goarch: "arm"}
-          - {go: "1.20.10", goos: "linux", goarch: "arm64"}
-          - {go: "1.20.10", goos: "freebsd", goarch: "386"}
-          - {go: "1.20.10", goos: "freebsd", goarch: "amd64"}
-          - {go: "1.20.10", goos: "windows", goarch: "386"}
-          - {go: "1.20.10", goos: "windows", goarch: "amd64"}
-          - {go: "1.20.10", goos: "solaris", goarch: "amd64"}
+          - {go: "1.20", goos: "linux", goarch: "386"}
+          - {go: "1.20", goos: "linux", goarch: "amd64"}
+          - {go: "1.20", goos: "linux", goarch: "arm"}
+          - {go: "1.20", goos: "linux", goarch: "arm64"}
+          - {go: "1.20", goos: "freebsd", goarch: "386"}
+          - {go: "1.20", goos: "freebsd", goarch: "amd64"}
+          - {go: "1.20", goos: "windows", goarch: "386"}
+          - {go: "1.20", goos: "windows", goarch: "amd64"}
+          - {go: "1.20", goos: "solaris", goarch: "amd64"}
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build
@@ -147,7 +147,7 @@ jobs:
       matrix:
         goos: [darwin]
         goarch: ["amd64"]
-        go: ["1.20.10"]
+        go: ["1.20"]
       fail-fast: true
 
     name: Go ${{ matrix.go }} ${{ matrix.goos }} ${{ matrix.goarch }} build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.20.10
+  GO_VERSION: 1.20
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Run Go checks
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Build
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Split E2E tests
         run: |
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Run Go checks
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Build
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Split E2E tests
         run: |
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: 1.20.10
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
 
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run Go checks
         run: |
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Build
         run: |
@@ -96,7 +96,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum
@@ -135,7 +135,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Split E2E tests
         run: |
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup gotestsum
         uses: ./.github/actions/setup-gotestsum

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: 1.20.10
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
 

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Run compatability tests
         run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: latest
 
       - name: Setup Vault
         uses: ./.github/actions/setup-vault

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Run compatability tests
         run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: latest
+          go-version: "latest"
 
       - name: Setup Vault
         uses: ./.github/actions/setup-vault

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.20
+  GO_VERSION: 1.20.10
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
   VAULT_VERSION: 1.10.3

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.20.10
+  GO_VERSION: 1.20
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
   VAULT_VERSION: 1.10.3

--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: 1.20.10
   CONSUL_VERSION: 1.12.1
   TERRAFORM_VERSION: 1.2.2
   VAULT_VERSION: 1.10.3
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Run compatability tests
         run: |
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "latest"
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Setup Vault
         uses: ./.github/actions/setup-vault

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 BUG FIXES:
 * Fix issue with re registration of services with checks not triggering task [[GH-1067](https://github.com/hashicorp/consul-terraform-sync/pull/1067)]
 
+FEATURES:
+* Go version bump to 1.21.10 [[GH-1067](https://github.com/hashicorp/consul-terraform-sync/pull/1067)]
+* Support for Terraform v1.6.2 [[GH-1067](https://github.com/hashicorp/consul-terraform-sync/pull/1067)]
+
 ## 0.7.0 (September 8, 2022)
 
 BREAKING CHANGES:

--- a/config/monitor_services.go
+++ b/config/monitor_services.go
@@ -131,10 +131,10 @@ func (c *ServicesMonitorConfig) Merge(o MonitorConfig) MonitorConfig {
 // Finalize ensures there no nil pointers.
 //
 // Exception: `Regexp` is never finalized and can potentially be nil.
-//  - There is a need to distinguish betweeen nil regex (unconfigured regex) and
-//  empty string regex ("" regex pattern) at Validate().
-//  - Setting `Regexp` as an empty string is not idempotent. There is a need to
-//  call Finalize() and Validate() multiple times.
+//   - There is a need to distinguish betweeen nil regex (unconfigured regex) and
+//     empty string regex ("" regex pattern) at Validate().
+//   - Setting `Regexp` as an empty string is not idempotent. There is a need to
+//     call Finalize() and Validate() multiple times.
 func (c *ServicesMonitorConfig) Finalize() {
 	if c == nil { // config not required, return early
 		return

--- a/config/task.go
+++ b/config/task.go
@@ -465,9 +465,10 @@ func (c *TaskConfig) Validate() error {
 
 // ValidateForDriver validates all remaining values and required options that were not checked during
 // the normal Validate() call. This method is recommended to run after:
-//  - Finalize()
-//  - Validate()
-//  - InheritParentConfig()
+//   - Finalize()
+//   - Validate()
+//   - InheritParentConfig()
+//
 // It is intended to indicate whether a task is safe to be converted into a driver for execution.
 func (c *TaskConfig) ValidateForDriver() error {
 	if err := c.BufferPeriod.Validate(); err != nil {
@@ -643,9 +644,10 @@ func FilterTasks(tasks *TaskConfigs, names []string) (*TaskConfigs, error) {
 }
 
 // validateCondition validates condition block taking into account services list
-// - ensure task is configured with a condition (condition block or services
-//   list)
-// - if services list is configured, condition block's monitored variable type
+//   - ensure task is configured with a condition (condition block or services
+//     list)
+//   - if services list is configured, condition block's monitored variable type
+//
 // cannot be services
 //
 // Note: checking that a condition block's monitored variable type is different

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -121,7 +121,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 
 			port := cts.Port()
 			taskSchedule := 10 * time.Second
-			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
+			scheduledWait := taskSchedule + 57*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -157,7 +157,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 			// check scheduled task did not trigger immediately and ran only on schedule
 			api.WaitForEvent(t, cts, taskName, registerTime, scheduledWait)
 			checkScheduledRun(t, taskName, registerTime, taskSchedule, port)
-			time.Sleep(20 * time.Second)
+			time.Sleep(defaultWaitForTestReadiness)
 
 			// confirm service resources created
 			resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)
@@ -348,6 +348,8 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	// check scheduled task did not trigger immediately and ran only on schedule
 	api.WaitForEvent(t, cts, taskName, registerTime, scheduledWait)
 	checkScheduledRun(t, taskName, registerTime, taskSchedule, port)
+
+	time.Sleep(defaultWaitForTestReadiness)
 
 	// confirm resources created
 	resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -301,7 +301,7 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	cts := ctsSetup(t, srv, tempDir, initTask)
 
 	taskSchedule := 10 * time.Second
-	scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
+	scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 	// Create a scheduled task with the CLI and a task file
 	var taskConfig hclConfig

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -300,7 +300,7 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	cts := ctsSetup(t, srv, tempDir, initTask)
 
 	taskSchedule := 10 * time.Second
-	scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
+	scheduledWait := taskSchedule + 17*time.Second // buffer for task to execute
 
 	// Create a scheduled task with the CLI and a task file
 	var taskConfig hclConfig

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -69,8 +69,8 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 	condition "schedule" {
 		cron = "*/10 * * * * * *"
 	}
-}
-`, taskName)
+	}
+	`, taskName)
 	moduleInputServices := fmt.Sprintf(scheduledServices, taskName)
 	moduleInputConsulKV := fmt.Sprintf(scheduledConsulKV, taskName)
 
@@ -121,7 +121,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 
 			port := cts.Port()
 			taskSchedule := 10 * time.Second
-			scheduledWait := taskSchedule + 57*time.Second // buffer for task to execute
+			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)
@@ -157,6 +157,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 			// check scheduled task did not trigger immediately and ran only on schedule
 			api.WaitForEvent(t, cts, taskName, registerTime, scheduledWait)
 			checkScheduledRun(t, taskName, registerTime, taskSchedule, port)
+			time.Sleep(20 * time.Second)
 
 			// confirm service resources created
 			resourcesPath := filepath.Join(tempDir, taskName, resourcesDir)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -299,8 +299,8 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "schedule_create_delete_cli")
 	cts := ctsSetup(t, srv, tempDir, initTask)
 
-	taskSchedule := 20 * time.Second
-	scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
+	taskSchedule := 10 * time.Second
+	scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
 
 	// Create a scheduled task with the CLI and a task file
 	var taskConfig hclConfig

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -121,7 +121,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 
 			port := cts.Port()
 			taskSchedule := 10 * time.Second
-			scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
+			scheduledWait := taskSchedule + 37*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -44,7 +44,7 @@ const (
 	condition "schedule" {
 		cron = "*/10 * * * * * *"
 	}
-	module_input "services"{
+	module_input "services" {
 		regexp = "^web.*|^api.*"
 	}
 }`
@@ -121,7 +121,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 
 			port := cts.Port()
 			taskSchedule := 10 * time.Second
-			scheduledWait := taskSchedule + 37*time.Second // buffer for task to execute
+			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -120,8 +120,8 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 			//    scheduled time. Check resources are created.
 
 			port := cts.Port()
-			taskSchedule := 20 * time.Second
-			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
+			taskSchedule := 10 * time.Second
+			scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode
 			eventCountBase := eventCount(t, taskName, port)

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -300,7 +300,7 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	cts := ctsSetup(t, srv, tempDir, initTask)
 
 	taskSchedule := 10 * time.Second
-	scheduledWait := taskSchedule + 17*time.Second // buffer for task to execute
+	scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
 
 	// Create a scheduled task with the CLI and a task file
 	var taskConfig hclConfig

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -299,8 +299,8 @@ func TestCondition_Schedule_CreateAndDeleteCLI(t *testing.T) {
 	tempDir := fmt.Sprintf("%s%s", tempDirPrefix, "schedule_create_delete_cli")
 	cts := ctsSetup(t, srv, tempDir, initTask)
 
-	taskSchedule := 10 * time.Second
-	scheduledWait := taskSchedule + 27*time.Second // buffer for task to execute
+	taskSchedule := 20 * time.Second
+	scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 	// Create a scheduled task with the CLI and a task file
 	var taskConfig hclConfig

--- a/e2e/condition_schedule_test.go
+++ b/e2e/condition_schedule_test.go
@@ -120,7 +120,7 @@ func TestCondition_Schedule_Basic(t *testing.T) {
 			//    scheduled time. Check resources are created.
 
 			port := cts.Port()
-			taskSchedule := 10 * time.Second
+			taskSchedule := 20 * time.Second
 			scheduledWait := taskSchedule + 7*time.Second // buffer for task to execute
 
 			// 0. Confirm at least one event for once-mode

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -212,7 +212,7 @@ func testServicesCondition(t *testing.T, tc servicesConditionTest) {
 	now = time.Now()
 	service = testutil.TestService{ID: "api-web-3", Name: "api-web", Tags: []string{"tag_a"}}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	time.Sleep(defaultWaitForNoEvent)
+	time.Sleep(defaultWaitForTestReadiness)
 	eventCountNow = eventCount(t, tc.taskName, cts.Port())
 	require.Equal(t, eventCountExpected, eventCountNow,
 		"change in event count. task was unexpectedly triggered")

--- a/e2e/condition_service_test.go
+++ b/e2e/condition_service_test.go
@@ -188,7 +188,7 @@ func testServicesCondition(t *testing.T, tc servicesConditionTest) {
 	now := time.Now()
 	service = testutil.TestService{ID: "api-web-1", Name: "api-web"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, tc.taskName, now, defaultWaitForEvent)
+	api.WaitForEvent(t, cts, tc.taskName, now, defaultWaitForTestReadiness)
 	eventCountNow = eventCount(t, tc.taskName, cts.Port())
 	eventCountExpected++
 	require.Equal(t, eventCountExpected, eventCountNow,
@@ -201,7 +201,7 @@ func testServicesCondition(t *testing.T, tc servicesConditionTest) {
 	now = time.Now()
 	service = testutil.TestService{ID: "api-web-2", Name: "api-web"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, tc.taskName, now, defaultWaitForEvent)
+	api.WaitForEvent(t, cts, tc.taskName, now, defaultWaitForTestReadiness)
 	eventCountNow = eventCount(t, tc.taskName, cts.Port())
 	eventCountExpected++
 	require.Equal(t, eventCountExpected, eventCountNow,
@@ -340,7 +340,7 @@ func TestConditionServices_SuppressTriggers_SharedDependencies(t *testing.T) {
 	now := time.Now()
 	service := testutil.TestService{ID: "api-test", Name: "api-test"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, taskName, now, defaultWaitForEvent)
+	api.WaitForEvent(t, cts, taskName, now, defaultWaitForTestReadiness)
 	count = eventCount(t, taskName, cts.Port())
 	expectedCount++
 	assert.Equal(t, expectedCount, count, "unexpected event count")
@@ -351,7 +351,7 @@ func TestConditionServices_SuppressTriggers_SharedDependencies(t *testing.T) {
 	now = time.Now()
 	service = testutil.TestService{ID: "web", Name: "web"}
 	testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
-	api.WaitForEvent(t, cts, initTaskName, now, defaultWaitForEvent)
+	api.WaitForEvent(t, cts, initTaskName, now, defaultWaitForTestReadiness)
 	initCount := eventCount(t, initTaskName, cts.Port())
 	assert.Equal(t, 2, initCount, "unexpected event count")
 	initResources := filepath.Join(tempDir, initTaskName, resourcesDir)

--- a/e2e/module_input_test.go
+++ b/e2e/module_input_test.go
@@ -394,7 +394,7 @@ func TestModuleInput_ConsulKVCondition(t *testing.T) {
 			service := testutil.TestService{ID: "api", Name: "api"}
 			testutils.RegisterConsulService(t, srv, service, defaultWaitForRegistration)
 
-			time.Sleep(defaultWaitForNoEvent)
+			time.Sleep(defaultWaitForTestReadiness)
 			testutils.CheckDir(t, false, resourcesPath)
 
 			// 2. Register kv pair to trigger condition. Confirm that

--- a/e2e/module_input_test.go
+++ b/e2e/module_input_test.go
@@ -223,7 +223,7 @@ func testModuleInputBasic(t *testing.T, tc moduleInputTest) {
 	tc.srv.SetKVString(t, "key", "value")
 	tc.srv.SetKVString(t, "key/recurse", "value-recurse")
 
-	time.Sleep(defaultWaitForNoEvent)
+	time.Sleep(defaultWaitForTestReadiness)
 	testutils.CheckDir(t, false, resourcesPath)
 
 	// 2. Register "web" service to trigger condition. Confirm that

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -47,7 +47,7 @@ const (
 	defaultWaitForCheckUpdate   = 15 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
-	defaultWaitForNoEvent = 15 * time.Second
+	defaultWaitForNoEvent = 6 * time.Second
 
 	// default TLS
 	defaultCTSClientCert = "../testutils/certs/localhost_leaf_cert.pem"

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -47,7 +47,7 @@ const (
 	defaultWaitForCheckUpdate   = 15 * time.Second
 
 	// liberal wait time to ensure event doesn't happen
-	defaultWaitForNoEvent = 6 * time.Second
+	defaultWaitForNoEvent = 15 * time.Second
 
 	// default TLS
 	defaultCTSClientCert = "../testutils/certs/localhost_leaf_cert.pem"

--- a/examples/reference-example/sync-tasks/my-task/main.tf
+++ b/examples/reference-example/sync-tasks/my-task/main.tf
@@ -12,7 +12,7 @@
 # Description: automate services for website X
 
 terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   required_providers {
     myprovider = {
       source  = "namespace/myprovider"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-terraform-sync
 
-go 1.18
+go 1.20.10
 
 require (
 	github.com/PaloAltoNetworks/pango v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-terraform-sync
 
-go 1.20.10
+go 1.20
 
 require (
 	github.com/PaloAltoNetworks/pango v0.5.1

--- a/internal/decode/decode.go
+++ b/internal/decode/decode.go
@@ -25,7 +25,8 @@ import (
 // Aliases must be lowercase, as keys are compared case-insensitive.
 //
 // Example alias tag:
-//    MyField []string `alias:"old_field_name,otherfieldname"`
+//
+//	MyField []string `alias:"old_field_name,otherfieldname"`
 //
 // This hook should ONLY be used to maintain backwards compatibility with
 // deprecated keys. For new structures use mapstructure struct tags to set the
@@ -149,7 +150,7 @@ type mapstructureFieldTags struct {
 // the target is a slice. This is necessary because this hook would have converted
 // the initial slices into single values on the first pass.
 //
-// Background
+// # Background
 //
 // HCL allows for repeated blocks which forces it to store structures
 // as []map[string]interface{} instead of map[string]interface{}. This is an

--- a/mocks/api/middleware.go
+++ b/mocks/api/middleware.go
@@ -32,8 +32,8 @@ type Interceptor_Intercept_Call struct {
 }
 
 // Intercept is a helper method to define mock.On call
-//  - _a0 http.ResponseWriter
-//  - _a1 *http.Request
+//   - _a0 http.ResponseWriter
+//   - _a1 *http.Request
 func (_e *Interceptor_Expecter) Intercept(_a0 interface{}, _a1 interface{}) *Interceptor_Intercept_Call {
 	return &Interceptor_Intercept_Call{Call: _e.mock.On("Intercept", _a0, _a1)}
 }
@@ -70,7 +70,7 @@ type Interceptor_ShouldIntercept_Call struct {
 }
 
 // ShouldIntercept is a helper method to define mock.On call
-//  - _a0 *http.Request
+//   - _a0 *http.Request
 func (_e *Interceptor_Expecter) ShouldIntercept(_a0 interface{}) *Interceptor_ShouldIntercept_Call {
 	return &Interceptor_ShouldIntercept_Call{Call: _e.mock.On("ShouldIntercept", _a0)}
 }

--- a/mocks/client/consul.go
+++ b/mocks/client/consul.go
@@ -43,9 +43,9 @@ type ConsulClientInterface_DeregisterService_Call struct {
 }
 
 // DeregisterService is a helper method to define mock.On call
-//  - ctx context.Context
-//  - serviceID string
-//  - q *api.QueryOptions
+//   - ctx context.Context
+//   - serviceID string
+//   - q *api.QueryOptions
 func (_e *ConsulClientInterface_Expecter) DeregisterService(ctx interface{}, serviceID interface{}, q interface{}) *ConsulClientInterface_DeregisterService_Call {
 	return &ConsulClientInterface_DeregisterService_Call{Call: _e.mock.On("DeregisterService", ctx, serviceID, q)}
 }
@@ -91,9 +91,9 @@ type ConsulClientInterface_GetHealthChecks_Call struct {
 }
 
 // GetHealthChecks is a helper method to define mock.On call
-//  - ctx context.Context
-//  - serviceName string
-//  - q *api.QueryOptions
+//   - ctx context.Context
+//   - serviceName string
+//   - q *api.QueryOptions
 func (_e *ConsulClientInterface_Expecter) GetHealthChecks(ctx interface{}, serviceName interface{}, q interface{}) *ConsulClientInterface_GetHealthChecks_Call {
 	return &ConsulClientInterface_GetHealthChecks_Call{Call: _e.mock.On("GetHealthChecks", ctx, serviceName, q)}
 }
@@ -137,8 +137,8 @@ type ConsulClientInterface_GetLicense_Call struct {
 }
 
 // GetLicense is a helper method to define mock.On call
-//  - ctx context.Context
-//  - q *api.QueryOptions
+//   - ctx context.Context
+//   - q *api.QueryOptions
 func (_e *ConsulClientInterface_Expecter) GetLicense(ctx interface{}, q interface{}) *ConsulClientInterface_GetLicense_Call {
 	return &ConsulClientInterface_GetLicense_Call{Call: _e.mock.On("GetLicense", ctx, q)}
 }
@@ -193,9 +193,9 @@ type ConsulClientInterface_KVGet_Call struct {
 }
 
 // KVGet is a helper method to define mock.On call
-//  - ctx context.Context
-//  - key string
-//  - q *api.QueryOptions
+//   - ctx context.Context
+//   - key string
+//   - q *api.QueryOptions
 func (_e *ConsulClientInterface_Expecter) KVGet(ctx interface{}, key interface{}, q interface{}) *ConsulClientInterface_KVGet_Call {
 	return &ConsulClientInterface_KVGet_Call{Call: _e.mock.On("KVGet", ctx, key, q)}
 }
@@ -241,8 +241,8 @@ type ConsulClientInterface_Lock_Call struct {
 }
 
 // Lock is a helper method to define mock.On call
-//  - l *api.Lock
-//  - stopCh <-chan struct{}
+//   - l *api.Lock
+//   - stopCh <-chan struct{}
 func (_e *ConsulClientInterface_Expecter) Lock(l interface{}, stopCh interface{}) *ConsulClientInterface_Lock_Call {
 	return &ConsulClientInterface_Lock_Call{Call: _e.mock.On("Lock", l, stopCh)}
 }
@@ -288,7 +288,7 @@ type ConsulClientInterface_LockOpts_Call struct {
 }
 
 // LockOpts is a helper method to define mock.On call
-//  - opts *api.LockOptions
+//   - opts *api.LockOptions
 func (_e *ConsulClientInterface_Expecter) LockOpts(opts interface{}) *ConsulClientInterface_LockOpts_Call {
 	return &ConsulClientInterface_LockOpts_Call{Call: _e.mock.On("LockOpts", opts)}
 }
@@ -334,9 +334,9 @@ type ConsulClientInterface_QueryServices_Call struct {
 }
 
 // QueryServices is a helper method to define mock.On call
-//  - ctx context.Context
-//  - filter string
-//  - q *api.QueryOptions
+//   - ctx context.Context
+//   - filter string
+//   - q *api.QueryOptions
 func (_e *ConsulClientInterface_Expecter) QueryServices(ctx interface{}, filter interface{}, q interface{}) *ConsulClientInterface_QueryServices_Call {
 	return &ConsulClientInterface_QueryServices_Call{Call: _e.mock.On("QueryServices", ctx, filter, q)}
 }
@@ -373,8 +373,8 @@ type ConsulClientInterface_RegisterService_Call struct {
 }
 
 // RegisterService is a helper method to define mock.On call
-//  - ctx context.Context
-//  - s *api.AgentServiceRegistration
+//   - ctx context.Context
+//   - s *api.AgentServiceRegistration
 func (_e *ConsulClientInterface_Expecter) RegisterService(ctx interface{}, s interface{}) *ConsulClientInterface_RegisterService_Call {
 	return &ConsulClientInterface_RegisterService_Call{Call: _e.mock.On("RegisterService", ctx, s)}
 }
@@ -427,9 +427,9 @@ type ConsulClientInterface_SessionCreate_Call struct {
 }
 
 // SessionCreate is a helper method to define mock.On call
-//  - ctx context.Context
-//  - se *api.SessionEntry
-//  - q *api.WriteOptions
+//   - ctx context.Context
+//   - se *api.SessionEntry
+//   - q *api.WriteOptions
 func (_e *ConsulClientInterface_Expecter) SessionCreate(ctx interface{}, se interface{}, q interface{}) *ConsulClientInterface_SessionCreate_Call {
 	return &ConsulClientInterface_SessionCreate_Call{Call: _e.mock.On("SessionCreate", ctx, se, q)}
 }
@@ -466,10 +466,10 @@ type ConsulClientInterface_SessionRenewPeriodic_Call struct {
 }
 
 // SessionRenewPeriodic is a helper method to define mock.On call
-//  - initialTTL string
-//  - id string
-//  - q *api.WriteOptions
-//  - doneCh <-chan struct{}
+//   - initialTTL string
+//   - id string
+//   - q *api.WriteOptions
+//   - doneCh <-chan struct{}
 func (_e *ConsulClientInterface_Expecter) SessionRenewPeriodic(initialTTL interface{}, id interface{}, q interface{}, doneCh interface{}) *ConsulClientInterface_SessionRenewPeriodic_Call {
 	return &ConsulClientInterface_SessionRenewPeriodic_Call{Call: _e.mock.On("SessionRenewPeriodic", initialTTL, id, q, doneCh)}
 }
@@ -506,7 +506,7 @@ type ConsulClientInterface_Unlock_Call struct {
 }
 
 // Unlock is a helper method to define mock.On call
-//  - l *api.Lock
+//   - l *api.Lock
 func (_e *ConsulClientInterface_Expecter) Unlock(l interface{}) *ConsulClientInterface_Unlock_Call {
 	return &ConsulClientInterface_Unlock_Call{Call: _e.mock.On("Unlock", l)}
 }

--- a/mocks/templates/template.go
+++ b/mocks/templates/template.go
@@ -49,7 +49,7 @@ type Template_Execute_Call struct {
 }
 
 // Execute is a helper method to define mock.On call
-//  - _a0 hcat.Recaller
+//   - _a0 hcat.Recaller
 func (_e *Template_Expecter) Execute(_a0 interface{}) *Template_Execute_Call {
 	return &Template_Execute_Call{Call: _e.mock.On("Execute", _a0)}
 }
@@ -122,7 +122,7 @@ type Template_Notify_Call struct {
 }
 
 // Notify is a helper method to define mock.On call
-//  - _a0 interface{}
+//   - _a0 interface{}
 func (_e *Template_Expecter) Notify(_a0 interface{}) *Template_Notify_Call {
 	return &Template_Notify_Call{Call: _e.mock.On("Notify", _a0)}
 }
@@ -166,7 +166,7 @@ type Template_Render_Call struct {
 }
 
 // Render is a helper method to define mock.On call
-//  - content []byte
+//   - content []byte
 func (_e *Template_Expecter) Render(content interface{}) *Template_Render_Call {
 	return &Template_Render_Call{Call: _e.mock.On("Render", content)}
 }

--- a/mocks/templates/watcher.go
+++ b/mocks/templates/watcher.go
@@ -35,7 +35,7 @@ type Watcher_BufferReset_Call struct {
 }
 
 // BufferReset is a helper method to define mock.On call
-//  - _a0 hcat.Notifier
+//   - _a0 hcat.Notifier
 func (_e *Watcher_Expecter) BufferReset(_a0 interface{}) *Watcher_BufferReset_Call {
 	return &Watcher_BufferReset_Call{Call: _e.mock.On("BufferReset", _a0)}
 }
@@ -72,7 +72,7 @@ type Watcher_Buffering_Call struct {
 }
 
 // Buffering is a helper method to define mock.On call
-//  - _a0 hcat.Notifier
+//   - _a0 hcat.Notifier
 func (_e *Watcher_Expecter) Buffering(_a0 interface{}) *Watcher_Buffering_Call {
 	return &Watcher_Buffering_Call{Call: _e.mock.On("Buffering", _a0)}
 }
@@ -147,7 +147,7 @@ type Watcher_Complete_Call struct {
 }
 
 // Complete is a helper method to define mock.On call
-//  - _a0 hcat.Notifier
+//   - _a0 hcat.Notifier
 func (_e *Watcher_Expecter) Complete(_a0 interface{}) *Watcher_Complete_Call {
 	return &Watcher_Complete_Call{Call: _e.mock.On("Complete", _a0)}
 }
@@ -181,7 +181,7 @@ type Watcher_Deregister_Call struct {
 }
 
 // Deregister is a helper method to define mock.On call
-//  - ns ...hcat.Notifier
+//   - ns ...hcat.Notifier
 func (_e *Watcher_Expecter) Deregister(ns ...interface{}) *Watcher_Deregister_Call {
 	return &Watcher_Deregister_Call{Call: _e.mock.On("Deregister",
 		append([]interface{}{}, ns...)...)}
@@ -216,7 +216,7 @@ type Watcher_MarkForSweep_Call struct {
 }
 
 // MarkForSweep is a helper method to define mock.On call
-//  - notifier hcat.IDer
+//   - notifier hcat.IDer
 func (_e *Watcher_Expecter) MarkForSweep(notifier interface{}) *Watcher_MarkForSweep_Call {
 	return &Watcher_MarkForSweep_Call{Call: _e.mock.On("MarkForSweep", notifier)}
 }
@@ -255,7 +255,7 @@ type Watcher_Recaller_Call struct {
 }
 
 // Recaller is a helper method to define mock.On call
-//  - _a0 hcat.Notifier
+//   - _a0 hcat.Notifier
 func (_e *Watcher_Expecter) Recaller(_a0 interface{}) *Watcher_Recaller_Call {
 	return &Watcher_Recaller_Call{Call: _e.mock.On("Recaller", _a0)}
 }
@@ -298,7 +298,7 @@ type Watcher_Register_Call struct {
 }
 
 // Register is a helper method to define mock.On call
-//  - ns ...hcat.Notifier
+//   - ns ...hcat.Notifier
 func (_e *Watcher_Expecter) Register(ns ...interface{}) *Watcher_Register_Call {
 	return &Watcher_Register_Call{Call: _e.mock.On("Register",
 		append([]interface{}{}, ns...)...)}
@@ -340,9 +340,9 @@ type Watcher_SetBufferPeriod_Call struct {
 }
 
 // SetBufferPeriod is a helper method to define mock.On call
-//  - min time.Duration
-//  - max time.Duration
-//  - tmplIDs ...string
+//   - min time.Duration
+//   - max time.Duration
+//   - tmplIDs ...string
 func (_e *Watcher_Expecter) SetBufferPeriod(min interface{}, max interface{}, tmplIDs ...interface{}) *Watcher_SetBufferPeriod_Call {
 	return &Watcher_SetBufferPeriod_Call{Call: _e.mock.On("SetBufferPeriod",
 		append([]interface{}{min, max}, tmplIDs...)...)}
@@ -440,7 +440,7 @@ type Watcher_Sweep_Call struct {
 }
 
 // Sweep is a helper method to define mock.On call
-//  - notifier hcat.IDer
+//   - notifier hcat.IDer
 func (_e *Watcher_Expecter) Sweep(notifier interface{}) *Watcher_Sweep_Call {
 	return &Watcher_Sweep_Call{Call: _e.mock.On("Sweep", notifier)}
 }
@@ -479,7 +479,7 @@ type Watcher_WaitCh_Call struct {
 }
 
 // WaitCh is a helper method to define mock.On call
-//  - _a0 context.Context
+//   - _a0 context.Context
 func (_e *Watcher_Expecter) WaitCh(_a0 interface{}) *Watcher_WaitCh_Call {
 	return &Watcher_WaitCh_Call{Call: _e.mock.On("WaitCh", _a0)}
 }
@@ -516,8 +516,8 @@ type Watcher_Watch_Call struct {
 }
 
 // Watch is a helper method to define mock.On call
-//  - _a0 context.Context
-//  - _a1 chan string
+//   - _a0 context.Context
+//   - _a1 chan string
 func (_e *Watcher_Expecter) Watch(_a0 interface{}, _a1 interface{}) *Watcher_Watch_Call {
 	return &Watcher_Watch_Call{Call: _e.mock.On("Watch", _a0, _a1)}
 }

--- a/templates/hcltmpl/block.go
+++ b/templates/hcltmpl/block.go
@@ -16,10 +16,10 @@ type Variables map[string]cty.Value
 // NamedBlock represents an HCL block with one label and an arbitrary number of
 // attributes of varying types.
 //
-// 	block "name" {
+//	block "name" {
 //		attr = "str"
 //		count = 10
-// 	}
+//	}
 type NamedBlock struct {
 	Name      string
 	Variables Variables

--- a/templates/tftmpl/root.go
+++ b/templates/tftmpl/root.go
@@ -139,7 +139,9 @@ func (d *RootModuleInputData) init() {
 
 // InitRootModule generates the root module and writes the following files to
 // disk.
-//   always: main.tf, variables.tf, terraform.tfvars.tmpl
+//
+//	always: main.tf, variables.tf, terraform.tfvars.tmpl
+//
 // conditionally: variables.module.tf, providers.tfvars
 func InitRootModule(input *RootModuleInputData) error {
 	input.init()

--- a/templates/tftmpl/root_test.go
+++ b/templates/tftmpl/root_test.go
@@ -32,14 +32,14 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"nil",
 			nil,
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
 }
 `,
 		}, {
 			"empty",
 			map[string]interface{}{"empty": map[string]interface{}{}},
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   backend "empty" {
   }
 }
@@ -48,7 +48,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"invalid structure",
 			map[string]interface{}{"invalid": "unexpected type"},
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
 }
 `,
 		}, {
@@ -57,7 +57,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"path": "relative/path/to/terraform.tfstate",
 			}},
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   backend "local" {
     path = "relative/path/to/terraform.tfstate"
   }
@@ -67,7 +67,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 			"consul",
 			consulBackend,
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   backend "consul" {
     address   = "consul.example.com"
     ca_file   = "ca_cert"
@@ -85,7 +85,7 @@ func TestAppendRootTerraformBlock_backend(t *testing.T) {
 				"conn_str": "postgres://user:pass@db.example.com/terraform_backend",
 			}},
 			`terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   backend "pg" {
     conn_str = "postgres://user:pass@db.example.com/terraform_backend"
   }

--- a/templates/tftmpl/testdata/catalog-services/main.tf
+++ b/templates/tftmpl/testdata/catalog-services/main.tf
@@ -9,7 +9,7 @@
 # Description: user description for task named 'test'
 
 terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
 }
 
 

--- a/templates/tftmpl/testdata/main.tf
+++ b/templates/tftmpl/testdata/main.tf
@@ -9,7 +9,7 @@
 # Description: user description for task named 'test'
 
 terraform {
-  required_version = ">= 0.13.0, < 1.3.0"
+  required_version = ">= 0.13.0, <= 1.6.2"
   required_providers {
     testProvider = {
       source  = "namespace/testProvider"

--- a/templates/tftmpl/tmplfunc/catalog_services_registration.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration.go
@@ -21,7 +21,7 @@ var _ hcatQuery = (*catalogServicesRegistrationQuery)(nil)
 // services. It queries the Catalog List Services API and supports the query
 // parameters dc, ns, and node-meta. It also adds an additional layer of
 // custom functionality on the API response:
-//  - Adds regex filtering on service name option e.g. "regexp=api"
+//   - Adds regex filtering on service name option e.g. "regexp=api"
 //
 // Endpoint: /v1/catalog/services
 // Template: {{ catalogServicesRegistration  <filter options> ... }}

--- a/templates/tftmpl/tmplfunc/services_meta.go
+++ b/templates/tftmpl/tmplfunc/services_meta.go
@@ -10,10 +10,10 @@ import (
 // ServicesMeta holds the user-defined metadata for the services of a task.
 // From task configuration, metadata is provided to a task's services in one
 // of two ways:
-// 1. map of metadata: a map of service-name to metadata so that each service
-//    has its own unique metadata
-// 2. metadata: a set of metadata is shared across all services that a task is
-//    configured with
+//  1. map of metadata: a map of service-name to metadata so that each service
+//     has its own unique metadata
+//  2. metadata: a set of metadata is shared across all services that a task is
+//     configured with
 type ServicesMeta struct {
 	// Deprecated in 0.5
 	// When this happens: when task.services field and associated

--- a/templates/tftmpl/tmplfunc/services_regex.go
+++ b/templates/tftmpl/tmplfunc/services_regex.go
@@ -34,8 +34,10 @@ var (
 // Health API query only.
 //
 // Endpoints:
-//   /v1/catalog/services
-//   /v1/health/service/:service
+//
+//	/v1/catalog/services
+//	/v1/health/service/:service
+//
 // Template: {{ servicesRegex regexp=<regex> <options> ... }}
 func servicesRegexFunc(recall hcat.Recaller) interface{} {
 	return func(opts ...string) ([]*dep.HealthService, error) {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -317,8 +317,8 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // WaitForHttpStatusChange performs a blocking http call every pollInterval and returns the response
 // whenever it encounters a StatusCode of newStatus. Any StatusCode other than oldStatus or newStatus
 // will return an error immediately. It is the caller's responsibility to:
-//  - prevent an infinite loop by eventually cancelling the context
-//  - close the response
+//   - prevent an infinite loop by eventually cancelling the context
+//   - close the response
 func WaitForHttpStatusChange(ctx context.Context, pollInterval time.Duration, method, url, body string, oldStatus, newStatus int) (*http.Response, error) {
 	for {
 		select {

--- a/version/terraform.go
+++ b/version/terraform.go
@@ -16,7 +16,7 @@ import (
 // account for. The upper bound may be removed once CTS has protocols
 // set in place for compatible modules and can handle Terraform syntax changes
 // and enhancements between versions.
-const CompatibleTerraformVersionConstraint = ">= 0.13.0, < 1.3.0"
+const CompatibleTerraformVersionConstraint = ">= 0.13.0, <= 1.6.2"
 
 // TerraformConstraint is the go-version constraint variable for
 // CompatibleTerraformVersionConstraint

--- a/version/terraform_test.go
+++ b/version/terraform_test.go
@@ -46,7 +46,7 @@ func TestTerraformConstraint(t *testing.T) {
 			false,
 		}, {
 			"invalid upper bound",
-			"1.3.0",
+			"1.6.3",
 			false,
 		}, {
 			"unsupported beta release",


### PR DESCRIPTION
Bump Go Version - 1.20.10
Updated Terraform Version - 1.6.2
Make E2E tests passing