### PR TITLE
chore: address io/ioutil depreciation

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,9 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -355,7 +355,7 @@ func TestServeWithTLS(t *testing.T) {
 			tlsConf := &tls.Config{}
 			if tc.clientCACert != "" {
 				caCertPool := x509.NewCertPool()
-				caCert, err := ioutil.ReadFile(tc.clientCACert)
+				caCert, err := os.ReadFile(tc.clientCACert)
 				require.NoError(t, err)
 				caCertPool.AppendCertsFromPEM(caCert)
 				tlsConf = &tls.Config{
@@ -550,11 +550,11 @@ func TestServeWithMutualTLS_MultipleCA(t *testing.T) {
 	cleanup := testutils.MakeTempDir(t, tmpDir)
 	defer cleanup()
 	for _, src := range caFiles {
-		input, err := ioutil.ReadFile(src)
+		input, err := os.ReadFile(src)
 		file := filepath.Base(src)
 		dest := filepath.Join(tmpDir, file)
 		require.NoError(t, err)
-		err = ioutil.WriteFile(dest, input, 0644)
+		err = os.WriteFile(dest, input, 0644)
 		require.NoError(t, err)
 	}
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -82,7 +82,7 @@ func TestRequest(t *testing.T) {
 			require.NoError(t, err)
 			bytesR := bytes.NewBuffer(b)
 			mockResp := &http.Response{
-				Body:       ioutil.NopCloser(bytesR),
+				Body:       io.NopCloser(bytesR),
 				StatusCode: tc.httpStatus,
 			}
 			hc.On("Do", mock.Anything).Return(mockResp, tc.httpError).Once()

--- a/api/task.go
+++ b/api/task.go
@@ -6,7 +6,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -101,7 +101,7 @@ func (h *taskHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.Trace("unable to read request body from update", "error", err)
 		jsonErrorResponse(ctx, w, http.StatusInternalServerError, err)

--- a/command/commands_test.go
+++ b/command/commands_test.go
@@ -4,7 +4,7 @@
 package command
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/mitchellh/cli"
@@ -12,7 +12,7 @@ import (
 )
 
 func Test_Commands(t *testing.T) {
-	cf := Commands(ioutil.Discard, ioutil.Discard)
+	cf := Commands(io.Discard, io.Discard)
 
 	// map of commands to synopsis
 	expectedCommands := map[string]cli.Command{

--- a/command/meta.go
+++ b/command/meta.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -82,7 +81,7 @@ func (m *meta) defaultFlagSet(name string) *flag.FlagSet {
 	m.tls.sslVerify = m.flags.Bool(FlagSSLVerify, true, fmt.Sprintf("Boolean to verify SSL or not. Set to true to verify SSL. "+
 		"\n\t\tThis can also be specified using the %s environment variable.", api.EnvTLSSSLVerify))
 
-	m.flags.SetOutput(ioutil.Discard)
+	m.flags.SetOutput(io.Discard)
 
 	return m.flags
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -489,7 +488,7 @@ func fromFile(path string) (*Config, error) {
 	}
 
 	logger := logging.Global().Named(logSystemName)
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		logger.Error("failed reading config file from disk", filePathLogKey, path)
 		return nil, err
@@ -533,7 +532,7 @@ func fromPath(path string) (*Config, error) {
 	}
 
 	// Ensure the given filepath has at least one config file
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		logger.Error("failed listing directory", filePathLogKey, path)
 		return nil, err
@@ -591,7 +590,7 @@ func stringFromEnv(list []string, def string) *string {
 
 func stringFromFile(list []string, def string) *string {
 	for _, s := range list {
-		c, err := ioutil.ReadFile(s)
+		c, err := os.ReadFile(s)
 		if err == nil {
 			return String(strings.TrimSpace(string(c)))
 		}

--- a/driver/terraform.go
+++ b/driver/terraform.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -145,7 +145,7 @@ func NewTerraform(config *TerraformConfig) (*Terraform, error) {
 		postApply:         h,
 		resolver:          hcat.NewResolver(),
 		watcher:           config.Watcher,
-		fileReader:        ioutil.ReadFile,
+		fileReader:        os.ReadFile,
 		logger:            logger,
 	}, nil
 }
@@ -496,7 +496,7 @@ func (tf *Terraform) inspectTask(ctx context.Context, returnPlan bool) (InspectP
 		if tf.logClient {
 			tfLogger = log.New(log.Writer(), "", log.Flags())
 		} else {
-			tfLogger = log.New(ioutil.Discard, "", 0)
+			tfLogger = log.New(io.Discard, "", 0)
 		}
 		defer tf.client.SetStdout(tfLogger.Writer())
 	}

--- a/e2e/command_test.go
+++ b/e2e/command_test.go
@@ -9,7 +9,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -639,7 +638,7 @@ task {
 			// If required by test case, verify contents of generated variables file
 			for _, v := range tc.tfVarsFiles {
 				expectedFilePath := filepath.Join(tempDir, taskName, "variables.auto.tfvars")
-				b, err := ioutil.ReadFile(expectedFilePath)
+				b, err := os.ReadFile(expectedFilePath)
 				require.NoError(t, err)
 				assert.Contains(t, string(b), v)
 			}

--- a/e2e/test_modules/incompatible_w_cts/variables.tf
+++ b/e2e/test_modules/incompatible_w_cts/variables.tf
@@ -2,5 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 
 variable "test" {
+  default = "test"
 }
 

--- a/templates/hcltmpl/integration_test.go
+++ b/templates/hcltmpl/integration_test.go
@@ -8,7 +8,7 @@ package hcltmpl
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -77,8 +77,8 @@ func TestLoadDynamicConfig_ConsulKV(t *testing.T) {
 	srv, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	require.NoError(t, err)
 	clients := hcat.NewClientSet()

--- a/templates/tftmpl/golden_test.go
+++ b/templates/tftmpl/golden_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"flag"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/consul-terraform-sync/templates/hcltmpl"
@@ -514,7 +514,7 @@ func TestNewFiles(t *testing.T) {
 func checkGoldenFile(t *testing.T, goldenFile string, actual string) {
 	// update golden files if necessary
 	if *update {
-		if err := ioutil.WriteFile(goldenFile, []byte(actual), 0644); err != nil {
+		if err := os.WriteFile(goldenFile, []byte(actual), 0644); err != nil {
 			require.NoError(t, err)
 		}
 	}

--- a/templates/tftmpl/integration_test.go
+++ b/templates/tftmpl/integration_test.go
@@ -8,7 +8,7 @@ package tftmpl
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -27,7 +27,7 @@ import (
 )
 
 func TestInitRootModule(t *testing.T) {
-	dir, err := ioutil.TempDir(".", "consul-terraform-sync-tftmpl-")
+	dir, err := os.MkdirTemp(".", "consul-terraform-sync-tftmpl-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
@@ -233,12 +233,12 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 			t.Parallel()
 
 			// Setup Consul server
-			log.SetOutput(ioutil.Discard)
+			log.SetOutput(io.Discard)
 			srv, err := testutil.NewTestServerConfigT(tb,
 				func(c *testutil.TestServerConfig) {
 					c.LogLevel = "warn"
-					c.Stdout = ioutil.Discard
-					c.Stderr = ioutil.Discard
+					c.Stdout = io.Discard
+					c.Stderr = io.Discard
 
 					// Hardcode node info so it doesn't change per run
 					c.NodeName = "worker-01"
@@ -275,8 +275,8 @@ func TestRenderTFVarsTmpl(t *testing.T) {
 					func(c *testutil.TestServerConfig) {
 						c.Bootstrap = false
 						c.LogLevel = "warn"
-						c.Stdout = ioutil.Discard
-						c.Stderr = ioutil.Discard
+						c.Stdout = io.Discard
+						c.Stderr = io.Discard
 
 						// Hardcode node info so it doesn't change per run
 						c.NodeName = "worker-02"

--- a/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
+++ b/templates/tftmpl/tmplfunc/catalog_services_registration_test.go
@@ -4,7 +4,7 @@
 package tmplfunc
 
 import (
-	"io/ioutil"
+	"io"
 	"regexp"
 	"testing"
 	"time"
@@ -182,8 +182,8 @@ func TestCatalogServicesRegistrationQuery_Fetch(t *testing.T) {
 		func(c *testutil.TestServerConfig) {
 			c.Bootstrap = false
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 			c.NodeMeta = map[string]string{"k": "v"}
 		})
 
@@ -195,8 +195,8 @@ func TestCatalogServicesRegistrationQuery_Fetch(t *testing.T) {
 			c.Datacenter = "dc2"
 			c.Bootstrap = true
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	require.NoError(t, err, "failed to start consul server 3")
 	defer srv3.Stop()

--- a/templates/tftmpl/tmplfunc/services_regex_test.go
+++ b/templates/tftmpl/tmplfunc/services_regex_test.go
@@ -5,7 +5,7 @@ package tmplfunc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"sort"
 	"testing"
@@ -155,8 +155,8 @@ func TestServicesRegexQuery_Fetch(t *testing.T) {
 		func(c *testutil.TestServerConfig) {
 			c.Bootstrap = false
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 			c.NodeMeta = nodeMeta
 		})
 	require.NoError(t, err, "failed to start consul server 2")
@@ -175,8 +175,8 @@ func TestServicesRegexQuery_Fetch(t *testing.T) {
 			c.Datacenter = "dc2"
 			c.Bootstrap = true
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 		})
 	require.NoError(t, err, "failed to start consul server 3")
 	defer srv3.Stop()

--- a/testutils/consul.go
+++ b/testutils/consul.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -44,8 +44,8 @@ func NewTestConsulServer(tb testing.TB, config TestConsulServerConfig) *testutil
 	srv, err := testutil.NewTestServerConfigT(tb,
 		func(c *testutil.TestServerConfig) {
 			c.LogLevel = "warn"
-			c.Stdout = ioutil.Discard
-			c.Stderr = ioutil.Discard
+			c.Stdout = io.Discard
+			c.Stderr = io.Discard
 
 			// Support CTS connecting over HTTP2
 			if config.HTTPSRelPath != "" {
@@ -158,7 +158,7 @@ func ListConsulServices(tb testing.TB, srv *testutil.TestServer, filter string) 
 	}
 	resp := RequestHTTP(tb, http.MethodGet, u, "")
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(tb, err)
 	defer resp.Body.Close()
 
@@ -193,7 +193,7 @@ func GetConsulService(tb testing.TB, srv *testutil.TestServer, serviceID string)
 	resp := RequestHTTP(tb, http.MethodGet, u, "")
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(tb, err)
 
 	if resp.StatusCode != 200 {
@@ -243,7 +243,7 @@ func ListConsulChecks(tb testing.TB, srv *testutil.TestServer) map[string]Consul
 	u := fmt.Sprintf("http://%s/v1/agent/checks", srv.HTTPAddr)
 	resp := RequestHTTP(tb, http.MethodGet, u, "")
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(tb, err)
 	defer resp.Body.Close()
 
@@ -340,7 +340,7 @@ func CheckStateFile(t *testing.T, consulAddr, taskname string) {
 func ShowMeServices(t testing.TB, srv *testutil.TestServer) {
 	u := fmt.Sprintf("http://%s/v1/agent/services", srv.HTTPAddr)
 	resp := RequestHTTP(t, http.MethodGet, u, "")
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	fmt.Println(string(b))
 	defer resp.Body.Close()
@@ -351,7 +351,7 @@ func ShowMeHealth(t testing.TB, srv *testutil.TestServer, svcName string) {
 	// get the node
 	u := fmt.Sprintf("http://%s/v1/health/service/%s", srv.HTTPAddr, svcName)
 	resp := RequestHTTP(t, http.MethodGet, u, "")
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	resp.Body.Close()
 	nodes := []struct{ Node struct{ Node string } }{}
@@ -361,7 +361,7 @@ func ShowMeHealth(t testing.TB, srv *testutil.TestServer, svcName string) {
 	// all services on that node
 	u = fmt.Sprintf("http://%s/v1/health/node/%s", srv.HTTPAddr, node)
 	resp = RequestHTTP(t, http.MethodGet, u, "")
-	b, err = ioutil.ReadAll(resp.Body)
+	b, err = io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	resp.Body.Close()
 

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"net"
 	"net/http"
 	"os"
@@ -130,8 +130,8 @@ func CopyFile(t testing.TB, src, dst string) {
 }
 
 // CheckDir checks whether a directory exists. If it exists, returns the file infos for further checking.
-func CheckDir(t testing.TB, exists bool, dir string) []os.FileInfo {
-	files, err := ioutil.ReadDir(dir)
+func CheckDir(t testing.TB, exists bool, dir string) []fs.DirEntry {
+	files, err := os.ReadDir(dir)
 	if exists {
 		require.NoError(t, err)
 		return files
@@ -139,7 +139,7 @@ func CheckDir(t testing.TB, exists bool, dir string) []os.FileInfo {
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no such file or directory")
-	return []os.FileInfo{}
+	return []fs.DirEntry{}
 }
 
 // WriteFile write a content to a file path.
@@ -167,7 +167,7 @@ func CheckFile(t testing.TB, exists bool, path, filename string) string {
 	require.NoError(t, err, fmt.Sprintf("file '%s' does not exist", filename))
 
 	// Return content of file if exists
-	content, err := ioutil.ReadFile(fp)
+	content, err := os.ReadFile(fp)
 	require.NoError(t, err, fmt.Sprintf("unable to read file '%s'", filename))
 	return string(content)
 }

--- a/testutils/utils_test.go
+++ b/testutils/utils_test.go
@@ -4,7 +4,6 @@
 package testutils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -41,11 +40,11 @@ func TestMakeTempDir(t *testing.T) {
 		tempDir := "test-temp"
 		del := MakeTempDir(t, tempDir)
 
-		_, err := ioutil.ReadDir(tempDir)
+		_, err := os.ReadDir(tempDir)
 		require.NoError(t, err)
 
 		del()
-		_, err = ioutil.ReadDir(tempDir)
+		_, err = os.ReadDir(tempDir)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
io/ioutil is deprecated as of Go 1.16.
