### PR TITLE
ci: gate PR merges on >=90% patch coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,10 +240,14 @@ jobs:
   coverage-gate:
     name: Coverage Gate
     needs: [coverage-report]
-    # Patch coverage measures the lines a PR adds/modifies, so it only applies
-    # to pull requests. Pushes to main run coverage-report for the badge but
-    # have no "patch" to evaluate. Only gate when the report succeeded.
-    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success' }}
+    # Patch coverage measures the lines a PR adds/modifies. This repo validates
+    # same-repo PRs through the `push` event (the `pull_request` run is skipped
+    # for non-fork branches via run-check), so the gate must NOT be limited to
+    # `pull_request` events. The coverage-report job resolves the open PR for
+    # the pushed branch and computes patch coverage; when there is no open PR
+    # (e.g. push to main), the patch output is empty and the gate passes as
+    # N/A. Only gate when the report succeeded.
+    if: ${{ !cancelled() && needs.coverage-report.result == 'success' }}
     runs-on: ubuntu-latest
     env:
       # Minimum required coverage of the lines a PR adds/modifies (patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
       id-token: write
     with:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
-      pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
+      pr-number: ${{ github.event_name == 'pull_request' && toJson(github.event.pull_request.number) || '' }}
 
   coverage-gate:
     name: Coverage Gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,64 @@ jobs:
       go-version: ${{ needs.get-go-version.outputs.go-version }}
       pr-number: ${{ github.event.pull_request.number != 0 && toJson(github.event.pull_request.number) || '' }}
 
+  coverage-gate:
+    name: Coverage Gate
+    needs: [coverage-report]
+    # Patch coverage measures the lines a PR adds/modifies, so it only applies
+    # to pull requests. Pushes to main run coverage-report for the badge but
+    # have no "patch" to evaluate. Only gate when the report succeeded.
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.coverage-report.result == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      # Minimum required coverage of the lines a PR adds/modifies (patch
+      # coverage). New/changed code must be at least this well tested.
+      PATCH_THRESHOLD: "90"
+    steps:
+      - name: Enforce patch coverage threshold
+        env:
+          PATCH: ${{ needs.coverage-report.outputs.patch }}
+          COVERED: ${{ needs.coverage-report.outputs.patch_covered }}
+          COVERABLE: ${{ needs.coverage-report.outputs.patch_coverable }}
+        run: |
+          set -euo pipefail
+
+          echo "Patch coverage:     ${PATCH:-<empty>}"
+          echo "Required threshold: ${PATCH_THRESHOLD}%"
+          echo "Changed lines:      ${COVERED:-0}/${COVERABLE:-0} covered"
+
+          # No coverable Go lines changed (docs/test-only) -> nothing to gate.
+          if [ -z "${PATCH}" ] || [ "${PATCH}" = "N/A" ]; then
+            echo "::notice::No coverable Go lines changed in this PR; patch-coverage gate skipped."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "No coverable Go lines changed in this PR, so there is nothing to gate."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          PCT="${PATCH%\%}"
+
+          if awk "BEGIN { exit !(${PCT} >= ${PATCH_THRESHOLD}) }"; then
+            echo "::notice::Patch coverage ${PATCH} meets the ${PATCH_THRESHOLD}% threshold."
+            {
+              echo "### ✅ Coverage gate passed"
+              echo ""
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) ≥ required **${PATCH_THRESHOLD}%**."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Patch coverage ${PATCH} is below the required ${PATCH_THRESHOLD}% threshold."
+            {
+              echo "### ❌ Coverage gate failed"
+              echo ""
+              echo "Patch coverage **${PATCH}** (${COVERED}/${COVERABLE} changed lines) is below the required **${PATCH_THRESHOLD}%** threshold."
+              echo ""
+              echo "The lines this PR adds or modifies are not sufficiently covered by tests."
+              echo "Add tests for the new/changed code, or adjust \`PATCH_THRESHOLD\` in \`.github/workflows/ci.yml\` (with reviewer sign-off)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   slack-notification:
     name: Slack Notification
     if: |

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -58,7 +58,7 @@ jobs:
           if [ -z "$PATCH" ] || [ "$PATCH" = "N/A" ]; then
             PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
           else
-            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered)"
           fi
           BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\n%s\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
             "$MARKER" "$TOTAL" "$PATCH_LINE" "$GH_REPO" "$RUN_ID")

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -45,6 +45,9 @@ jobs:
           PR_NUMBER=$(cat coverage-data/pr-number.txt 2>/dev/null || echo "")
           TOTAL=$(cat coverage-data/coverage-total.txt 2>/dev/null || echo "")
           RUN_ID=$(cat coverage-data/run-id.txt 2>/dev/null || echo "${{ github.event.workflow_run.id }}")
