### PR TITLE
ci: add Go test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,14 @@ jobs:
         run: |
           make test-unit-and-integration
 
+      - name: Upload coverage profile
+        if: always()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: cts-coverage
+          path: coverage.txt
+          retention-days: 3
+
       - name: Annotate tests
         if: always()
         uses: guyarb/golang-test-annotations@2941118d7ef622b1b3771d1ff6eae9e90659eb26 # v0.8.0
@@ -201,6 +209,22 @@ jobs:
         uses: guyarb/golang-test-annotations@2941118d7ef622b1b3771d1ff6eae9e90659eb26 # v0.8.0
         with:
           test-results: .build/test-results.json
+
+  coverage-report:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    needs:
+      - run-check
+      - unit-and-integration
+    if: ${{ !cancelled() && needs.run-check.result == 'success' && needs.unit-and-integration.result != 'skipped' }}
+    uses: ./.github/workflows/reusable-coverage-report.yml
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    with:
+      go-version: ${{ env.GO_VERSION }}
+      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
 
   slack-notification:
     name: Slack Notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,17 @@ jobs:
       - run: |
           echo "Run-check job ran successfully"
 
+  get-go-version:
+    name: Get Go Version
+    runs-on: ubuntu-latest
+    needs: [run-check]
+    if: needs.run-check.result == 'success'
+    outputs:
+      go-version: ${{ steps.get.outputs.go-version }}
+    steps:
+      - id: get
+        run: echo "go-version=${{ env.GO_VERSION }}" >> "$GITHUB_OUTPUT"
+
   checks:
     name: Checks
     runs-on: ubuntu-latest
@@ -212,9 +223,9 @@ jobs:
 
   coverage-report:
     name: Coverage Report
-    runs-on: ubuntu-latest
     needs:
       - run-check
+      - get-go-version
       - unit-and-integration
     if: ${{ !cancelled() && needs.run-check.result == 'success' && needs.unit-and-integration.result != 'skipped' }}
     uses: ./.github/workflows/reusable-coverage-report.yml
@@ -223,7 +234,7 @@ jobs:
       pull-requests: write
       id-token: write
     with:
-      go-version: ${{ env.GO_VERSION }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
       pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
 
   slack-notification:

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -20,7 +20,8 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'push') &&
       github.event.workflow_run.conclusion != 'skipped' &&
       github.event.workflow_run.conclusion != 'cancelled'
     steps:

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,72 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Posts a PR comment with the coverage total once CI completes.
+# Runs via workflow_run so it has base-repo write permissions even for fork PRs.
+
+name: coverage-comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+  contents: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'skipped' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    steps:
+      - name: Download coverage comment data
+        id: download
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        continue-on-error: true
+        with:
+          name: coverage-comment-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          path: coverage-data
+
+      - name: Post or update PR comment
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          PR_NUMBER=$(cat coverage-data/pr-number.txt 2>/dev/null || echo "")
+          TOTAL=$(cat coverage-data/coverage-total.txt 2>/dev/null || echo "")
+          RUN_ID=$(cat coverage-data/run-id.txt 2>/dev/null || echo "${{ github.event.workflow_run.id }}")
+
+          if [ -z "$PR_NUMBER" ] || [ -z "$TOTAL" ] || [ "$TOTAL" = "N/A" ]; then
+            echo "No PR number or coverage data, skipping"
+            exit 0
+          fi
+
+          MARKER="<!-- coverage-report-comment -->"
+          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
+            "$MARKER" "$TOTAL" "$GH_REPO" "$RUN_ID")
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh api \
+              --method POST \
+              "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+              -f body="$BODY"
+          fi

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -32,6 +32,19 @@ jobs:
         with:
           go-version: ${{ inputs.go-version }}
 
+      - name: Resolve PR number
+        id: resolve-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR="${{ inputs.pr-number }}"
+          if [ -z "$PR" ]; then
+            PR=$(gh api "repos/${{ github.repository }}/pulls?state=open&head=${{ github.repository_owner }}:${{ github.ref_name }}" \
+              --jq '.[0].number // ""' 2>/dev/null || echo "")
+            echo "Resolved PR number from branch: $PR"
+          fi
+          echo "pr-number=$PR" >> "$GITHUB_OUTPUT"
+
       - name: Download coverage profiles
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
@@ -104,15 +117,15 @@ jobs:
           go tool cover -html=merged-coverage.out -o coverage.html
 
       - name: Save coverage data for PR comment
-        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
         run: |
           mkdir -p coverage-comment-data
-          echo "${{ inputs.pr-number }}" > coverage-comment-data/pr-number.txt
+          echo "${{ steps.resolve-pr.outputs.pr-number }}" > coverage-comment-data/pr-number.txt
           echo "${{ steps.coverage.outputs.total }}" > coverage-comment-data/coverage-total.txt
           echo "${{ github.run_id }}" > coverage-comment-data/run-id.txt
 
       - name: Upload coverage comment data
-        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: coverage-comment-data
@@ -120,18 +133,19 @@ jobs:
           retention-days: 1
 
       - name: Post PR comment
