### PR TITLE
chore: trigger CRT rebuild for 0.9.1 (comment-only change)

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -24,6 +24,8 @@ var (
 	//
 	// Version must conform to the format expected by
 	// github.com/hashicorp/go-version for tests to work.
+	// Note: 0.9.1 includes the go-jose/go-jose/v3 v3.0.5 security fix
+	// (GHSA-78h2-9frx-2jm8 / GO-2026-4945).
 	Version = "0.9.1"
 
 	// VersionPrerelease is a pre-release marker for the version. If this is ""


### PR DESCRIPTION
Comment-only change in version/version.go to force a fresh CRT merge -> build -> prepare run on release/0.9.x for 0.9.1.

Context: the go-jose/go-jose/v3 v3.0.5 fix (GHSA-78h2-9frx-2jm8 / GO-2026-4945) and the GO-2026-5932 triage suppression are already on the branch; this merge is only to re-trigger the CRT pipeline. No functional changes.