+          PATCH=$(cat coverage-data/patch.txt 2>/dev/null || echo "")
+          PATCH_COVD=$(cat coverage-data/patch-covered.txt 2>/dev/null || echo "")
+          PATCH_COVB=$(cat coverage-data/patch-coverable.txt 2>/dev/null || echo "")
 
           if [ -z "$PR_NUMBER" ] || [ -z "$TOTAL" ] || [ "$TOTAL" = "N/A" ]; then
             echo "No PR number or coverage data, skipping"
@@ -52,8 +55,13 @@ jobs:
           fi
 
           MARKER="<!-- coverage-report-comment -->"
-          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
-            "$MARKER" "$TOTAL" "$GH_REPO" "$RUN_ID")
+          if [ -z "$PATCH" ] || [ "$PATCH" = "N/A" ]; then
+            PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
+          else
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+          fi
+          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\n%s\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
+            "$MARKER" "$TOTAL" "$PATCH_LINE" "$GH_REPO" "$RUN_ID")
 
           COMMENT_ID=$(gh api --paginate \
             "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -172,9 +172,9 @@ jobs:
           # diff the API cannot return (.patch == null, e.g. the file's diff is
           # too large to render) must not be silently treated as zero changed
           # lines and let the gate pass.
-          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+          if grep -q '^NULLPATCH' /tmp/pr-patches.txt; then
             echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
-            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            grep '^NULLPATCH' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
             echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
             exit 1
           fi

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -17,6 +17,25 @@ on:
       pr-number:
         required: false
         type: string
+    outputs:
+      total:
+        description: >-
+          Total computed coverage as a percentage string (e.g. "67.0%"), or
+          "N/A" when no coverage profiles were found.
+        value: ${{ jobs.report.outputs.total }}
+      patch:
+        description: >-
+          Patch coverage: the percentage of the non-test, non-mock,
+          non-generated Go lines this PR adds/modifies that are covered by
+          tests. "N/A" when the PR changes no coverable Go lines. Consumed by
+          the coverage-gate job to enforce a minimum patch-coverage threshold.
+        value: ${{ jobs.report.outputs.patch }}
+      patch_covered:
+        description: Number of changed coverable lines that are covered.
+        value: ${{ jobs.report.outputs.patch_covered }}
+      patch_coverable:
+        description: Number of changed coverable lines in the PR.
+        value: ${{ jobs.report.outputs.patch_coverable }}
 
 jobs:
   report:
@@ -25,6 +44,11 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write  # required for OIDC tokenless Codecov upload
+    outputs:
+      total: ${{ steps.coverage.outputs.total }}
+      patch: ${{ steps.patch.outputs.patch }}
+      patch_covered: ${{ steps.patch.outputs.covered }}
+      patch_coverable: ${{ steps.patch.outputs.coverable }}
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
@@ -116,6 +140,83 @@ jobs:
 
           go tool cover -html=merged-coverage.out -o coverage.html
 
+      - name: Compute patch coverage
+        id: patch
+        if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.resolve-pr.outputs.pr-number }}
+          REPO: ${{ github.repository }}
+          MODULE: github.com/hashicorp/consul-terraform-sync
+        run: |
+          set -euo pipefail
+
+          # 1) Collect the lines this PR adds/modifies for non-test, non-mock,
+          #    non-generated Go files, read straight from the PR diff via the
+          #    API, emitting "<import-path>\t<lineno>". merged-coverage.out is
+          #    already filtered (mocks/.pb.go/vendor removed), so changed lines
+          #    in those paths never intersect a block and are ignored as
+          #    non-coverable.
+          gh api --paginate "repos/${REPO}/pulls/${PR}/files" \
+            --jq '.[]
+                  | select(.filename | test("\\.go$"))
+                  | select(.filename | test("_test\\.go$") | not)
+                  | select(.filename | test("\\.pb\\.go$") | not)
+                  | select(.filename | test("(^|/)mocks/|(^|/)mock_") | not)
+                  | "FILE\t\(.filename)\n\(.patch // "")"' > /tmp/pr-patches.txt || true
+
+          awk -v module="$MODULE" '
+            /^FILE\t/ { file=$2; next }
+            /^@@ / {
+              # @@ -a,b +c,d @@  -> new-file hunk starts at line c
+              plus=$3; sub(/^\+/, "", plus); split(plus, a, ","); newline=a[1]; next
+            }
+            {
+              if (file=="") next
+              ch=substr($0,1,1)
+              if (ch=="+")      { print module"/"file"\t"newline; newline++ }
+              else if (ch=="-") { }                  # removed line: no new-file number
+              else              { newline++ }         # context line advances pointer
+            }
+          ' /tmp/pr-patches.txt > /tmp/changed-lines.txt
+
+          # 2) Intersect changed lines with the (already filtered) coverage
+          #    profile. A changed line is "coverable" if it falls inside any
+          #    profile block, and "covered" if any such block has a hit count > 0.
+          awk '
+            BEGIN { NB = 0 }
+            FNR==NR {
+              if ($0 ~ /^mode:/) next
+              n=split($1, p, ":"); f=p[1]
+              split(p[2], rr, ","); split(rr[1], s, "."); split(rr[2], e, ".")
+              blkF[NB]=f; blkS[NB]=s[1]; blkE[NB]=e[1]; blkC[NB]=$3; NB++
+              next
+            }
+            {
+              f=$1; L=$2; coverable=0; covered=0
+              for (i=0; i<NB; i++) {
+                if (blkF[i]==f && L>=blkS[i] && L<=blkE[i]) {
+                  coverable=1; if (blkC[i]>0) covered=1
+                }
+              }
+              if (coverable) { tot++; if (covered) cov++ }
+            }
+            END {
+              if (tot==0) { print "patch=N/A"; print "covered=0"; print "coverable=0" }
+              else { printf "patch=%.1f%%\n", cov/tot*100; print "covered="cov; print "coverable="tot }
+            }
+          ' merged-coverage.out /tmp/changed-lines.txt > /tmp/patch-result.txt
+
+          PATCH=$(awk -F= '/^patch=/{print $2}' /tmp/patch-result.txt)
+          COVD=$(awk -F= '/^covered=/{print $2}' /tmp/patch-result.txt)
+          COVB=$(awk -F= '/^coverable=/{print $2}' /tmp/patch-result.txt)
+          echo "Patch coverage: ${PATCH} (${COVD}/${COVB} changed coverable lines)"
+          {
+            echo "patch=${PATCH}"
+            echo "covered=${COVD}"
+            echo "coverable=${COVB}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Save coverage data for PR comment
         if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
         run: |
@@ -123,6 +224,9 @@ jobs:
           echo "${{ steps.resolve-pr.outputs.pr-number }}" > coverage-comment-data/pr-number.txt
           echo "${{ steps.coverage.outputs.total }}" > coverage-comment-data/coverage-total.txt
           echo "${{ github.run_id }}" > coverage-comment-data/run-id.txt
+          echo "${{ steps.patch.outputs.patch }}" > coverage-comment-data/patch.txt
+          echo "${{ steps.patch.outputs.covered }}" > coverage-comment-data/patch-covered.txt
+          echo "${{ steps.patch.outputs.coverable }}" > coverage-comment-data/patch-coverable.txt
 
       - name: Upload coverage comment data
         if: steps.resolve-pr.outputs.pr-number != '' && steps.coverage.outputs.total != 'N/A'
@@ -139,10 +243,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TOTAL: ${{ steps.coverage.outputs.total }}
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr-number }}
+          PATCH: ${{ steps.patch.outputs.patch }}
+          PATCH_COVD: ${{ steps.patch.outputs.covered }}
+          PATCH_COVB: ${{ steps.patch.outputs.coverable }}
         run: |
           MARKER="<!-- coverage-report-comment -->"
