### PR TITLE
chore: upgrade github.com/hashicorp/cronexpr to v1.1.3

### DIFF
--- a/.changelog/1147.txt
+++ b/.changelog/1147.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+- deps: Upgraded github.com/hashicorp/cronexpr from v1.1.1 to v1.1.3
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+DEPENDENCIES:
+* Upgrade `github.com/hashicorp/cronexpr` to `v1.1.3` [[GH-1147](https://github.com/hashicorp/consul-terraform-sync/pull/1147)]
+
 ## 0.9.0 (January 30, 2026)
 
 SECURITY:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## UNRELEASED
-
-DEPENDENCIES:
-* Upgrade `github.com/hashicorp/cronexpr` to `v1.1.3` [[GH-1147](https://github.com/hashicorp/consul-terraform-sync/pull/1147)]
-
 ## 0.9.0 (January 30, 2026)
 
 SECURITY:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.5.0
 	github.com/hashicorp/consul/api v1.33.2
 	github.com/hashicorp/consul/sdk v0.17.1
-	github.com/hashicorp/cronexpr v1.1.1
+	github.com/hashicorp/cronexpr v1.1.3
 	github.com/hashicorp/go-bexpr v0.1.4
 	github.com/hashicorp/go-checkpoint v0.5.0
 	github.com/hashicorp/go-getter v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/hashicorp/consul/api v1.33.2/go.mod h1:K3yoL/vnIBcQV/25NeMZVokRvPPERi
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
 github.com/hashicorp/consul/sdk v0.17.1 h1:LumAh8larSXmXw2wvw/lK5ZALkJ2wK8VRwWMLVV5M5c=
 github.com/hashicorp/consul/sdk v0.17.1/go.mod h1:EngiixMhmw9T7wApycq6rDRFXXVUwjjf7HuLiGMH/Sw=
-github.com/hashicorp/cronexpr v1.1.1 h1:NJZDd87hGXjoZBdvyCF9mX4DCq5Wy7+A/w+A7q0wn6c=
-github.com/hashicorp/cronexpr v1.1.1/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
+github.com/hashicorp/cronexpr v1.1.3 h1:rl5IkxXN2m681EfivTlccqIryzYJSXRGRNa0xeG7NA4=
+github.com/hashicorp/cronexpr v1.1.3/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
## Description

Upgrades `github.com/hashicorp/cronexpr` from `v1.1.1` to `v1.1.3`.

## Changes
- Updated `go.mod` and `go.sum` with the new version

## Testing
- [ ] Unit tests pass locally