-        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.coverage.outputs.total }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr-number }}
         run: |
           MARKER="<!-- coverage-report-comment -->"
           BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
             "$MARKER" "$TOTAL" "${{ github.repository }}" "${{ github.run_id }}")
 
           COMMENT_ID=$(gh api --paginate \
-            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
             --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
             | tail -n1)
 
@@ -143,7 +157,7 @@ jobs:
           else
             gh api \
               --method POST \
-              "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+              "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
               -f body="$BODY"
           fi
 

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -1,0 +1,217 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Reusable workflow: merges per-runner coverage profiles from unit-and-integration,
+# computes the total, posts/edits a PR comment (same-repo only), uploads an HTML
+# artifact, uploads to Codecov, and (on main) pushes a coverage badge SVG to the
+# `badges` branch for the README.
+
+name: reusable-coverage-report
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        required: true
+        type: string
+      pr-number:
+        required: false
+        type: string
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write  # required for OIDC tokenless Codecov upload
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Download coverage profiles
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          pattern: '*-coverage'
+          path: coverage-artifacts
+
+      - name: Compute coverage
+        id: coverage
+        run: |
+          PROFILES=$(find coverage-artifacts -name 'coverage.txt' 2>/dev/null | sort)
+          COUNT=$(echo "$PROFILES" | grep -c . || true)
+          echo "Found $COUNT coverage profile(s)"
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No coverage profiles found"
+            echo "total=N/A" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -eq 1 ]; then
+            cp "$(echo "$PROFILES")" merged-coverage.out
+          else
+            go install github.com/wadey/gocovmerge@b5bfa59ec0ad
+            echo "$PROFILES" | xargs gocovmerge > merged-coverage.out
+          fi
+
+          # Exclude generated mock files, protobuf generated code, and vendor.
+          TOTAL=$(awk '
+            /^mode:/ { next }
+            /\/mocks\/|\/mock_|\.pb\.go:|\/vendor\// { next }
+            { stmts += $2; if ($3 > 0) covered += $2 }
+            END { if (stmts > 0) printf "%.1f%%", covered/stmts*100; else print "0.0%" }
+          ' merged-coverage.out)
+          echo "Total coverage: $TOTAL"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Strip excluded lines from profile before generating HTML and per-package summary.
+          grep -v -e '/mocks/' -e '/mock_' -e '\.pb\.go:' -e '/vendor/' merged-coverage.out > filtered-coverage.out || true
+          mv filtered-coverage.out merged-coverage.out
+
+          # Package-level summary grouped by top-level directory.
+          go tool cover -func merged-coverage.out | grep -v '^total:' | \
+            awk '{
+              sub(/^github\.com\/hashicorp\/consul-terraform-sync\//, "", $1)
+              split($1, parts, "/")
+              pkg = parts[1]
+              gsub(/:.*/, "", pkg)
+              pct = $NF; gsub(/%/, "", pct)
+              sum[pkg] += pct; n[pkg]++
+            }
+            END {
+              for (pkg in sum) printf "%-40s %.1f%%\n", pkg, sum[pkg]/n[pkg]
+            }' | sort > pkg-summary.txt
+
+          {
+            echo "## Go Test Coverage"
+            echo ""
+            echo "**Total coverage: $TOTAL**"
+            echo ""
+            echo "| Package | Avg Coverage |"
+            echo "|---------|-------------|"
+            while IFS= read -r line; do
+              pkg=$(echo "$line" | awk '{print $1}')
+              pct=$(echo "$line" | awk '{print $2}')
+              echo "| \`$pkg\` | $pct |"
+            done < pkg-summary.txt
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          go tool cover -html=merged-coverage.out -o coverage.html
+
+      - name: Save coverage data for PR comment
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        run: |
+          mkdir -p coverage-comment-data
+          echo "${{ inputs.pr-number }}" > coverage-comment-data/pr-number.txt
+          echo "${{ steps.coverage.outputs.total }}" > coverage-comment-data/coverage-total.txt
+          echo "${{ github.run_id }}" > coverage-comment-data/run-id.txt
+
+      - name: Upload coverage comment data
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-comment-data
+          path: coverage-comment-data/
+          retention-days: 1
+
+      - name: Post PR comment
+        if: inputs.pr-number != '' && steps.coverage.outputs.total != 'N/A' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOTAL: ${{ steps.coverage.outputs.total }}
+        run: |
+          MARKER="<!-- coverage-report-comment -->"
+          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
+            "$MARKER" "$TOTAL" "${{ github.repository }}" "${{ github.run_id }}")
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- coverage-report-comment -->"))) | .id' \
+            | tail -n1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -f body="$BODY"
+          else
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/issues/${{ inputs.pr-number }}/comments" \
+              -f body="$BODY"
+          fi
+
+      - name: Upload HTML coverage report
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: coverage-report-html
+          path: |
+            merged-coverage.out
+            coverage.html
+
+      - name: Upload to Codecov
+        if: steps.coverage.outputs.total != 'N/A'
+        uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
+        with:
+          files: merged-coverage.out
+          use_oidc: true
+          fail_ci_if_error: false
+          verbose: false
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && steps.coverage.outputs.total != 'N/A'
+        env:
+          TOTAL: ${{ steps.coverage.outputs.total }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PCT="${TOTAL%%%}"
+          if (( $(echo "$PCT >= 80" | bc -l) )); then COLOR="brightgreen"
+          elif (( $(echo "$PCT >= 60" | bc -l) )); then COLOR="yellow"
+          else COLOR="red"
+          fi
+
+          cat > coverage.svg <<SVGEOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="20">
+            <linearGradient id="s" x2="0" y2="100%">
+              <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+              <stop offset="1" stop-opacity=".1"/>
+            </linearGradient>
+            <rect rx="3" width="120" height="20" fill="#555"/>
+            <rect rx="3" x="62" width="58" height="20" fill="${COLOR}"/>
+            <rect x="62" width="4" height="20" fill="${COLOR}"/>
+            <rect rx="3" width="120" height="20" fill="url(#s)"/>
+            <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+              <text x="32" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+              <text x="32" y="14">coverage</text>
+              <text x="90" y="15" fill="#010101" fill-opacity=".3">${TOTAL}</text>
+              <text x="90" y="14">${TOTAL}</text>
+            </g>
+          </svg>
+          SVGEOF
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+
+          git fetch origin badges 2>/dev/null || true
+          if git rev-parse --verify origin/badges >/dev/null 2>&1; then
+            git checkout -B badges origin/badges
+          else
+            git checkout --orphan badges
+            git rm -rf . --quiet || true
+          fi
+
+          mv coverage.svg coverage.svg.tmp
+          git rm -rf . --quiet || true
+          mv coverage.svg.tmp coverage.svg
+
+          git add coverage.svg
+          git commit -m "ci: update coverage badge to ${TOTAL}" || echo "No changes to badge"
+          git push origin badges

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           pattern: '*-coverage'
           path: coverage-artifacts
+          merge-multiple: false
 
       - name: Compute coverage
         id: coverage

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test:
 test-unit-and-integration:
 	@echo "==> Testing ${NAME} (unit & integration tests)"
 	@mkdir -p .build/test-results
-	@gotestsum --format testname --jsonfile .build/test-results.json -- -count=1 -timeout=2m -tags=integration -cover ./... ${TESTARGS}
+	@gotestsum --format testname --jsonfile .build/test-results.json -- -count=1 -timeout=2m -tags=integration -cover -coverprofile=coverage.txt ./... ${TESTARGS}
 .PHONY: test-unit-and-integration
 
 # test-setup-e2e sets up the CTS binary and permissions to run in E2E tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Consul-Terraform-Sync [![Build Status](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/build.yml/badge.svg)](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/build.yml) [![CI](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/ci.yml)
+# Consul-Terraform-Sync [![Build Status](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/build.yml/badge.svg)](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/build.yml) [![CI](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/ci.yml/badge.svg)](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/ci.yml) [![Coverage](https://raw.githubusercontent.com/hashicorp/consul-terraform-sync/badges/coverage.svg)](https://github.com/hashicorp/consul-terraform-sync/actions/workflows/ci.yml)
 
 **We're looking for feedback on how our users interact with Consul-Terraform-Sync (CTS), please fill out our brief [survey](https://hashicorp.sjc1.qualtrics.com/jfe/form/SV_9BHmabK0UHe5O06)!**
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+ignore:
+  - "**/*_test.go"
+  - "mocks/**"
+  - "**/*.pb.go"
+  - "vendor/**"
+  - "e2e/**"


### PR DESCRIPTION
## Summary

Adds Go test coverage reporting to the CTS CI pipeline, following the same pattern established in consul-dataplane (PR #1083), consul-esm (PR #377), consul-k8s (PR #5347), and consul (PR #23611).

## Changes

### `Makefile`
- Adds `-coverprofile=coverage.txt` to the `test-unit-and-integration` target. The `-cover` flag was already present; this surfaces the output as a file.

### `.github/workflows/ci.yml`
- Adds a `get-go-version` job to expose `env.GO_VERSION` via `needs` output (required because `env` context is not available in job-level `with:` for reusable workflows).
- Uploads `coverage.txt` as a `cts-coverage` artifact after the test run.
- Adds a `coverage-report` job that calls `reusable-coverage-report.yml` after `unit-and-integration` completes.

### `.github/workflows/reusable-coverage-report.yml` (new)
- Downloads `*-coverage` artifacts, merges them with `gocovmerge`, computes total coverage %, posts/updates a sticky PR comment, uploads an HTML report artifact, uploads to Codecov (OIDC), and pushes a badge SVG to the `badges` branch on merge to main.

### `.github/workflows/coverage-comment.yml` (new)
- Triggers on `workflow_run: [CI] completed` with base-repo write permissions.
- Downloads the `coverage-comment-data` artifact and posts/updates the PR comment.

### `README.md`
- Adds coverage badge pointing to the `badges` branch SVG.