-          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
-            "$MARKER" "$TOTAL" "${{ github.repository }}" "${{ github.run_id }}")
+          if [ -z "${PATCH:-}" ] || [ "${PATCH:-N/A}" = "N/A" ]; then
+            PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
+          else
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+          fi
+          BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\n%s\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
+            "$MARKER" "$TOTAL" "$PATCH_LINE" "${{ github.repository }}" "${{ github.run_id }}")
 
           COMMENT_ID=$(gh api --paginate \
             "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \

--- a/.github/workflows/reusable-coverage-report.yml
+++ b/.github/workflows/reusable-coverage-report.yml
@@ -163,7 +163,21 @@ jobs:
                   | select(.filename | test("_test\\.go$") | not)
                   | select(.filename | test("\\.pb\\.go$") | not)
                   | select(.filename | test("(^|/)mocks/|(^|/)mock_") | not)
-                  | "FILE\t\(.filename)\n\(.patch // "")"' > /tmp/pr-patches.txt || true
+                  | if .patch == null
+                    then "NULLPATCH\t\(.filename)"
+                    else "FILE\t\(.filename)\n\(.patch)"
+                    end' > /tmp/pr-patches.txt
+
+          # This is a merge gate, so fail closed: a coverable .go file whose
+          # diff the API cannot return (.patch == null, e.g. the file's diff is
+          # too large to render) must not be silently treated as zero changed
+          # lines and let the gate pass.
+          if grep -q '^NULLPATCH\t' /tmp/pr-patches.txt; then
+            echo "::error::Cannot compute patch coverage: the GitHub API returned no diff (patch == null) for changed Go file(s):"
+            grep '^NULLPATCH\t' /tmp/pr-patches.txt | cut -f2 | sed 's/^/  - /'
+            echo "This usually means a single file's diff is too large for the API to render. Split the change so coverage can be measured."
+            exit 1
+          fi
 
           awk -v module="$MODULE" '
             /^FILE\t/ { file=$2; next }
@@ -171,6 +185,7 @@ jobs:
               # @@ -a,b +c,d @@  -> new-file hunk starts at line c
               plus=$3; sub(/^\+/, "", plus); split(plus, a, ","); newline=a[1]; next
             }
+            /^\\/ { next }                          # e.g. "\ No newline at end of file": not a real line
             {
               if (file=="") next
               ch=substr($0,1,1)
@@ -251,7 +266,7 @@ jobs:
           if [ -z "${PATCH:-}" ] || [ "${PATCH:-N/A}" = "N/A" ]; then
             PATCH_LINE="**Patch coverage:** N/A (no coverable Go lines changed)"
           else
-            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered, required ≥ 90%)"
+            PATCH_LINE="**Patch coverage:** ${PATCH} (${PATCH_COVD}/${PATCH_COVB} changed lines covered)"
           fi
           BODY=$(printf '%s\n\n### Go Test Coverage: **%s**\n\n%s\n\nSee the [workflow run](https://github.com/%s/actions/runs/%s) for the full per-package breakdown and downloadable HTML report.' \
             "$MARKER" "$TOTAL" "$PATCH_LINE" "${{ github.repository }}" "${{ github.run_id }}")


### PR DESCRIPTION
## What

Adds a deterministic, self-contained **patch-coverage gate** to CI. A PR fails the gate when the non-test / non-mock / non-generated Go lines it **adds or modifies** are less than **90%** covered by tests.

This mirrors the same gate already rolled out to consul-esm, consul-k8s, consul, and consul-ecs.

## How it works

- **`reusable-coverage-report.yml`**
  - Computes *patch coverage* by parsing the PR diff (via `gh api .../pulls/{n}/files`) for added/changed lines in coverable Go files, then intersecting those line numbers with the already-filtered merged Go coverage profile.
  - Exposes `total`, `patch`, `patch_covered`, `patch_coverable` as `workflow_call` outputs.
  - Adds a **Patch coverage** line to the PR coverage comment (same-repo path).
- **`coverage-comment.yml`**
  - Includes the patch line in the fork-safe `workflow_run` comment path.
- **`ci.yml`**
  - New `coverage-gate` job reads the `patch` output and fails if it is below `PATCH_THRESHOLD` (`"90"`).

## Event model (important)

This repo validates **same-repo PRs through the `push` event** — the `pull_request` run is intentionally skipped for non-fork branches via the `run-check` job. The gate therefore runs on the **push-event** validation run (not gated on `github.event_name == 'pull_request'`). The `coverage-report` job's `resolve-pr` step finds the open PR for the pushed branch and computes patch coverage. When there is no open PR (e.g. push to `main`), the patch output is empty and the gate passes as **N/A**.

## :warning: Required follow-up — branch protection

Unlike consul-ecs / consul, **this repo has no fan-in / `*-success` aggregator job** to attach the gate to. After merge, add **`Coverage Gate`** as a **required status check** on the `main` branch protection rule so it blocks merges. (Same model used for consul-esm and consul-k8s.)

## Notes

- **Single module** (`github.com/hashicorp/consul-terraform-sync`), so one `MODULE` prefix maps diff paths to import paths.
- The `coverage-comment.yml` `workflow_run` path runs from `main`; until this PR merges it may overwrite the direct comment and strip the patch line — self-resolves on merge (same caveat as the consul rollout).
- **Codecov remains informational**; this gate is the source of truth.
- The gate reports **N/A → pass** for PRs that change no coverable Go lines (e.g. docs/YAML-only). This bootstrap PR (YAML only) shows N/A.
- Threshold lives in `.github/workflows/ci.yml` (`PATCH_THRESHOLD`) and can be adjusted with reviewer sign-off.